### PR TITLE
fix: switch cloud run deployer to prefer project in Skaffold manifest over Cloud Run manifest

### DIFF
--- a/integration/testdata/deploy-cloudrun/skaffold.yaml
+++ b/integration/testdata/deploy-cloudrun/skaffold.yaml
@@ -7,5 +7,5 @@ manifests:
     - service.yaml
 deploy:
   cloudrun:
-    defaultprojectid: k8s-skaffold
+    projectid: k8s-skaffold
     region: us-central1

--- a/pkg/skaffold/deploy/cloudrun/deploy.go
+++ b/pkg/skaffold/deploy/cloudrun/deploy.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/skaffold/deploy/cloudrun/deploy_test.go
+++ b/pkg/skaffold/deploy/cloudrun/deploy_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/skaffold/deploy/cloudrun/deploy_test.go
+++ b/pkg/skaffold/deploy/cloudrun/deploy_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -28,9 +28,11 @@ import (
 	"google.golang.org/api/run/v1"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/label"
+	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v2"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/proto/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -42,6 +44,7 @@ func TestDeploy(tOuter *testing.T) {
 		region         string
 		expectedPath   string
 		httpErr        int
+		errCode        proto.StatusCode
 	}{
 		{
 			description:    "test deploy",
@@ -58,7 +61,7 @@ func TestDeploy(tOuter *testing.T) {
 			description:    "test deploy with specified project",
 			defaultProject: "testProject",
 			region:         "us-central1",
-			expectedPath:   "/v1/projects/my-project/locations/us-central1/services",
+			expectedPath:   "/v1/projects/testProject/locations/us-central1/services",
 			toDeploy: &run.Service{
 				Metadata: &run.ObjectMeta{
 					Name:      "test-service",
@@ -77,6 +80,17 @@ func TestDeploy(tOuter *testing.T) {
 					Namespace: "my-project",
 				},
 			},
+			errCode: proto.StatusCode_DEPLOY_CLOUD_RUN_GET_SERVICE_ERR,
+		},
+		{
+			description: "test no project specified",
+			region:      "us-central1",
+			toDeploy: &run.Service{
+				Metadata: &run.ObjectMeta{
+					Name: "test-service",
+				},
+			},
+			errCode: proto.StatusCode_DEPLOY_READ_MANIFEST_ERR,
 		},
 	}
 	for _, test := range tests {
@@ -107,16 +121,22 @@ func TestDeploy(tOuter *testing.T) {
 				w.Write(b)
 			}))
 
-			deployer, _ := NewDeployer(&runcontext.RunContext{}, &label.DefaultLabeller{}, &latest.CloudRunDeploy{DefaultProjectID: test.defaultProject, Region: test.region})
+			deployer, _ := NewDeployer(&runcontext.RunContext{}, &label.DefaultLabeller{}, &latest.CloudRunDeploy{ProjectID: test.defaultProject, Region: test.region})
 			deployer.clientOptions = append(deployer.clientOptions, option.WithEndpoint(ts.URL), option.WithoutAuthentication())
 			deployer.useGcpOptions = false
 			manifest, _ := json.Marshal(test.toDeploy)
 			manifests := [][]byte{manifest}
 			err := deployer.Deploy(context.Background(), os.Stderr, []graph.Artifact{}, manifests)
-			if test.httpErr == 0 && err != nil {
+			if test.errCode == proto.StatusCode_OK && err != nil {
 				t.Fatalf("Expected success but got err: %v", err)
-			} else if test.httpErr != 0 && err == nil {
-				t.Fatalf("Expected HTTP Error %s but got success", http.StatusText(test.httpErr))
+			} else if test.errCode != proto.StatusCode_OK {
+				if err == nil {
+					t.Fatalf("Expected status code %s but got success", test.errCode)
+				}
+				sErr := err.(sErrors.Error)
+				if sErr.StatusCode() != test.errCode {
+					t.Fatalf("Expected status code %v but got %v", test.errCode, sErr.StatusCode())
+				}
 			}
 		})
 	}
@@ -146,7 +166,7 @@ func TestCleanup(tOuter *testing.T) {
 			description:    "test cleanup with specified project",
 			defaultProject: "testProject",
 			region:         "us-central1",
-			expectedPath:   "/v1/projects/my-project/locations/us-central1/services/test-service",
+			expectedPath:   "/v1/projects/testProject/locations/us-central1/services/test-service",
 			toDelete: &run.Service{
 				Metadata: &run.ObjectMeta{
 					Name:      "test-service",
@@ -187,7 +207,7 @@ func TestCleanup(tOuter *testing.T) {
 				w.Write(b)
 			}))
 			defer ts.Close()
-			deployer, _ := NewDeployer(&runcontext.RunContext{}, &label.DefaultLabeller{}, &latest.CloudRunDeploy{DefaultProjectID: test.defaultProject, Region: test.region})
+			deployer, _ := NewDeployer(&runcontext.RunContext{}, &label.DefaultLabeller{}, &latest.CloudRunDeploy{ProjectID: test.defaultProject, Region: test.region})
 			deployer.clientOptions = append(deployer.clientOptions, option.WithEndpoint(ts.URL), option.WithoutAuthentication())
 			deployer.useGcpOptions = false
 			manifest, _ := json.Marshal(test.toDelete)

--- a/pkg/skaffold/runner/deployer.go
+++ b/pkg/skaffold/runner/deployer.go
@@ -204,12 +204,13 @@ func GetDeployer(ctx context.Context, runCtx *runcontext.RunContext, labeller *l
 The "default deployer" is used in `skaffold apply`, which uses a `kubectl` deployer to actuate resources
 on a cluster regardless of provided deployer configuration in the skaffold.yaml.
 The default deployer will honor a select set of deploy configuration from an existing skaffold.yaml:
-	- deploy.StatusCheckDeadlineSeconds
-	- deploy.Logs.Prefix
-	- deploy.Kubectl.Flags
-	- deploy.Kubectl.DefaultNamespace
-	- deploy.Kustomize.Flags
-	- deploy.Kustomize.DefaultNamespace
+  - deploy.StatusCheckDeadlineSeconds
+  - deploy.Logs.Prefix
+  - deploy.Kubectl.Flags
+  - deploy.Kubectl.DefaultNamespace
+  - deploy.Kustomize.Flags
+  - deploy.Kustomize.DefaultNamespace
+
 For a multi-config project, we do not currently support resolving conflicts between differing sets of this deploy configuration.
 Therefore, in this function we do implicit validation of the provided configuration, and fail if any conflict cannot be resolved.
 */
@@ -321,10 +322,10 @@ func getCloudRunDeployer(runCtx *runcontext.RunContext, labeller *label.DefaultL
 				return nil, fmt.Errorf("expected all Cloud Run deploys to be in the same region, found deploys to %s and %s", region, crDeploy.Region)
 			}
 			region = crDeploy.Region
-			if defaultProject != "" && defaultProject != crDeploy.DefaultProjectID {
-				return nil, fmt.Errorf("expected all Cloud Run deploys to use the same default project, found deploys to projects %s and %s", defaultProject, crDeploy.DefaultProjectID)
+			if defaultProject != "" && defaultProject != crDeploy.ProjectID {
+				return nil, fmt.Errorf("expected all Cloud Run deploys to use the same project, found deploys to projects %s and %s", defaultProject, crDeploy.ProjectID)
 			}
 		}
 	}
-	return cloudrun.NewDeployer(runCtx, labeller, &latest.CloudRunDeploy{Region: region, DefaultProjectID: defaultProject})
+	return cloudrun.NewDeployer(runCtx, labeller, &latest.CloudRunDeploy{Region: region, ProjectID: defaultProject})
 }

--- a/pkg/skaffold/runner/deployer_test.go
+++ b/pkg/skaffold/runner/deployer_test.go
@@ -237,11 +237,11 @@ func TestGetDeployer(tOuter *testing.T) {
 				cfg: latest.Pipeline{
 					Deploy: latest.DeployConfig{
 						DeployType: latest.DeployType{
-							CloudRunDeploy: &latest.CloudRunDeploy{DefaultProjectID: "TestProject", Region: "us-central1"},
+							CloudRunDeploy: &latest.CloudRunDeploy{ProjectID: "TestProject", Region: "us-central1"},
 						},
 					},
 				},
-				expected: t.RequireNonNilResult(cloudrun.NewDeployer(&runcontext.RunContext{}, &label.DefaultLabeller{}, &latest.CloudRunDeploy{DefaultProjectID: "TestProject", Region: "us-central1"})).(deploy.Deployer),
+				expected: t.RequireNonNilResult(cloudrun.NewDeployer(&runcontext.RunContext{}, &label.DefaultLabeller{}, &latest.CloudRunDeploy{ProjectID: "TestProject", Region: "us-central1"})).(deploy.Deployer),
 			},
 			{
 				description: "apply does not allow multiple deployers when Cloud Run is used",

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -696,7 +696,7 @@ type DeployType struct {
 // CloudRunDeploy *alpha* deploys the container to Google Cloud Run.
 type CloudRunDeploy struct {
 	// ProjectID of the GCP Project to use for Cloud Run.
-	DefaultProjectID string `yaml:"defaultprojectid,omitempty"`
+	ProjectID string `yaml:"projectid,omitempty"`
 
 	// Region in GCP to use for the Cloud Run Deploy.
 	// Must be one of the regions listed in https://cloud.google.com/run/docs/locations.


### PR DESCRIPTION

**Related**: #3217

**Description**
The initial implementation of the Cloud Run Deployer would use the project specified in the Skaffold manifest only if a project wasn't specified in the Cloud Run manifest.  This inverts the precedence: a project specified in a Skaffold manifest will override the project specified in the Cloud Run manifest.

This way, if you build your Skaffold config  using an existing Cloud Run manifest, you can change the projects for different profiles entirely in the Skaffold config, without having to use Kustomize etc. to modify the Cloud Run manifest.

**User facing changes (remove if N/A)**
For Cloud Run deploys, prefer the Google Cloud project id in the Skaffold manifest over the project id in the Cloud Run manifest.
*Before*:
Given a Cloud Run manifest with
metadata:
 &nbsp; &nbsp;namespace: project1

and a Skaffold manifest with
deploy:
 &nbsp; &nbsp;cloudrun:
  &nbsp; &nbsp; &nbsp; &nbsp;defaultprojectid: project2

The service would be deployed to project1.

*After*:
Given a Cloud Run manifest with
metadata:
 &nbsp; &nbsp;namespace: project1

and a Skaffold manifest with
deploy:
 &nbsp; &nbsp;cloudrun:
  &nbsp; &nbsp; &nbsp; &nbsp;projectid: project2 

The service will be deployed to project2