### PR TITLE
chore: use rbac.authorization.k8s.io/v1

### DIFF
--- a/deploy/webhook-v2/deployment.yaml
+++ b/deploy/webhook-v2/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: admin-serviceaccount
   namespace: default
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: admin-crb

--- a/deploy/webhook/deployment.yaml
+++ b/deploy/webhook/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: admin-serviceaccount
   namespace: default
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: admin-crb

--- a/integration/testdata/skaffold-in-cluster/build-step/skaffold-rbac.yaml
+++ b/integration/testdata/skaffold-in-cluster/build-step/skaffold-rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: skaffold-svc
   namespace: default
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: admin-crb


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: https://github.com/GoogleContainerTools/skaffold/issues/7571

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Replace rbac.authorization.k8s.io/v1beta1 with rbac.authorization.k8s.io/v1. rbac.authorization.k8s.io/v1beta1 is removed from Kubernetes 1.22 so it is better if we use the latest API. Ref: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#rbac-resources-v122

Thanks for your review!


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
