### PR TITLE
Replace deprecated ioutil pkg with os & io

### DIFF
--- a/cmd/skaffold/app/cmd/build.go
+++ b/cmd/skaffold/app/cmd/build.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -65,7 +65,7 @@ func NewCmdBuild() *cobra.Command {
 func doBuild(ctx context.Context, out io.Writer) error {
 	buildOut := out
 	if quietFlag {
-		buildOut = ioutil.Discard
+		buildOut = io.Discard
 	}
 
 	return withRunner(ctx, out, func(r runner.Runner, configs []util.VersionedConfig) error {
@@ -85,7 +85,7 @@ func doBuild(ctx context.Context, out io.Writer) error {
 			}
 
 			if buildOutputFlag != "" {
-				if err := ioutil.WriteFile(buildOutputFlag, buildOutput.Bytes(), 0644); err != nil {
+				if err := os.WriteFile(buildOutputFlag, buildOutput.Bytes(), 0644); err != nil {
 					return fmt.Errorf("writing build output to file: %w", err)
 				}
 			}

--- a/cmd/skaffold/app/cmd/build_test.go
+++ b/cmd/skaffold/app/cmd/build_test.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/flags"
@@ -171,7 +171,7 @@ func TestFileOutputFlag(t *testing.T) {
 			t.CheckDeepEqual(string(test.expectedOutput), output.String())
 
 			// Check that file contents are correct
-			fileContent, err := ioutil.ReadFile(test.filename)
+			fileContent, err := os.ReadFile(test.filename)
 			t.CheckNoError(err)
 			t.CheckDeepEqual(string(test.expectedFileContent), string(fileContent))
 		})
@@ -206,7 +206,7 @@ func TestRunBuild(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&createRunner, test.mock)
 
-			err := doBuild(context.Background(), ioutil.Discard)
+			err := doBuild(context.Background(), io.Discard)
 
 			t.CheckError(test.shouldErr, err)
 		})

--- a/cmd/skaffold/app/cmd/config/set_test.go
+++ b/cmd/skaffold/app/cmd/config/set_test.go
@@ -18,7 +18,7 @@ package config
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
@@ -382,7 +382,7 @@ func TestSetAndUnsetConfig(t *testing.T) {
 			}
 
 			// set specified value
-			err := Set(context.Background(), ioutil.Discard, []string{test.key, test.value})
+			err := Set(context.Background(), io.Discard, []string{test.key, test.value})
 			actualConfig, cfgErr := config.ReadConfigFile(cfg)
 			t.CheckNoError(cfgErr)
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expectedSetCfg, actualConfig)
@@ -393,7 +393,7 @@ func TestSetAndUnsetConfig(t *testing.T) {
 			}
 
 			// unset the value
-			err = Unset(context.Background(), ioutil.Discard, []string{test.key})
+			err = Unset(context.Background(), io.Discard, []string{test.key})
 			newConfig, cfgErr := config.ReadConfigFile(cfg)
 			t.CheckNoError(cfgErr)
 

--- a/cmd/skaffold/app/cmd/credits/export.go
+++ b/cmd/skaffold/app/cmd/credits/export.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	iofs "io/fs"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -48,12 +47,12 @@ func Export(ctx context.Context, out io.Writer) error {
 				return fmt.Errorf("opening %q in embedded filesystem: %w", filePath, err)
 			}
 
-			buf, err := ioutil.ReadAll(file)
+			buf, err := io.ReadAll(file)
 			if err != nil {
 				return fmt.Errorf("reading %q in embedded filesystem: %w", filePath, err)
 			}
 
-			if err := ioutil.WriteFile(newPath, buf, 0664); err != nil {
+			if err := os.WriteFile(newPath, buf, 0664); err != nil {
 				return fmt.Errorf("writing %q to %q: %w", filePath, newPath, err)
 			}
 		}

--- a/cmd/skaffold/app/cmd/dev_test.go
+++ b/cmd/skaffold/app/cmd/dev_test.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
@@ -106,7 +105,7 @@ func TestDoDev(t *testing.T) {
 				NoPrune: false,
 			})
 
-			err := doDev(context.Background(), ioutil.Discard)
+			err := doDev(context.Background(), io.Discard)
 
 			t.CheckDeepEqual(test.expectedCalls, mockRunner.calls)
 			t.CheckTrue(err == context.Canceled)
@@ -156,7 +155,7 @@ func TestDevConfigChange(t *testing.T) {
 			NoPrune: false,
 		})
 
-		err := doDev(context.Background(), ioutil.Discard)
+		err := doDev(context.Background(), io.Discard)
 
 		// ensure that we received the context.Canceled error (and not ErrorConfigurationChanged)
 		// also ensure that the we run through dev cycles (since we reloaded on the first),

--- a/cmd/skaffold/app/cmd/fix.go
+++ b/cmd/skaffold/app/cmd/fix.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -110,7 +110,7 @@ func fix(out io.Writer, configFile, outFile string, toVersion string) error {
 		return fmt.Errorf("marshaling new config: %w", err)
 	}
 	if outFile != "" {
-		if err := ioutil.WriteFile(outFile, newCfg, 0644); err != nil {
+		if err := os.WriteFile(outFile, newCfg, 0644); err != nil {
 			return fmt.Errorf("writing config file: %w", err)
 		}
 		output.Default.Fprintf(out, "New config at version %s generated and written to %s\n", toVersion, outFile)

--- a/cmd/skaffold/app/cmd/fix_test.go
+++ b/cmd/skaffold/app/cmd/fix_test.go
@@ -19,7 +19,7 @@ package cmd
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -206,7 +206,7 @@ deploy:
 		var b bytes.Buffer
 		err := fix(&b, cfgFile, cfgFile, latestV1.Version)
 
-		output, _ := ioutil.ReadFile(cfgFile)
+		output, _ := os.ReadFile(cfgFile)
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual(expectedOutput, string(output))

--- a/cmd/skaffold/app/cmd/render.go
+++ b/cmd/skaffold/app/cmd/render.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/spf13/cobra"
 
@@ -53,7 +52,7 @@ func NewCmdRender() *cobra.Command {
 func doRender(ctx context.Context, out io.Writer) error {
 	// TODO(nkubala): remove this from opts in favor of a param to Build()
 	opts.RenderOnly = true
-	buildOut := ioutil.Discard
+	buildOut := io.Discard
 	if showBuild {
 		buildOut = out
 	}

--- a/cmd/skaffold/app/cmd/run_test.go
+++ b/cmd/skaffold/app/cmd/run_test.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
@@ -120,7 +119,7 @@ func TestDoRun(t *testing.T) {
 				SkipTests:    test.skipTests,
 			})
 
-			err := doRun(context.Background(), ioutil.Discard)
+			err := doRun(context.Background(), io.Discard)
 			t.CheckNoError(err)
 			t.CheckDeepEqual(test.skipTests, !mockRunner.testRan)
 			t.CheckDeepEqual([]string{"second-test", "test"}, mockRunner.artifactImageNames)

--- a/cmd/skaffold/app/cmd/runner_test.go
+++ b/cmd/skaffold/app/cmd/runner_test.go
@@ -19,7 +19,7 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/blang/semver"
@@ -102,7 +102,7 @@ func TestCreateNewRunner(t *testing.T) {
 				Write("skaffold.yaml", fmt.Sprintf("apiVersion: %s\nkind: Config\n%s", latest.Version, test.config)).
 				Chdir()
 
-			_, _, _, err := createNewRunner(context.Background(), ioutil.Discard, test.options)
+			_, _, _, err := createNewRunner(context.Background(), io.Discard, test.options)
 
 			t.CheckError(test.shouldErr, err)
 			if test.expectedError != "" {

--- a/cmd/skaffold/app/flags/build_output.go
+++ b/cmd/skaffold/app/flags/build_output.go
@@ -19,7 +19,7 @@ package flags
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
@@ -53,12 +53,12 @@ func (t *BuildOutputFileFlag) Set(value string) error {
 	)
 
 	if value == "-" {
-		buf, err = ioutil.ReadAll(os.Stdin)
+		buf, err = io.ReadAll(os.Stdin)
 	} else {
 		if _, err := os.Stat(value); os.IsNotExist(err) {
 			return err
 		}
-		buf, err = ioutil.ReadFile(value)
+		buf, err = os.ReadFile(value)
 	}
 	if err != nil {
 		return err

--- a/cmd/skaffold/app/skaffold_test.go
+++ b/cmd/skaffold/app/skaffold_test.go
@@ -18,7 +18,7 @@ package app
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -48,7 +48,7 @@ func TestMainUnknownCommand(t *testing.T) {
 		// --interactive=false removes the update check and survey prompt.
 		t.Override(&os.Args, []string{"skaffold", "unknown", "--interactive=false"})
 
-		err := Run(ioutil.Discard, ioutil.Discard)
+		err := Run(io.Discard, io.Discard)
 
 		t.CheckError(true, err)
 	})
@@ -78,7 +78,7 @@ func TestSkaffoldCmdline_MainUnknownCommand(t *testing.T) {
 		t.Override(&os.Args, []string{"skaffold"})
 		t.SetEnvs(map[string]string{"SKAFFOLD_CMDLINE": "unknown"})
 
-		err := Run(ioutil.Discard, ioutil.Discard)
+		err := Run(io.Discard, io.Discard)
 
 		t.CheckError(true, err)
 	})
@@ -88,19 +88,19 @@ func TestMain_InvalidUsageExitCode(t *testing.T) {
 	testutil.Run(t, "unknown command", func(t *testutil.T) {
 		// --interactive=false removes the update check and survey prompt.
 		t.Override(&os.Args, []string{"skaffold", "unknown", "--interactive=false"})
-		err := Run(ioutil.Discard, ioutil.Discard)
+		err := Run(io.Discard, io.Discard)
 		t.CheckErrorAndExitCode(127, err)
 	})
 	testutil.Run(t, "unknown flag", func(t *testutil.T) {
 		// --interactive=false removes the update check and survey prompt.
 		t.Override(&os.Args, []string{"skaffold", "--help2", "--interactive=false"})
-		err := Run(ioutil.Discard, ioutil.Discard)
+		err := Run(io.Discard, io.Discard)
 		t.CheckErrorAndExitCode(127, err)
 	})
 	testutil.Run(t, "exactargs error", func(t *testutil.T) {
 		// --interactive=false removes the update check and survey prompt.
 		t.Override(&os.Args, []string{"skaffold", "config", "set", "a", "b", "c"})
-		err := Run(ioutil.Discard, ioutil.Discard)
+		err := Run(io.Discard, io.Discard)
 		t.CheckErrorAndExitCode(127, err)
 	})
 }

--- a/codelab/03_buildpacks-runimage-override/app/main.go
+++ b/codelab/03_buildpacks-runimage-override/app/main.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 )
 
 func main() {
@@ -15,7 +15,7 @@ func main() {
 }
 
 func hello(w http.ResponseWriter, _ *http.Request) {
-	data, err := ioutil.ReadFile("/hello.txt")
+	data, err := os.ReadFile("/hello.txt")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}

--- a/examples/lifecycle-hooks/main.go
+++ b/examples/lifecycle-hooks/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"syscall"
@@ -12,14 +11,14 @@ import (
 func main() {
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGHUP)
-	data, err := ioutil.ReadFile("hello.txt")
+	data, err := os.ReadFile("hello.txt")
 	if err != nil {
 		fmt.Printf("failed to read file hello.txt: %v", err)
 	}
 	go func() {
 		for range sigs {
 			fmt.Printf("received SIGHUP signal. Reloading file hello.txt\n")
-			data, err = ioutil.ReadFile("hello.txt")
+			data, err = os.ReadFile("hello.txt")
 			if err != nil {
 				fmt.Printf("failed to read file hello.txt: %v", err)
 			}

--- a/examples/simple-artifact-dependency/app/main.go
+++ b/examples/simple-artifact-dependency/app/main.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 )
 
 func main() {
-	dat, err := ioutil.ReadFile("hello.txt")
+	dat, err := os.ReadFile("hello.txt")
 	if err != nil {
 		panic(err)
 	}

--- a/hack/comparisonstats/devrunner/devrunner.go
+++ b/hack/comparisonstats/devrunner/devrunner.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -102,13 +101,13 @@ func Dev(ctx context.Context, app types.Application, skaffoldBinaryPath string, 
 	}
 	time.Sleep(5 * time.Second)
 	return &DevInfo{CmdArgs: cmd.Args}, wait.Poll(time.Second, 2*time.Minute, func() (bool, error) {
-		contents, err := ioutil.ReadFile(eventsFileAbsPath)
+		contents, err := os.ReadFile(eventsFileAbsPath)
 		return err == nil && len(contents) > 0, nil
 	})
 }
 
 func copyAppToTmpDir(app *types.Application) error {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		return fmt.Errorf("temp dir: %w", err)
 	}

--- a/hack/comparisonstats/events/parse.go
+++ b/hack/comparisonstats/events/parse.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
@@ -120,7 +120,7 @@ func get(contents []byte) ([]*v1.LogEntry, error) {
 }
 
 func getFromFile(fp string) ([]*v1.LogEntry, error) {
-	contents, err := ioutil.ReadFile(fp)
+	contents, err := os.ReadFile(fp)
 	if err != nil {
 		return nil, errors.Wrapf(err, "reading %s", fp)
 	}

--- a/hack/comparisonstats/main.go
+++ b/hack/comparisonstats/main.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -75,7 +74,7 @@ func main() {
 
 	// if yamlInputFile set, update values from yaml file to override flag opts
 	if yamlInputFile != "" {
-		yamlFile, err := ioutil.ReadFile(yamlInputFile)
+		yamlFile, err := os.ReadFile(yamlInputFile)
 		if err != nil {
 			logrus.Fatalf("error reading yaml input file: %v ", err)
 		}
@@ -139,7 +138,7 @@ func main() {
 	}
 	if summaryOutputPath != "" {
 		logrus.Infof("writing summary information to path %v", summaryOutputPath)
-		if err := ioutil.WriteFile(filepath.Join(workDir, summaryOutputPath), b.Bytes(), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(workDir, summaryOutputPath), b.Bytes(), 0644); err != nil {
 			logrus.Fatal(err)
 		}
 	}

--- a/hack/man/man_test.go
+++ b/hack/man/man_test.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -40,11 +40,11 @@ func TestPrintMan(t *testing.T) {
 	testutil.CheckContains(t, "Env vars", output)
 
 	// Compare to current man page
-	header, err := ioutil.ReadFile(filepath.Join("..", "..", "docs", "content", "en", "docs", "references", "cli", "index_header"))
+	header, err := os.ReadFile(filepath.Join("..", "..", "docs", "content", "en", "docs", "references", "cli", "index_header"))
 	testutil.CheckError(t, false, err)
 	header = bytes.ReplaceAll(header, []byte("\r\n"), []byte("\n"))
 
-	expected, err := ioutil.ReadFile(filepath.Join("..", "..", "docs", "content", "en", "docs", "references", "cli", "_index.md"))
+	expected, err := os.ReadFile(filepath.Join("..", "..", "docs", "content", "en", "docs", "references", "cli", "_index.md"))
 	testutil.CheckError(t, false, err)
 	expected = bytes.ReplaceAll(expected, []byte("\r\n"), []byte("\n"))
 

--- a/hack/release/changelog/main.go
+++ b/hack/release/changelog/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -88,7 +87,7 @@ func updateChangelog(filepath, templatePath string, data changelogData) error {
 	if err = tmpl.Execute(&buf, data); err != nil {
 		return fmt.Errorf("executing changelog template: %w", err)
 	}
-	b, err := ioutil.ReadFile(filepath)
+	b, err := os.ReadFile(filepath)
 	if err != nil {
 		return fmt.Errorf("reading changelog file: %w", err)
 	}
@@ -96,7 +95,7 @@ func updateChangelog(filepath, templatePath string, data changelogData) error {
 	if err != nil {
 		return fmt.Errorf("writing to changelog buffer: %w", err)
 	}
-	if err = ioutil.WriteFile(filepath, buf.Bytes(), 0644); err != nil {
+	if err = os.WriteFile(filepath, buf.Bytes(), 0644); err != nil {
 		return fmt.Errorf("writing to changelog file: %w", err)
 	}
 

--- a/hack/release/changelog/main_test.go
+++ b/hack/release/changelog/main_test.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path"
 	"testing"
 
@@ -33,8 +33,8 @@ func TestUpdateChangelog(t *testing.T) {
 	}
 
 	// Read original `testdata/changelog.md` and write it back after test
-	changelogB, _ := ioutil.ReadFile(path.Join("testdata", "changelog.md"))
-	defer ioutil.WriteFile(path.Join("testdata", "changelog.md"), changelogB, 0644)
+	changelogB, _ := os.ReadFile(path.Join("testdata", "changelog.md"))
+	defer os.WriteFile(path.Join("testdata", "changelog.md"), changelogB, 0644)
 
 	// function should only error on standard lib errors
 	err := updateChangelog(path.Join("testdata", "changelog.md"), path.Join("template.md"), data)
@@ -42,8 +42,8 @@ func TestUpdateChangelog(t *testing.T) {
 		t.Fatalf("%s", err)
 	}
 
-	gotB, _ := ioutil.ReadFile(path.Join("testdata", "changelog.md"))
-	wantB, _ := ioutil.ReadFile(path.Join("testdata", "expected.md"))
+	gotB, _ := os.ReadFile(path.Join("testdata", "changelog.md"))
+	wantB, _ := os.ReadFile(path.Join("testdata", "expected.md"))
 	gotB = bytes.ReplaceAll(gotB, []byte("\r\n"), []byte("\n"))
 	wantB = bytes.ReplaceAll(wantB, []byte("\r\n"), []byte("\n"))
 

--- a/hack/schemas/main.go
+++ b/hack/schemas/main.go
@@ -23,7 +23,6 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -31,7 +30,7 @@ import (
 	"strings"
 	"sync"
 
-	blackfriday "github.com/russross/blackfriday/v2"
+	"github.com/russross/blackfriday/v2"
 	"github.com/xeipuuv/gojsonschema"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema"
@@ -152,7 +151,7 @@ func generateV1Schema(root string, dryRun bool, version schema.Version) (bool, e
 	var current []byte
 	if _, err := os.Stat(output); err == nil {
 		var err error
-		current, err = ioutil.ReadFile(output)
+		current, err = os.ReadFile(output)
 		if err != nil {
 			return false, fmt.Errorf("unable to read existing schema for version %q: %w", version.APIVersion, err)
 		}
@@ -163,7 +162,7 @@ func generateV1Schema(root string, dryRun bool, version schema.Version) (bool, e
 	current = bytes.ReplaceAll(current, []byte("\r\n"), []byte("\n"))
 
 	if !dryRun {
-		if err := ioutil.WriteFile(output, buf, os.ModePerm); err != nil {
+		if err := os.WriteFile(output, buf, os.ModePerm); err != nil {
 			return false, fmt.Errorf("unable to write schema %q: %w", output, err)
 		}
 	}

--- a/hack/schemas/main_test.go
+++ b/hack/schemas/main_test.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -60,7 +60,7 @@ func TestGenerators(t *testing.T) {
 			actual, err := generator.Apply(input)
 			t.CheckNoError(err)
 
-			expected, err := ioutil.ReadFile(expectedOutput)
+			expected, err := os.ReadFile(expectedOutput)
 			t.CheckNoError(err)
 
 			expected = bytes.ReplaceAll(expected, []byte("\r\n"), []byte("\n"))

--- a/hack/struct-json/main.go
+++ b/hack/struct-json/main.go
@@ -23,13 +23,12 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 
-	blackfriday "github.com/russross/blackfriday/v2"
+	"github.com/russross/blackfriday/v2"
 )
 
 var camelSepRegex = regexp.MustCompile(`([a-z0-9])([A-Z])`)
@@ -62,7 +61,7 @@ func generateJSON(root, input, output string, dryRun bool) error {
 	}
 
 	if !dryRun {
-		if err := ioutil.WriteFile(output, buf, os.ModePerm); err != nil {
+		if err := os.WriteFile(output, buf, os.ModePerm); err != nil {
 			return fmt.Errorf("unable to write json %q: %w", output, err)
 		}
 	}

--- a/hack/tools/logrus_analyzer.go
+++ b/hack/tools/logrus_analyzer.go
@@ -17,8 +17,9 @@ limitations under the License.
 package main
 
 import (
-	"golang.org/x/tools/go/analysis/singlechecker"
 	"tools/linters"
+
+	"golang.org/x/tools/go/analysis/singlechecker"
 )
 
 func main() {

--- a/hack/versions/cmd/new/version.go
+++ b/hack/versions/cmd/new/version.go
@@ -19,7 +19,6 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -162,7 +161,7 @@ func template(file string) string {
 }
 
 func read(path string) []byte {
-	buf, err := ioutil.ReadFile(path)
+	buf, err := os.ReadFile(path)
 	if err != nil {
 		panic("unable to read " + path)
 	}
@@ -170,7 +169,7 @@ func read(path string) []byte {
 }
 
 func write(path string, buf []byte) {
-	if err := ioutil.WriteFile(path, buf, os.ModePerm); err != nil {
+	if err := os.WriteFile(path, buf, os.ModePerm); err != nil {
 		panic("unable to write " + path)
 	}
 }

--- a/hack/versions/pkg/schema/check.go
+++ b/hack/versions/pkg/schema/check.go
@@ -19,7 +19,7 @@ package schema
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 
@@ -53,18 +53,18 @@ func RunSchemaCheckOnChangedFiles() error {
 		}
 	}
 
-	root, err := ioutil.TempDir("", "skaffold")
+	root, err := os.MkdirTemp("", "skaffold")
 	if err != nil {
 		return err
 	}
 	var filesInError []string
 	for _, configFile := range changedConfigFiles {
-		content, err := ioutil.ReadFile(configFile)
+		content, err := os.ReadFile(configFile)
 		if err != nil {
 			return fmt.Errorf("reading %q: %w", configFile, err)
 		}
 		changedFile := path.Join(root, "changed.go")
-		if err = ioutil.WriteFile(changedFile, content, 0666); err != nil {
+		if err = os.WriteFile(changedFile, content, 0666); err != nil {
 			return fmt.Errorf("writing changed version of %q: %w", configFile, err)
 		}
 
@@ -77,7 +77,7 @@ func RunSchemaCheckOnChangedFiles() error {
 			return err
 		}
 		baseFile := path.Join(root, "base.go")
-		if err = ioutil.WriteFile(baseFile, content, 0666); err != nil {
+		if err = os.WriteFile(baseFile, content, 0666); err != nil {
 			return fmt.Errorf("writing %s version of %q: %w", baseRef, configFile, err)
 		}
 

--- a/hack/versions/pkg/schema/comment.go
+++ b/hack/versions/pkg/schema/comment.go
@@ -22,7 +22,6 @@ import (
 	"go/parser"
 	"go/printer"
 	"go/token"
-	"io/ioutil"
 	"os"
 	"os/exec"
 )
@@ -51,7 +50,7 @@ func UpdateVersionComment(origFile string, released bool) error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(origFile, content, info.Mode()); err != nil {
+	if err := os.WriteFile(origFile, content, info.Mode()); err != nil {
 		return err
 	}
 

--- a/hack/versions/pkg/schema/version.go
+++ b/hack/versions/pkg/schema/version.go
@@ -18,8 +18,9 @@ package schema
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"regexp"
 	"strings"
 
@@ -33,7 +34,7 @@ func GetLatestVersion() (string, bool) {
 	current := strings.TrimPrefix(latest.Version, "skaffold/")
 	logrus.Debugf("Current Skaffold version: %s", current)
 
-	config, err := ioutil.ReadFile("pkg/skaffold/schema/latest/config.go")
+	config, err := os.ReadFile("pkg/skaffold/schema/latest/config.go")
 	if err != nil {
 		logrus.Fatalf("failed to read latest config: %s", err)
 	}
@@ -65,7 +66,7 @@ func GetLastReleasedVersion() string {
 		resp, err := http.Get(url)
 		if err == nil && resp.StatusCode >= 200 && resp.StatusCode < 300 {
 			defer resp.Body.Close()
-			config, err := ioutil.ReadAll(resp.Body)
+			config, err := io.ReadAll(resp.Body)
 			if err != nil {
 				logrus.Fatalf("failed to fetch config for %s, err: %s", lastTag, err)
 			}
@@ -80,7 +81,7 @@ func GetLastReleasedVersion() string {
 
 // IsReleased takes a filepath to a skaffold config in pkg/skaffold/schema and returns true if it's released and false if otherwise.
 func IsReleased(filepath string) (bool, error) {
-	b, err := ioutil.ReadFile(filepath)
+	b, err := os.ReadFile(filepath)
 	if err != nil {
 		return false, err
 	}

--- a/integration/build_cluster_test.go
+++ b/integration/build_cluster_test.go
@@ -18,7 +18,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -101,25 +100,25 @@ func TestBuildInCluster(t *testing.T) {
 }
 
 func replaceNamespace(t *testutil.T, fileName string, ns *v1.Namespace) {
-	origSkaffoldYaml, err := ioutil.ReadFile(fileName)
+	origSkaffoldYaml, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatalf("failed reading %s: %s", fileName, err)
 	}
 
 	namespacedYaml := strings.ReplaceAll(string(origSkaffoldYaml), "VAR_CLUSTER_NAMESPACE", ns.Name)
 
-	if err := ioutil.WriteFile(fileName, []byte(namespacedYaml), 0666); err != nil {
+	if err := os.WriteFile(fileName, []byte(namespacedYaml), 0666); err != nil {
 		t.Fatalf("failed to write %s: %s", fileName, err)
 	}
 }
 
 func copyFile(t *testutil.T, src, dst string) {
-	content, err := ioutil.ReadFile(src)
+	content, err := os.ReadFile(src)
 	if err != nil {
 		t.Fatalf("can't read source file: %s: %s", src, err)
 	}
 
-	if err := ioutil.WriteFile(dst, content, 0666); err != nil {
+	if err := os.WriteFile(dst, content, 0666); err != nil {
 		t.Fatalf("failed to copy file %s to %s: %s", src, dst, err)
 	}
 }
@@ -134,7 +133,7 @@ func copyDir(t *testutil.T, src string, dst string) {
 		t.Fatalf("failed to copy dir %s->%s: %s ", src, dst, err)
 	}
 
-	files, err := ioutil.ReadDir(src)
+	files, err := os.ReadDir(src)
 	if err != nil {
 		t.Fatalf("failed to copy dir %s->%s: %s ", src, dst, err)
 	}

--- a/integration/credits_test.go
+++ b/integration/credits_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package integration
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/integration/skaffold"
@@ -34,7 +34,7 @@ func TestCredits(t *testing.T) {
 		t.CheckNoError(err)
 		t.CheckContains("Successfully exported third party notices", string(out))
 
-		content, err := ioutil.ReadFile(tmpDir.Path("skaffold-credits/github.com/docker/docker/LICENSE"))
+		content, err := os.ReadFile(tmpDir.Path("skaffold-credits/github.com/docker/docker/LICENSE"))
 		t.CheckNoError(err)
 		t.CheckContains("Apache License", string(content))
 	})
@@ -51,7 +51,7 @@ func TestCreditsDir(t *testing.T) {
 		t.CheckNoError(err)
 		t.CheckContains("Successfully exported third party notices", string(out))
 
-		content, err := ioutil.ReadFile(tmpDir.Path("test/skaffold-credits/credits/github.com/docker/docker/LICENSE"))
+		content, err := os.ReadFile(tmpDir.Path("test/skaffold-credits/credits/github.com/docker/docker/LICENSE"))
 		t.CheckNoError(err)
 		t.CheckContains("Apache License", string(content))
 	})

--- a/integration/custom_test.go
+++ b/integration/custom_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package integration
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -48,10 +47,10 @@ func TestCustomTest(t *testing.T) {
 	skaffold.Dev().InDir(testDir).WithConfig(config).InNs(ns.Name).RunLive(t)
 
 	client.WaitForPodsReady("custom-test-example")
-	ioutil.WriteFile(depFile, []byte("foo"), 0644)
+	os.WriteFile(depFile, []byte("foo"), 0644)
 
 	err := wait.PollImmediate(time.Millisecond*500, 1*time.Minute, func() (bool, error) {
-		out, e := ioutil.ReadFile(testFile)
+		out, e := os.ReadFile(testFile)
 		failNowIfError(t, e)
 		return string(out) == expectedText, nil
 	})

--- a/integration/deploy_test.go
+++ b/integration/deploy_test.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -113,7 +112,7 @@ func TestDeployWithImages(t *testing.T) {
 	skaffold.Build("--file-output=artifacts.json", "--default-repo=").InDir("examples/getting-started").RunOrFail(t)
 
 	var artifacts flags.BuildOutput
-	if ba, err := ioutil.ReadFile("examples/getting-started/artifacts.json"); err != nil {
+	if ba, err := os.ReadFile("examples/getting-started/artifacts.json"); err != nil {
 		t.Fatal("could not read artifacts.json", err)
 	} else if err := json.Unmarshal(ba, &artifacts); err != nil {
 		t.Fatal("could not decode artifacts.json", err)

--- a/integration/dev_test.go
+++ b/integration/dev_test.go
@@ -19,7 +19,7 @@ package integration
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"runtime"
@@ -281,7 +281,7 @@ func TestDevPortForward(t *testing.T) {
 			failNowIfError(t, fErr)
 			defer func() {
 				if original != nil {
-					ioutil.WriteFile(fmt.Sprintf("%s/leeroy-app/app.go", test.dir), original, perms)
+					os.WriteFile(fmt.Sprintf("%s/leeroy-app/app.go", test.dir), original, perms)
 				}
 			}()
 
@@ -308,7 +308,7 @@ func TestDevPortForwardDefaultNamespace(t *testing.T) {
 	failNowIfError(t, fErr)
 	defer func() {
 		if original != nil {
-			ioutil.WriteFile("examples/microservices/leeroy-app/app.go", original, perms)
+			os.WriteFile("examples/microservices/leeroy-app/app.go", original, perms)
 		}
 	}()
 
@@ -383,7 +383,7 @@ func assertResponseFromPort(t *testing.T, address string, port int, expected str
 				continue
 			}
 			defer resp.Body.Close()
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			if err != nil {
 				t.Logf("[retriable error] reading response: %v", err)
 				continue
@@ -401,14 +401,14 @@ func replaceInFile(target, replacement, filepath string) ([]byte, os.FileMode, e
 	if err != nil {
 		return nil, 0, err
 	}
-	original, err := ioutil.ReadFile(filepath)
+	original, err := os.ReadFile(filepath)
 	if err != nil {
 		return nil, 0, err
 	}
 
 	newContents := strings.ReplaceAll(string(original), target, replacement)
 
-	err = ioutil.WriteFile(filepath, []byte(newContents), 0)
+	err = os.WriteFile(filepath, []byte(newContents), 0)
 
 	return original, fInfo.Mode(), err
 }

--- a/integration/diagnose_test.go
+++ b/integration/diagnose_test.go
@@ -19,7 +19,6 @@ package integration
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -53,13 +52,13 @@ func TestDiagnose(t *testing.T) {
 func folders(root string) ([]string, error) {
 	var folders []string
 
-	files, err := ioutil.ReadDir(root)
+	files, err := os.ReadDir(root)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, f := range files {
-		if f.Mode().IsDir() {
+		if f.IsDir() {
 			folders = append(folders, f.Name())
 		}
 	}
@@ -95,13 +94,13 @@ func TestMultiConfigDiagnose(t *testing.T) {
 			args := []string{}
 			if test.cpSkaffold {
 				tmpDir := t.NewTempDir()
-				configContents, err := ioutil.ReadFile(filepath.Join(test.dir, "skaffold.yaml"))
+				configContents, err := os.ReadFile(filepath.Join(test.dir, "skaffold.yaml"))
 				t.CheckNoError(err)
 				tmpDir.Write("skaffold.yaml", string(configContents))
 				args = append(args, fmt.Sprintf("-f=%s", tmpDir.Path("skaffold.yaml")))
 			}
 			out := skaffold.Diagnose(append(args, "--yaml-only")...).InDir(test.dir).RunOrFailOutput(t.T)
-			templ, err := ioutil.ReadFile(filepath.Join(test.dir, "diagnose.tmpl"))
+			templ, err := os.ReadFile(filepath.Join(test.dir, "diagnose.tmpl"))
 			t.CheckNoError(err)
 			outTemplate := template.Must(template.New("tmpl").Parse(string(templ)))
 			cwd, err := filepath.Abs(test.dir)

--- a/integration/examples/lifecycle-hooks/main.go
+++ b/integration/examples/lifecycle-hooks/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"syscall"
@@ -12,14 +11,14 @@ import (
 func main() {
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGHUP)
-	data, err := ioutil.ReadFile("hello.txt")
+	data, err := os.ReadFile("hello.txt")
 	if err != nil {
 		fmt.Printf("failed to read file hello.txt: %v", err)
 	}
 	go func() {
 		for range sigs {
 			fmt.Printf("received SIGHUP signal. Reloading file hello.txt\n")
-			data, err = ioutil.ReadFile("hello.txt")
+			data, err = os.ReadFile("hello.txt")
 			if err != nil {
 				fmt.Printf("failed to read file hello.txt: %v", err)
 			}

--- a/integration/examples/simple-artifact-dependency/app/main.go
+++ b/integration/examples/simple-artifact-dependency/app/main.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 )
 
 func main() {
-	dat, err := ioutil.ReadFile("hello.txt")
+	dat, err := os.ReadFile("hello.txt")
 	if err != nil {
 		panic(err)
 	}

--- a/integration/fix_test.go
+++ b/integration/fix_test.go
@@ -17,12 +17,11 @@ limitations under the License.
 package integration
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 
 	"github.com/GoogleContainerTools/skaffold/integration/skaffold"
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -62,7 +61,7 @@ func TestFixOutputFile(t *testing.T) {
 	testutil.CheckContains(t, "written to updated.yaml", string(out))
 	defer os.Remove(filepath.Join("testdata", "fix", "updated.yaml"))
 
-	f, err := ioutil.ReadFile(filepath.Join("testdata", "fix", "updated.yaml"))
+	f, err := os.ReadFile(filepath.Join("testdata", "fix", "updated.yaml"))
 	testutil.CheckError(t, false, err)
 
 	parsed := make(map[string]interface{})

--- a/integration/generate_pipeline_test.go
+++ b/integration/generate_pipeline_test.go
@@ -18,7 +18,6 @@ package integration
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -78,9 +77,9 @@ func TestGeneratePipeline(t *testing.T) {
 			failNowIfError(t, err)
 			defer writeOriginalContents(contents)
 
-			originalConfig, err := ioutil.ReadFile(test.dir + "/skaffold.yaml")
+			originalConfig, err := os.ReadFile(test.dir + "/skaffold.yaml")
 			failNowIfError(t, err)
-			defer ioutil.WriteFile(test.dir+"/skaffold.yaml", originalConfig, 0755)
+			defer os.WriteFile(test.dir+"/skaffold.yaml", originalConfig, 0755)
 			defer os.Remove(test.dir + "/pipeline.yaml")
 
 			skaffoldEnv := []string{
@@ -104,7 +103,7 @@ func getOriginalContents(testArgs []string, testDir string, configFiles []string
 		testArgs = append(testArgs, []string{"--config-files", configFile}...)
 
 		path := testDir + "/" + configFile
-		contents, err := ioutil.ReadFile(path)
+		contents, err := os.ReadFile(path)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -116,15 +115,15 @@ func getOriginalContents(testArgs []string, testDir string, configFiles []string
 
 func writeOriginalContents(contents []configContents) {
 	for _, content := range contents {
-		ioutil.WriteFile(content.path, content.data, 0755)
+		os.WriteFile(content.path, content.data, 0755)
 	}
 }
 
 func checkFileContents(t *testing.T, wantFile, gotFile string) {
-	wantContents, err := ioutil.ReadFile(wantFile)
+	wantContents, err := os.ReadFile(wantFile)
 	failNowIfError(t, err)
 
-	gotContents, err := ioutil.ReadFile(gotFile)
+	gotContents, err := os.ReadFile(gotFile)
 	failNowIfError(t, err)
 
 	if !bytes.Equal(wantContents, gotContents) {

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -18,7 +18,6 @@ package integration
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -175,20 +174,20 @@ func TestInitWithCLIArtifactAndManifestGeneration(t *testing.T) {
 }
 
 func checkGeneratedConfig(t *testutil.T, dir string) {
-	expectedOutput, err := ioutil.ReadFile(filepath.Join(dir, "skaffold.yaml"))
+	expectedOutput, err := os.ReadFile(filepath.Join(dir, "skaffold.yaml"))
 	t.CheckNoError(err)
 
-	output, err := ioutil.ReadFile(filepath.Join(dir, "skaffold.yaml.out"))
+	output, err := os.ReadFile(filepath.Join(dir, "skaffold.yaml.out"))
 	t.CheckNoError(err)
 	t.CheckDeepEqual(string(expectedOutput), string(output))
 }
 
 func checkGeneratedManifests(t *testutil.T, dir string, manifestPaths []string) {
 	for _, path := range manifestPaths {
-		expectedOutput, err := ioutil.ReadFile(filepath.Join(dir, strings.Join([]string{".", path, ".expected"}, "")))
+		expectedOutput, err := os.ReadFile(filepath.Join(dir, strings.Join([]string{".", path, ".expected"}, "")))
 		t.CheckNoError(err)
 
-		output, err := ioutil.ReadFile(filepath.Join(dir, path))
+		output, err := os.ReadFile(filepath.Join(dir, path))
 		t.CheckNoError(err)
 		t.CheckDeepEqual(string(expectedOutput), string(output))
 	}

--- a/integration/inspect_test.go
+++ b/integration/inspect_test.go
@@ -18,7 +18,7 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -96,7 +96,7 @@ func TestInspectBuildEnv(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			tmpDir := t.NewTempDir()
-			configContents, err := ioutil.ReadFile(filepath.Join("testdata/inspect", test.inputConfigFile))
+			configContents, err := os.ReadFile(filepath.Join("testdata/inspect", test.inputConfigFile))
 			t.CheckNoError(err)
 			tmpDir.Write("skaffold.yaml", string(configContents))
 			args := append(test.args, fmt.Sprintf("-f=%s", tmpDir.Path("skaffold.yaml")))
@@ -105,9 +105,9 @@ func TestInspectBuildEnv(t *testing.T) {
 				t.CheckDeepEqual(test.expectedOut, string(out))
 			}
 			if test.expectedConfigFile != "" {
-				expectedConfig, err := ioutil.ReadFile(filepath.Join("testdata/inspect", test.expectedConfigFile))
+				expectedConfig, err := os.ReadFile(filepath.Join("testdata/inspect", test.expectedConfigFile))
 				t.CheckNoError(err)
-				actualConfig, err := ioutil.ReadFile(tmpDir.Path("skaffold.yaml"))
+				actualConfig, err := os.ReadFile(tmpDir.Path("skaffold.yaml"))
 				t.CheckNoError(err)
 				t.CheckDeepEqual(expectedConfig, actualConfig)
 			}

--- a/integration/ko_test.go
+++ b/integration/ko_test.go
@@ -19,7 +19,7 @@ package integration
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	stdlog "log"
 	"net/http/httptest"
 	"path/filepath"
@@ -78,7 +78,7 @@ func TestBuildAndPushKoImageProgrammatically(t *testing.T) {
 // The registry uses a NOP logger to avoid spamming test logs.
 // Remember to call `defer Close()` on the returned `httptest.Server`.
 func registryServerWithImage(namespace string) (*httptest.Server, error) {
-	nopLog := stdlog.New(ioutil.Discard, "", 0)
+	nopLog := stdlog.New(io.Discard, "", 0)
 	r := registry.New(registry.Logger(nopLog))
 	s := httptest.NewServer(r)
 	imageName := fmt.Sprintf("%s/%s", s.Listener.Addr().String(), namespace)

--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -19,13 +19,12 @@ package integration
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
 	"path"
 	"regexp"
 	"testing"
 
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 
 	"github.com/GoogleContainerTools/skaffold/integration/skaffold"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
@@ -682,7 +681,7 @@ spec:
 				skaffold.Render(args...).RunOrFail(t.T)
 			}
 
-			fileContent, err := ioutil.ReadFile("rendered.yaml")
+			fileContent, err := os.ReadFile("rendered.yaml")
 			t.RequireNoError(err)
 
 			// Tests are written in a way that actual output is valid YAML

--- a/integration/rpc_test.go
+++ b/integration/rpc_test.go
@@ -19,7 +19,7 @@ package integration
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net"
 	"net/http"
@@ -340,7 +340,7 @@ func retrieveHTTPState(t *testing.T, httpAddr string) *proto.State {
 	}
 	defer httpResponse.Body.Close()
 
-	b, err := ioutil.ReadAll(httpResponse.Body)
+	b, err := io.ReadAll(httpResponse.Body)
 	if err != nil {
 		t.Errorf("error reading body from http response: %s", err.Error())
 	}
@@ -393,7 +393,7 @@ func checkBuildAndDeployComplete(state *proto.State) bool {
 	return state.DeployState.Status == event.Complete
 }
 
-func apiEvents(t *testing.T, rpcAddr string) (proto.SkaffoldServiceClient, chan *proto.LogEntry) { //nolint
+func apiEvents(t *testing.T, rpcAddr string) (proto.SkaffoldServiceClient, chan *proto.LogEntry) { // nolint
 	client := setupRPCClient(t, rpcAddr)
 
 	stream, err := readEventAPIStream(client, t, readRetries)

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package integration
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -232,7 +231,7 @@ func TestRunRenderOnly(t *testing.T) {
 
 		skaffold.Run(test.args...).InDir(test.dir).RunOrFail(t)
 
-		dat, err := ioutil.ReadFile(renderPath)
+		dat, err := os.ReadFile(renderPath)
 		tu.CheckNoError(err)
 
 		tu.CheckMatches("name: getting-started", string(dat))
@@ -457,7 +456,7 @@ func TestRunTest(t *testing.T) {
 					}
 					return true, nil
 				}
-				out, e := ioutil.ReadFile(test.testFile)
+				out, e := os.ReadFile(test.testFile)
 				failNowIfError(t, e)
 				return string(out) == test.expectedText, nil
 			})

--- a/integration/sync_test.go
+++ b/integration/sync_test.go
@@ -19,7 +19,6 @@ package integration
 import (
 	"bufio"
 	"context"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -70,7 +69,7 @@ func TestDevSync(t *testing.T) {
 
 			client.WaitForPodsReady("test-file-sync")
 
-			ioutil.WriteFile("testdata/file-sync/foo", []byte("foo"), 0644)
+			os.WriteFile("testdata/file-sync/foo", []byte("foo"), 0644)
 			defer func() { os.Truncate("testdata/file-sync/foo", 0) }()
 
 			err := wait.PollImmediate(time.Millisecond*500, 1*time.Minute, func() (bool, error) {
@@ -97,7 +96,7 @@ func TestDevSyncDefaultNamespace(t *testing.T) {
 
 			client.WaitForPodsReady("test-file-sync")
 
-			ioutil.WriteFile("testdata/file-sync/foo", []byte("foo"), 0644)
+			os.WriteFile("testdata/file-sync/foo", []byte("foo"), 0644)
 			defer func() { os.Truncate("testdata/file-sync/foo", 0) }()
 
 			err := wait.PollImmediate(time.Millisecond*500, 1*time.Minute, func() (bool, error) {
@@ -161,7 +160,7 @@ func TestDevAutoSync(t *testing.T) {
 			directFile := "direct-file"
 			directFilePath := dir + "src/main/jib/" + directFile
 			directFileData := "direct-data"
-			if err := ioutil.WriteFile(directFilePath, []byte(directFileData), 0644); err != nil {
+			if err := os.WriteFile(directFilePath, []byte(directFileData), 0644); err != nil {
 				t.Fatalf("Failed to write local file to sync %s", directFilePath)
 			}
 			defer func() { os.Truncate(directFilePath, 0) }()
@@ -174,15 +173,15 @@ func TestDevAutoSync(t *testing.T) {
 
 			// compile and sync
 			generatedFileSrc := dir + "src/main/java/hello/HelloController.java"
-			if oldContents, err := ioutil.ReadFile(generatedFileSrc); err != nil {
+			if oldContents, err := os.ReadFile(generatedFileSrc); err != nil {
 				t.Fatalf("Failed to read file %s", generatedFileSrc)
 			} else {
 				newContents := strings.Replace(string(oldContents), "text-to-replace", test.uniqueStr, 1)
-				if err := ioutil.WriteFile(generatedFileSrc, []byte(newContents), 0644); err != nil {
+				if err := os.WriteFile(generatedFileSrc, []byte(newContents), 0644); err != nil {
 					t.Fatalf("Failed to write new contents to file %s", generatedFileSrc)
 				}
 				defer func() {
-					ioutil.WriteFile(generatedFileSrc, oldContents, 0644)
+					os.WriteFile(generatedFileSrc, oldContents, 0644)
 				}()
 			}
 			err = wait.PollImmediate(time.Millisecond*500, 1*time.Minute, func() (bool, error) {
@@ -214,7 +213,7 @@ func TestDevSyncAPITrigger(t *testing.T) {
 
 	client.WaitForPodsReady("test-file-sync")
 
-	ioutil.WriteFile("testdata/file-sync/foo", []byte("foo"), 0644)
+	os.WriteFile("testdata/file-sync/foo", []byte("foo"), 0644)
 	defer func() { os.Truncate("testdata/file-sync/foo", 0) }()
 
 	rpcClient.Execute(context.Background(), &proto.UserIntentRequest{
@@ -244,7 +243,7 @@ func TestDevAutoSyncAPITrigger(t *testing.T) {
 
 	client.WaitForPodsReady("test-file-sync")
 
-	ioutil.WriteFile("testdata/file-sync/foo", []byte("foo"), 0644)
+	os.WriteFile("testdata/file-sync/foo", []byte("foo"), 0644)
 	defer func() { os.Truncate("testdata/file-sync/foo", 0) }()
 
 	rpcClient.AutoSync(context.Background(), &proto.TriggerRequest{
@@ -257,7 +256,7 @@ func TestDevAutoSyncAPITrigger(t *testing.T) {
 
 	verifySyncCompletedWithEvents(t, entries, ns.Name, "foo")
 
-	ioutil.WriteFile("testdata/file-sync/foo", []byte("bar"), 0644)
+	os.WriteFile("testdata/file-sync/foo", []byte("bar"), 0644)
 	defer func() { os.Truncate("testdata/file-sync/foo", 0) }()
 
 	verifySyncCompletedWithEvents(t, entries, ns.Name, "bar")

--- a/integration/verify_test.go
+++ b/integration/verify_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package integration
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -45,7 +44,7 @@ func TestVerifyPassingTestsWithEnvVar(t *testing.T) {
 	testutil.CheckContains(t, "foo-var", logs)
 
 	// verify logs are in the event output as well
-	b, err := ioutil.ReadFile(logFile + ".v2")
+	b, err := os.ReadFile(logFile + ".v2")
 	if err != nil {
 		t.Fatalf("error reading %s", logFile+".v2")
 	}
@@ -73,7 +72,7 @@ func TestVerifyOneTestFailsWithEnvVar(t *testing.T) {
 	testutil.CheckContains(t, "foo-var", logs)
 
 	// verify logs are in the event output as well
-	b, err := ioutil.ReadFile(logFile + ".v2")
+	b, err := os.ReadFile(logFile + ".v2")
 	if err != nil {
 		t.Fatalf("error reading %s", logFile+".v2")
 	}

--- a/pkg/skaffold/build/bazel/build_test.go
+++ b/pkg/skaffold/build/bazel/build_test.go
@@ -18,7 +18,7 @@ package bazel
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
@@ -46,7 +46,7 @@ func TestBuildBazel(t *testing.T) {
 		}
 
 		builder := NewArtifactBuilder(fakeLocalDaemon(), &mockConfig{}, false)
-		_, err := builder.Build(context.Background(), ioutil.Discard, artifact, "img:tag", platform.Matcher{})
+		_, err := builder.Build(context.Background(), io.Discard, artifact, "img:tag", platform.Matcher{})
 
 		t.CheckNoError(err)
 	})
@@ -69,7 +69,7 @@ func TestBazelTarPathFRespectWorkspace(t *testing.T) {
 		}
 
 		builder := NewArtifactBuilder(fakeLocalDaemon(), &mockConfig{}, false)
-		_, err := builder.Build(context.Background(), ioutil.Discard, artifact, "img:tag", platform.Matcher{})
+		_, err := builder.Build(context.Background(), io.Discard, artifact, "img:tag", platform.Matcher{})
 
 		t.CheckNoError(err)
 	})
@@ -86,7 +86,7 @@ func TestBuildBazelFailInvalidTarget(t *testing.T) {
 		}
 
 		builder := NewArtifactBuilder(nil, &mockConfig{}, false)
-		_, err := builder.Build(context.Background(), ioutil.Discard, artifact, "img:tag", platform.Matcher{})
+		_, err := builder.Build(context.Background(), io.Discard, artifact, "img:tag", platform.Matcher{})
 
 		t.CheckErrorContains("the bazel build target should end with .tar", err)
 	})

--- a/pkg/skaffold/build/buildpacks/build_test.go
+++ b/pkg/skaffold/build/buildpacks/build_test.go
@@ -19,7 +19,6 @@ package buildpacks
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	pack "github.com/buildpacks/pack/pkg/client"
@@ -279,7 +278,7 @@ value = "VALUE2"
 			localDocker := fakeLocalDaemon(test.api)
 
 			builder := NewArtifactBuilder(localDocker, test.pushImages, test.mode, test.resolver)
-			_, err := builder.Build(context.Background(), ioutil.Discard, test.artifact, test.tag, platform.Matcher{})
+			_, err := builder.Build(context.Background(), io.Discard, test.artifact, test.tag, platform.Matcher{})
 
 			t.CheckError(test.shouldErr, err)
 			if test.expectedOptions != nil {
@@ -420,7 +419,7 @@ func TestBuildWithArtifactDependencies(t *testing.T) {
 			localDocker := fakeLocalDaemon(test.api)
 
 			builder := NewArtifactBuilder(localDocker, test.pushImages, test.mode, test.resolver)
-			_, err := builder.Build(context.Background(), ioutil.Discard, test.artifact, test.tag, platform.Matcher{})
+			_, err := builder.Build(context.Background(), io.Discard, test.artifact, test.tag, platform.Matcher{})
 
 			t.CheckError(test.shouldErr, err)
 			if test.expectedOptions != nil {

--- a/pkg/skaffold/build/cache/cache.go
+++ b/pkg/skaffold/build/cache/cache.go
@@ -19,7 +19,7 @@ package cache
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sync"
 
@@ -143,7 +143,7 @@ func resolveCacheFile(cacheFile string) (string, error) {
 
 func retrieveArtifactCache(cacheFile string) (ArtifactCache, error) {
 	cache := ArtifactCache{}
-	contents, err := ioutil.ReadFile(cacheFile)
+	contents, err := os.ReadFile(cacheFile)
 	if err != nil {
 		return nil, err
 	}
@@ -159,5 +159,5 @@ func saveArtifactCache(cacheFile string, contents ArtifactCache) error {
 		return err
 	}
 
-	return ioutil.WriteFile(cacheFile, data, 0755)
+	return os.WriteFile(cacheFile, data, 0755)
 }

--- a/pkg/skaffold/build/cache/lookup.go
+++ b/pkg/skaffold/build/cache/lookup.go
@@ -19,7 +19,7 @@ package cache
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"sync"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
@@ -142,7 +142,7 @@ func (c *cache) tryImport(ctx context.Context, a *latest.Artifact, tag string, h
 
 	if !c.client.ImageExists(ctx, tag) {
 		log.Entry(ctx).Debugf("Importing artifact %s from docker registry", tag)
-		err := c.client.Pull(ctx, ioutil.Discard, tag)
+		err := c.client.Pull(ctx, io.Discard, tag)
 		if err != nil {
 			return entry, err
 		}

--- a/pkg/skaffold/build/cache/retrieve_test.go
+++ b/pkg/skaffold/build/cache/retrieve_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"github.com/docker/docker/api/types"
@@ -149,7 +148,7 @@ func TestCacheBuildLocal(t *testing.T) {
 
 		// First build: Need to build both artifacts
 		builder := &mockBuilder{dockerDaemon: dockerDaemon, push: false, store: store}
-		bRes, err := artifactCache.Build(context.Background(), ioutil.Discard, tags, artifacts, platform.Resolver{}, builder.Build)
+		bRes, err := artifactCache.Build(context.Background(), io.Discard, tags, artifacts, platform.Resolver{}, builder.Build)
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual(2, len(builder.built))
@@ -158,7 +157,7 @@ func TestCacheBuildLocal(t *testing.T) {
 		// Second build: both artifacts are read from cache
 		// Artifacts should always be returned in their original order
 		builder = &mockBuilder{dockerDaemon: dockerDaemon, push: false, store: store}
-		bRes, err = artifactCache.Build(context.Background(), ioutil.Discard, tags, artifacts, platform.Resolver{}, builder.Build)
+		bRes, err = artifactCache.Build(context.Background(), io.Discard, tags, artifacts, platform.Resolver{}, builder.Build)
 
 		t.CheckNoError(err)
 		t.CheckEmpty(builder.built)
@@ -170,7 +169,7 @@ func TestCacheBuildLocal(t *testing.T) {
 		// Artifacts should always be returned in their original order
 		tmpDir.Write("dep1", "new content")
 		builder = &mockBuilder{dockerDaemon: dockerDaemon, push: false, store: store}
-		bRes, err = artifactCache.Build(context.Background(), ioutil.Discard, tags, artifacts, platform.Resolver{}, builder.Build)
+		bRes, err = artifactCache.Build(context.Background(), io.Discard, tags, artifacts, platform.Resolver{}, builder.Build)
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual(1, len(builder.built))
@@ -182,7 +181,7 @@ func TestCacheBuildLocal(t *testing.T) {
 		// Artifacts should always be returned in their original order
 		tmpDir.Write("dep3", "new content")
 		builder = &mockBuilder{dockerDaemon: dockerDaemon, push: false, store: store}
-		bRes, err = artifactCache.Build(context.Background(), ioutil.Discard, tags, artifacts, platform.Resolver{}, builder.Build)
+		bRes, err = artifactCache.Build(context.Background(), io.Discard, tags, artifacts, platform.Resolver{}, builder.Build)
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual(1, len(builder.built))
@@ -245,7 +244,7 @@ func TestCacheBuildRemote(t *testing.T) {
 
 		// First build: Need to build both artifacts
 		builder := &mockBuilder{dockerDaemon: dockerDaemon, push: true}
-		bRes, err := artifactCache.Build(context.Background(), ioutil.Discard, tags, artifacts, platform.Resolver{}, builder.Build)
+		bRes, err := artifactCache.Build(context.Background(), io.Discard, tags, artifacts, platform.Resolver{}, builder.Build)
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual(2, len(builder.built))
@@ -256,7 +255,7 @@ func TestCacheBuildRemote(t *testing.T) {
 
 		// Second build: both artifacts are read from cache
 		builder = &mockBuilder{dockerDaemon: dockerDaemon, push: true}
-		bRes, err = artifactCache.Build(context.Background(), ioutil.Discard, tags, artifacts, platform.Resolver{}, builder.Build)
+		bRes, err = artifactCache.Build(context.Background(), io.Discard, tags, artifacts, platform.Resolver{}, builder.Build)
 
 		t.CheckNoError(err)
 		t.CheckEmpty(builder.built)
@@ -267,7 +266,7 @@ func TestCacheBuildRemote(t *testing.T) {
 		// Third build: change one artifact's dependencies
 		tmpDir.Write("dep1", "new content")
 		builder = &mockBuilder{dockerDaemon: dockerDaemon, push: true}
-		bRes, err = artifactCache.Build(context.Background(), ioutil.Discard, tags, artifacts, platform.Resolver{}, builder.Build)
+		bRes, err = artifactCache.Build(context.Background(), io.Discard, tags, artifacts, platform.Resolver{}, builder.Build)
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual(1, len(builder.built))
@@ -330,7 +329,7 @@ func TestCacheFindMissing(t *testing.T) {
 
 		// Because the artifacts are in the docker registry, we expect them to be imported correctly.
 		builder := &mockBuilder{dockerDaemon: dockerDaemon, push: false, store: make(mockArtifactStore)}
-		bRes, err := artifactCache.Build(context.Background(), ioutil.Discard, tags, artifacts, platform.Resolver{}, builder.Build)
+		bRes, err := artifactCache.Build(context.Background(), io.Discard, tags, artifacts, platform.Resolver{}, builder.Build)
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual(0, len(builder.built))

--- a/pkg/skaffold/build/cluster/secret.go
+++ b/pkg/skaffold/build/cluster/secret.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -65,7 +65,7 @@ func (b *Builder) setupPullSecret(ctx context.Context, out io.Writer) (func(), e
 }
 
 func (b *Builder) createSecretFromFile(ctx context.Context, secrets typedV1.SecretInterface) (func(), error) {
-	secretData, err := ioutil.ReadFile(b.PullSecretPath)
+	secretData, err := os.ReadFile(b.PullSecretPath)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create secret %s from path %s. reading pull secret: %w", b.PullSecretName, b.PullSecretPath, err)
 	}
@@ -114,7 +114,7 @@ func (b *Builder) setupDockerConfigSecret(ctx context.Context, out io.Writer) (f
 		return func() {}, nil
 	}
 
-	secretData, err := ioutil.ReadFile(b.DockerConfig.Path)
+	secretData, err := os.ReadFile(b.DockerConfig.Path)
 	if err != nil {
 		return nil, fmt.Errorf("reading docker config: %w", err)
 	}

--- a/pkg/skaffold/build/cluster/secret_test.go
+++ b/pkg/skaffold/build/cluster/secret_test.go
@@ -18,7 +18,7 @@ package cluster
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -48,7 +48,7 @@ func TestCreateSecret(t *testing.T) {
 		t.CheckNoError(err)
 
 		// Should create a secret
-		cleanup, err := builder.setupPullSecret(context.Background(), ioutil.Discard)
+		cleanup, err := builder.setupPullSecret(context.Background(), io.Discard)
 		t.CheckNoError(err)
 
 		// Check that the secret was created
@@ -77,7 +77,7 @@ func TestExistingSecretNotFound(t *testing.T) {
 		t.CheckNoError(err)
 
 		// should fail to retrieve an existing secret
-		_, err = builder.setupPullSecret(context.Background(), ioutil.Discard)
+		_, err = builder.setupPullSecret(context.Background(), io.Discard)
 
 		t.CheckErrorContains("secret kaniko-secret does not exist. No path specified to create it", err)
 	})
@@ -100,7 +100,7 @@ func TestExistingSecret(t *testing.T) {
 		t.CheckNoError(err)
 
 		// should retrieve an existing secret
-		cleanup, err := builder.setupPullSecret(context.Background(), ioutil.Discard)
+		cleanup, err := builder.setupPullSecret(context.Background(), io.Discard)
 		cleanup()
 
 		t.CheckNoError(err)
@@ -119,7 +119,7 @@ func TestSkipSecretCreation(t *testing.T) {
 		t.CheckNoError(err)
 
 		// should retrieve an existing secret
-		cleanup, err := builder.setupPullSecret(context.Background(), ioutil.Discard)
+		cleanup, err := builder.setupPullSecret(context.Background(), io.Discard)
 		cleanup()
 
 		t.CheckNoError(err)

--- a/pkg/skaffold/build/custom/script_test.go
+++ b/pkg/skaffold/build/custom/script_test.go
@@ -18,7 +18,7 @@ package custom
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"os/exec"
 	"runtime"
 	"testing"
@@ -146,7 +146,7 @@ func TestRetrieveCmd(t *testing.T) {
 			t.Override(&buildContext, func(string) (string, error) { return test.artifact.Workspace, nil })
 
 			builder := NewArtifactBuilder(nil, nil, false, true, nil)
-			cmd, err := builder.retrieveCmd(context.Background(), ioutil.Discard, test.artifact, test.tag, platform.Matcher{})
+			cmd, err := builder.retrieveCmd(context.Background(), io.Discard, test.artifact, test.tag, platform.Matcher{})
 
 			t.CheckNoError(err)
 			if runtime.GOOS == "windows" {

--- a/pkg/skaffold/build/docker/docker_test.go
+++ b/pkg/skaffold/build/docker/docker_test.go
@@ -19,7 +19,7 @@ package docker
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -173,7 +173,7 @@ func TestDockerCLIBuild(t *testing.T) {
 				},
 			}
 
-			_, err := builder.Build(context.Background(), ioutil.Discard, artifact, "tag", platform.Matcher{})
+			_, err := builder.Build(context.Background(), io.Discard, artifact, "tag", platform.Matcher{})
 			t.CheckError(test.err != nil, err)
 			if mockCmd != nil {
 				t.CheckDeepEqual(1, mockCmd.TimesCalled())
@@ -243,7 +243,7 @@ func TestDockerCLICheckCacheFromArgs(t *testing.T) {
 			t.Override(&util.DefaultExecCommand, mockCmd)
 
 			builder := NewArtifactBuilder(fakeLocalDaemonWithExtraEnv([]string{}), mockConfig{}, true, util.BoolPtr(false), false, mockArtifactResolver{make(map[string]string)}, nil)
-			_, err := builder.Build(context.Background(), ioutil.Discard, &a, test.tag, platform.Matcher{})
+			_, err := builder.Build(context.Background(), io.Discard, &a, test.tag, platform.Matcher{})
 			t.CheckNoError(err)
 		})
 	}

--- a/pkg/skaffold/build/docker/errors_test.go
+++ b/pkg/skaffold/build/docker/errors_test.go
@@ -18,7 +18,7 @@ package docker
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"path/filepath"
 	"testing"
 
@@ -72,7 +72,7 @@ Refer https://skaffold.dev/docs/references/yaml/#build-artifacts-docker for deta
 				},
 			}
 
-			_, err := builder.Build(context.Background(), ioutil.Discard, artifact, "tag", platform.Matcher{})
+			_, err := builder.Build(context.Background(), io.Discard, artifact, "tag", platform.Matcher{})
 			t.CheckError(test.shouldErr, err)
 			if test.shouldErr {
 				t.CheckErrorContains("", err)

--- a/pkg/skaffold/build/jib/gradle_test.go
+++ b/pkg/skaffold/build/jib/gradle_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"runtime"
@@ -88,7 +88,7 @@ func TestBuildJibGradleToDocker(t *testing.T) {
 			localDocker := fakeLocalDaemon(api)
 
 			builder := NewArtifactBuilder(localDocker, &mockConfig{}, false, false, nil)
-			result, err := builder.Build(context.Background(), ioutil.Discard, &latest.Artifact{
+			result, err := builder.Build(context.Background(), io.Discard, &latest.Artifact{
 				ArtifactType: latest.ArtifactType{
 					JibArtifact: test.artifact,
 				},
@@ -159,7 +159,7 @@ func TestBuildJibGradleToRegistry(t *testing.T) {
 			localDocker := fakeLocalDaemon(&testutil.FakeAPIClient{})
 
 			builder := NewArtifactBuilder(localDocker, &mockConfig{}, true, false, nil)
-			result, err := builder.Build(context.Background(), ioutil.Discard, &latest.Artifact{
+			result, err := builder.Build(context.Background(), io.Discard, &latest.Artifact{
 				ArtifactType: latest.ArtifactType{
 					JibArtifact: test.artifact,
 				},

--- a/pkg/skaffold/build/jib/init.go
+++ b/pkg/skaffold/build/jib/init.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -113,7 +113,7 @@ func validate(ctx context.Context, path string, enableGradleAnalysis bool) []Art
 	}
 
 	// Search for indication of Jib in build file before proceeding
-	if content, err := ioutil.ReadFile(path); err != nil || !strings.Contains(string(content), searchString) {
+	if content, err := os.ReadFile(path); err != nil || !strings.Contains(string(content), searchString) {
 		return nil
 	}
 

--- a/pkg/skaffold/build/jib/maven_test.go
+++ b/pkg/skaffold/build/jib/maven_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"runtime"
@@ -88,7 +88,7 @@ func TestBuildJibMavenToDocker(t *testing.T) {
 			localDocker := fakeLocalDaemon(api)
 
 			builder := NewArtifactBuilder(localDocker, &mockConfig{}, false, false, mockArtifactResolver{})
-			result, err := builder.Build(context.Background(), ioutil.Discard, &latest.Artifact{
+			result, err := builder.Build(context.Background(), io.Discard, &latest.Artifact{
 				ArtifactType: latest.ArtifactType{
 					JibArtifact: test.artifact,
 				},
@@ -153,7 +153,7 @@ func TestBuildJibMavenToRegistry(t *testing.T) {
 			localDocker := fakeLocalDaemon(&testutil.FakeAPIClient{})
 
 			builder := NewArtifactBuilder(localDocker, &mockConfig{}, true, false, mockArtifactResolver{})
-			result, err := builder.Build(context.Background(), ioutil.Discard, &latest.Artifact{
+			result, err := builder.Build(context.Background(), io.Discard, &latest.Artifact{
 				ArtifactType: latest.ArtifactType{
 					JibArtifact: test.artifact,
 				},

--- a/pkg/skaffold/build/local/local_test.go
+++ b/pkg/skaffold/build/local/local_test.go
@@ -19,7 +19,7 @@ package local
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/docker/docker/api/types"
@@ -244,8 +244,8 @@ func TestLocalRun(t *testing.T) {
 				Concurrency: &constants.DefaultLocalConcurrency,
 			})
 			t.CheckNoError(err)
-			ab := builder.Build(context.Background(), ioutil.Discard, test.artifact)
-			res, err := ab(context.Background(), ioutil.Discard, test.artifact, test.tag, platform.Matcher{})
+			ab := builder.Build(context.Background(), io.Discard, test.artifact)
+			res, err := ab(context.Background(), io.Discard, test.artifact, test.tag, platform.Matcher{})
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, res)
 			t.CheckDeepEqual(test.expectedWarnings, fakeWarner.Warnings)
 			t.CheckDeepEqual(test.expectedPushed, test.api.Pushed())

--- a/pkg/skaffold/build/scheduler_test.go
+++ b/pkg/skaffold/build/scheduler_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -252,7 +251,7 @@ func TestInOrderConcurrency(t *testing.T) {
 			}
 
 			initializeEvents()
-			results, err := InOrder(context.Background(), ioutil.Discard, tags, platform.Resolver{}, artifacts, builder, test.limit, NewArtifactStore())
+			results, err := InOrder(context.Background(), io.Discard, tags, platform.Resolver{}, artifacts, builder, test.limit, NewArtifactStore())
 
 			t.CheckNoError(err)
 			t.CheckDeepEqual(test.artifacts, len(results))
@@ -375,7 +374,7 @@ func TestInOrderForArgs(t *testing.T) {
 
 			setDependencies(artifacts, test.dependency)
 			initializeEvents()
-			actual, err := InOrder(context.Background(), ioutil.Discard, tags, platform.Resolver{}, artifacts, test.buildArtifact, test.concurrency, NewArtifactStore())
+			actual, err := InOrder(context.Background(), io.Discard, tags, platform.Resolver{}, artifacts, test.buildArtifact, test.concurrency, NewArtifactStore())
 
 			t.CheckDeepEqual(test.expected, actual)
 			t.CheckDeepEqual(test.err, err, cmp.Comparer(errorsComparer))
@@ -388,7 +387,7 @@ func TestInOrderForArgs(t *testing.T) {
 // m = {
 //    0 : {1, 2},
 //    2 : {3},
-//}
+// }
 // implies that a[0] artifact depends on a[1] and a[2]; and a[2] depends on a[3].
 func setDependencies(a []*latest.Artifact, d map[int][]int) {
 	for k, dep := range d {

--- a/pkg/skaffold/config/util.go
+++ b/pkg/skaffold/config/util.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -105,7 +105,7 @@ func ResolveConfigFile(configFile string) (string, error) {
 // ReadConfigFileNoCache reads the given config yaml file and unmarshals the contents.
 // Only visible for testing, use ReadConfigFile instead.
 func ReadConfigFileNoCache(configFile string) (*GlobalConfig, error) {
-	contents, err := ioutil.ReadFile(configFile)
+	contents, err := os.ReadFile(configFile)
 	if err != nil {
 		log.Entry(context.TODO()).Warnf("Could not load global Skaffold defaults. Error encounter while reading file %q", configFile)
 		return nil, fmt.Errorf("reading global config: %w", err)
@@ -514,7 +514,7 @@ func WriteFullConfig(configFile string, cfg *GlobalConfig) error {
 	if err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(configFileOrDefault, contents, 0644); err != nil {
+	if err := os.WriteFile(configFileOrDefault, contents, 0644); err != nil {
 		return fmt.Errorf("writing config file: %w", err)
 	}
 	return nil

--- a/pkg/skaffold/deploy/helm/helm.go
+++ b/pkg/skaffold/deploy/helm/helm.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -30,7 +29,7 @@ import (
 	"time"
 
 	"github.com/blang/semver"
-	backoff "github.com/cenkalti/backoff/v4"
+	"github.com/cenkalti/backoff/v4"
 	apimachinery "k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/access"
@@ -442,7 +441,7 @@ func (h *Deployer) deployRelease(ctx context.Context, out io.Writer, releaseName
 		return nil, nil, err
 	}
 
-	if err := helm.Exec(ctx, h, ioutil.Discard, false, nil, helm.GetArgs(releaseName, opts.namespace)...); err != nil {
+	if err := helm.Exec(ctx, h, io.Discard, false, nil, helm.GetArgs(releaseName, opts.namespace)...); err != nil {
 		output.Yellow.Fprintf(out, "Helm release %s not installed. Installing...\n", releaseName)
 
 		opts.upgrade = false
@@ -473,7 +472,7 @@ func (h *Deployer) deployRelease(ctx context.Context, out io.Writer, releaseName
 			return nil, nil, helm.UserErr("cannot marshal overrides to create overrides values.yaml", err)
 		}
 
-		if err := ioutil.WriteFile(constants.HelmOverridesFilename, overrides, 0666); err != nil {
+		if err := os.WriteFile(constants.HelmOverridesFilename, overrides, 0666); err != nil {
 			return nil, nil, helm.UserErr(fmt.Sprintf("cannot create file %q", constants.HelmOverridesFilename), err)
 		}
 
@@ -540,7 +539,7 @@ func (h *Deployer) packageChart(ctx context.Context, r latest.HelmRelease) (stri
 	tmpDir := h.pkgTmpDir
 
 	if tmpDir == "" {
-		t, err := ioutil.TempDir("", "skaffold-helm")
+		t, err := os.MkdirTemp("", "skaffold-helm")
 		if err != nil {
 			return "", fmt.Errorf("tempdir: %w", err)
 		}

--- a/pkg/skaffold/deploy/helm/helm_test.go
+++ b/pkg/skaffold/deploy/helm/helm_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -376,7 +376,7 @@ func TestNewDeployer(t *testing.T) {
 }
 
 func TestHelmDeploy(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "TestHelmDeploy")
+	tmpDir, err := os.MkdirTemp("", "TestHelmDeploy")
 	if err != nil {
 		t.Fatalf("tempdir: %v", err)
 	}
@@ -945,7 +945,7 @@ func TestHelmDeploy(t *testing.T) {
 			}
 			deployer.pkgTmpDir = tmpDir
 			// Deploy returns nil unless `helm get all <release>` is set up to return actual release info
-			err = deployer.Deploy(context.Background(), ioutil.Discard, test.builds, nil)
+			err = deployer.Deploy(context.Background(), io.Discard, test.builds, nil)
 			t.CheckError(test.shouldErr, err)
 			t.CheckDeepEqual(test.expectedWarnings, fakeWarner.Warnings)
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expectedNamespaces, *deployer.namespaces)
@@ -1027,7 +1027,7 @@ func TestHelmCleanup(t *testing.T) {
 			}, &label.DefaultLabeller{}, &test.helm, nil)
 			t.RequireNoError(err)
 
-			deployer.Cleanup(context.Background(), ioutil.Discard, test.dryRun, nil)
+			deployer.Cleanup(context.Background(), io.Discard, test.dryRun, nil)
 
 			t.CheckDeepEqual(test.expectedWarnings, fakeWarner.Warnings)
 		})
@@ -1361,7 +1361,7 @@ func TestHelmRender(t *testing.T) {
 				Generate: latest.Generate{Helm: &latest.Helm{Flags: test.helm.Flags, Releases: test.helm.Releases}},
 			}, labels)
 			t.RequireNoError(err)
-			_, err = helmRenderer.Render(context.Background(), ioutil.Discard, test.builds, true)
+			_, err = helmRenderer.Render(context.Background(), io.Discard, test.builds, true)
 			t.CheckError(test.shouldErr, err)
 		})
 	}
@@ -1406,9 +1406,9 @@ func TestHelmHooks(t *testing.T) {
 
 			k, err := NewDeployer(context.Background(), &helmConfig{}, &label.DefaultLabeller{}, &testDeployConfig, nil)
 			t.RequireNoError(err)
-			err = k.PreDeployHooks(context.Background(), ioutil.Discard)
+			err = k.PreDeployHooks(context.Background(), io.Discard)
 			t.CheckError(test.shouldErr, err)
-			err = k.PostDeployHooks(context.Background(), ioutil.Discard)
+			err = k.PostDeployHooks(context.Background(), io.Discard)
 			t.CheckError(test.shouldErr, err)
 		})
 	}

--- a/pkg/skaffold/deploy/kpt/kpt.go
+++ b/pkg/skaffold/deploy/kpt/kpt.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -293,7 +292,7 @@ func kptfileInitIfNot(ctx context.Context, out io.Writer, k *Deployer) error {
 		if err != nil {
 			return err
 		}
-		if err = ioutil.WriteFile(kptFilePath, configByte, 0644); err != nil {
+		if err = os.WriteFile(kptFilePath, configByte, 0644); err != nil {
 			return err
 		}
 	}

--- a/pkg/skaffold/deploy/kpt/kpt_test.go
+++ b/pkg/skaffold/deploy/kpt/kpt_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -144,7 +143,7 @@ func TestKptfileInitIfNot(t *testing.T) {
 
 			k, _ := NewDeployer(&kptConfig{}, &label.DefaultLabeller{}, &latest.KptDeploy{Dir: "."},
 				config.SkaffoldOptions{})
-			err := kptfileInitIfNot(context.Background(), ioutil.Discard, k)
+			err := kptfileInitIfNot(context.Background(), io.Discard, k)
 			if !test.shouldErr {
 				t.CheckNoError(err)
 			} else {
@@ -176,7 +175,7 @@ func TestDeploy(t *testing.T) {
 
 			k, err := NewDeployer(&kptConfig{}, &label.DefaultLabeller{}, &test.kpt, config.SkaffoldOptions{})
 			t.CheckNoError(err)
-			err = k.Deploy(context.Background(), ioutil.Discard, test.builds, nil)
+			err = k.Deploy(context.Background(), io.Discard, test.builds, nil)
 			t.CheckNoError(err)
 			fmt.Fprintf(os.Stdout, "deployer namespaces: %+v\n", *k.namespaces)
 			t.CheckDeepEqual(*k.namespaces, []string{"test-kptv2"})

--- a/pkg/skaffold/deploy/kubectl/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -367,7 +366,7 @@ func (k *Deployer) readManifests(ctx context.Context, offline bool) (manifest.Ma
 func createManifestList(manifests []string) (manifest.ManifestList, error) {
 	var manifestList manifest.ManifestList
 	for _, manifestFilePath := range manifests {
-		manifestFileContent, err := ioutil.ReadFile(manifestFilePath)
+		manifestFileContent, err := os.ReadFile(manifestFilePath)
 		if err != nil {
 			return nil, readManifestErr(fmt.Errorf("reading manifest file %v: %w", manifestFilePath, err))
 		}

--- a/pkg/skaffold/deploy/kubectl/kubectl_test.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl_test.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -237,7 +237,7 @@ func TestKubectlV1RenderDeploy(t *testing.T) {
 			m, errR := r.Render(context.Background(), &b, []graph.Artifact{{ImageName: "leeroy-web", Tag: "leeroy-web:v1"}},
 				true)
 			t.CheckNoError(errR)
-			err = k.Deploy(context.Background(), ioutil.Discard, test.builds, m)
+			err = k.Deploy(context.Background(), io.Discard, test.builds, m)
 
 			t.CheckError(test.shouldErr, err)
 		})
@@ -329,7 +329,7 @@ func TestKubectlCleanup(t *testing.T) {
 				true)
 			t.CheckNoError(errR)
 
-			err = k.Cleanup(context.Background(), ioutil.Discard, test.dryRun, m)
+			err = k.Cleanup(context.Background(), io.Discard, test.dryRun, m)
 
 			t.CheckError(test.shouldErr, err)
 		})
@@ -375,7 +375,7 @@ func TestKubectlDeployerRemoteCleanup(t *testing.T) {
 			}, &label.DefaultLabeller{}, &test.kubectl)
 			t.RequireNoError(err)
 
-			err = k.Cleanup(context.Background(), ioutil.Discard, false, nil)
+			err = k.Cleanup(context.Background(), io.Discard, false, nil)
 
 			t.CheckNoError(err)
 		})
@@ -408,7 +408,7 @@ func TestKubectlRedeploy(t *testing.T) {
 		m, err := manifest.Load(bytes.NewReader([]byte(DeploymentAppYAMLv1)))
 		m.Append([]byte(DeploymentWebYAMLv1))
 		t.CheckNoError(err)
-		err = deployer.Deploy(context.Background(), ioutil.Discard, []graph.Artifact{
+		err = deployer.Deploy(context.Background(), io.Discard, []graph.Artifact{
 			{ImageName: "leeroy-web", Tag: "leeroy-web:v1"},
 			{ImageName: "leeroy-app", Tag: "leeroy-app:v1"},
 		}, m)
@@ -417,14 +417,14 @@ func TestKubectlRedeploy(t *testing.T) {
 		// Deploy one manifest since only one image is updated
 		m, err = manifest.Load(bytes.NewReader([]byte(DeploymentAppYAMLv2)))
 		t.CheckNoError(err)
-		err = deployer.Deploy(context.Background(), ioutil.Discard, []graph.Artifact{
+		err = deployer.Deploy(context.Background(), io.Discard, []graph.Artifact{
 			{ImageName: "leeroy-web", Tag: "leeroy-web:v1"},
 			{ImageName: "leeroy-app", Tag: "leeroy-app:v2"},
 		}, m)
 		t.CheckNoError(err)
 
 		// Deploy zero manifest since no image is updated
-		err = deployer.Deploy(context.Background(), ioutil.Discard, []graph.Artifact{
+		err = deployer.Deploy(context.Background(), io.Discard, []graph.Artifact{
 			{ImageName: "leeroy-web", Tag: "leeroy-web:v1"},
 			{ImageName: "leeroy-app", Tag: "leeroy-app:v2"},
 		}, nil)
@@ -512,7 +512,7 @@ func TestKubectlWaitForDeletionsFails(t *testing.T) {
 
 		m, err := manifest.Load(bytes.NewReader([]byte(DeploymentWebYAMLv1)))
 		t.CheckNoError(err)
-		err = deployer.Deploy(context.Background(), ioutil.Discard, []graph.Artifact{
+		err = deployer.Deploy(context.Background(), io.Discard, []graph.Artifact{
 			{ImageName: "leeroy-web", Tag: "leeroy-web:v1"},
 		}, m)
 
@@ -605,7 +605,7 @@ func TestGCSManifests(t *testing.T) {
 			if err := os.MkdirAll(manifest.ManifestTmpDir, os.ModePerm); err != nil {
 				t.Fatal(err)
 			}
-			if err := ioutil.WriteFile(manifest.ManifestTmpDir+"/deployment.yaml", []byte(DeploymentWebYAML), os.ModePerm); err != nil {
+			if err := os.WriteFile(manifest.ManifestTmpDir+"/deployment.yaml", []byte(DeploymentWebYAML), os.ModePerm); err != nil {
 				t.Fatal(err)
 			}
 			rc := latest.RenderConfig{Generate: test.generate}
@@ -629,7 +629,7 @@ func TestGCSManifests(t *testing.T) {
 			}, &label.DefaultLabeller{}, &latest.KubectlDeploy{})
 			t.RequireNoError(err)
 
-			err = k.Deploy(context.Background(), ioutil.Discard, nil, m)
+			err = k.Deploy(context.Background(), io.Discard, nil, m)
 
 			t.CheckError(test.shouldErr, err)
 		})

--- a/pkg/skaffold/deploy/kustomize/kustomize_test.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 	"time"
@@ -215,7 +214,7 @@ func TestKustomizeDeploy(t *testing.T) {
 					Namespace: skaffoldNamespaceOption,
 				}}}, &label.DefaultLabeller{}, &test.kustomize)
 			t.RequireNoError(err)
-			err = k.Deploy(context.Background(), ioutil.Discard, test.builds, nil)
+			err = k.Deploy(context.Background(), io.Discard, test.builds, nil)
 
 			t.CheckError(test.shouldErr, err)
 		})
@@ -292,7 +291,7 @@ func TestKustomizeCleanup(t *testing.T) {
 					Namespace: kubectl.TestNamespace}},
 			}, &label.DefaultLabeller{}, &test.kustomize)
 			t.RequireNoError(err)
-			err = k.Cleanup(context.Background(), ioutil.Discard, test.dryRun, nil)
+			err = k.Cleanup(context.Background(), io.Discard, test.dryRun, nil)
 
 			t.CheckError(test.shouldErr, err)
 		})
@@ -342,9 +341,9 @@ func TestKustomizeHooks(t *testing.T) {
 					Namespace: kubectl.TestNamespace}},
 			}, &label.DefaultLabeller{}, &latest.KustomizeDeploy{})
 			t.RequireNoError(err)
-			err = k.PreDeployHooks(context.Background(), ioutil.Discard)
+			err = k.PreDeployHooks(context.Background(), io.Discard)
 			t.CheckError(test.shouldErr, err)
-			err = k.PostDeployHooks(context.Background(), ioutil.Discard)
+			err = k.PostDeployHooks(context.Background(), io.Discard)
 			t.CheckError(test.shouldErr, err)
 		})
 	}

--- a/pkg/skaffold/deploy/kustomize/util.go
+++ b/pkg/skaffold/deploy/kustomize/util.go
@@ -18,7 +18,7 @@ package kustomize
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -39,7 +39,7 @@ func DependenciesForKustomization(dir string) ([]string, error) {
 		return deps, nil
 	}
 
-	buf, err := ioutil.ReadFile(path)
+	buf, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/skaffold/diagnose/diagnose.go
+++ b/pkg/skaffold/diagnose/diagnose.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"time"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
@@ -155,5 +154,5 @@ func sizeOfDockerContext(ctx context.Context, a *latest.Artifact, cfg docker.Con
 		buildCtxWriter.Close()
 	}()
 
-	return io.Copy(ioutil.Discard, buildCtx)
+	return io.Copy(io.Discard, buildCtx)
 }

--- a/pkg/skaffold/diagnose/diagnose_test.go
+++ b/pkg/skaffold/diagnose/diagnose_test.go
@@ -18,7 +18,7 @@ package diagnose
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v2"
@@ -90,7 +90,7 @@ func TestCheckArtifacts(t *testing.T) {
 					},
 				},
 			}},
-		}, ioutil.Discard)
+		}, io.Discard)
 
 		t.CheckNoError(err)
 	})

--- a/pkg/skaffold/docker/image_test.go
+++ b/pkg/skaffold/docker/image_test.go
@@ -18,7 +18,7 @@ package docker
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -70,7 +70,7 @@ func TestPush(t *testing.T) {
 			t.Override(&DefaultAuthHelper, testAuthHelper{})
 
 			localDocker := NewLocalDaemon(test.api, nil, false, nil)
-			digest, err := localDocker.Push(context.Background(), ioutil.Discard, test.imageName)
+			digest, err := localDocker.Push(context.Background(), io.Discard, test.imageName)
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expectedDigest, digest)
 		})
@@ -85,14 +85,14 @@ func TestDoNotPushAlreadyPushed(t *testing.T) {
 		api.Add("image", "sha256:imageIDabcab")
 		localDocker := NewLocalDaemon(api, nil, false, nil)
 
-		digest, err := localDocker.Push(context.Background(), ioutil.Discard, "image")
+		digest, err := localDocker.Push(context.Background(), io.Discard, "image")
 		t.CheckNoError(err)
 		t.CheckDeepEqual("sha256:bb1f952848763dd1f8fcf14231d7a4557775abf3c95e588561bc7a478c94e7e0", digest)
 
 		// Images already pushed don't need being pushed.
 		api.ErrImagePush = true
 
-		digest, err = localDocker.Push(context.Background(), ioutil.Discard, "image")
+		digest, err = localDocker.Push(context.Background(), io.Discard, "image")
 		t.CheckNoError(err)
 		t.CheckDeepEqual("sha256:bb1f952848763dd1f8fcf14231d7a4557775abf3c95e588561bc7a478c94e7e0", digest)
 	})
@@ -202,7 +202,7 @@ func TestBuild(t *testing.T) {
 
 			localDocker := NewLocalDaemon(test.api, nil, false, nil)
 			opts := BuildOptions{Tag: "finalimage", Mode: test.mode}
-			_, err := localDocker.Build(context.Background(), ioutil.Discard, test.workspace, "final-image", test.artifact, opts)
+			_, err := localDocker.Build(context.Background(), io.Discard, test.workspace, "final-image", test.artifact, opts)
 
 			if test.shouldErr {
 				t.CheckErrorContains(test.expectedError, err)

--- a/pkg/skaffold/docker/logger/log_test.go
+++ b/pkg/skaffold/docker/logger/log_test.go
@@ -18,7 +18,7 @@ package logger
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"testing"
 )
 
@@ -26,7 +26,7 @@ func TestDockerLoggerZeroValue(t *testing.T) {
 	var m *Logger
 
 	// Should not raise a nil dereference
-	m.Start(context.Background(), ioutil.Discard)
+	m.Start(context.Background(), io.Discard)
 	m.Mute()
 	m.Unmute()
 	m.Stop()

--- a/pkg/skaffold/docker/parse.go
+++ b/pkg/skaffold/docker/parse.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -86,7 +85,7 @@ var (
 // ReadCopyCmdsFromDockerfile parses a given dockerfile for COPY commands accounting for build args, env vars, globs, etc
 // and returns an array of FromTos specifying the files that will be copied 'from' local dirs 'to' container dirs in the COPY statements
 func ReadCopyCmdsFromDockerfile(ctx context.Context, onlyLastImage bool, absDockerfilePath, workspace string, buildArgs map[string]*string, cfg Config) ([]FromTo, error) {
-	r, err := ioutil.ReadFile(absDockerfilePath)
+	r, err := os.ReadFile(absDockerfilePath)
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +119,7 @@ func ReadCopyCmdsFromDockerfile(ctx context.Context, onlyLastImage bool, absDock
 }
 
 func ExtractOnlyCopyCommands(absDockerfilePath string) ([]FromTo, error) {
-	r, err := ioutil.ReadFile(absDockerfilePath)
+	r, err := os.ReadFile(absDockerfilePath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/skaffold/event/event_test.go
+++ b/pkg/skaffold/event/event_test.go
@@ -19,7 +19,6 @@ package event
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"sync/atomic"
@@ -625,7 +624,7 @@ func TestDevLoopFailedInPhase(t *testing.T) {
 }
 
 func TestSaveEventsToFile(t *testing.T) {
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("getting temp file: %v", err)
 	}
@@ -649,7 +648,7 @@ func TestSaveEventsToFile(t *testing.T) {
 	}
 
 	// ensure that the events in the file match the event log
-	contents, err := ioutil.ReadFile(f.Name())
+	contents, err := os.ReadFile(f.Name())
 	if err != nil {
 		t.Fatalf("reading tmp file: %v", err)
 	}

--- a/pkg/skaffold/event/v2/event_test.go
+++ b/pkg/skaffold/event/v2/event_test.go
@@ -18,7 +18,6 @@ package v2
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -96,7 +95,7 @@ func wait(t *testing.T, condition func() bool) {
 }
 
 func TestSaveEventsToFile(t *testing.T) {
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("getting temp file: %v", err)
 	}
@@ -120,7 +119,7 @@ func TestSaveEventsToFile(t *testing.T) {
 	}
 
 	// ensure that the events in the file match the event log
-	contents, err := ioutil.ReadFile(f.Name())
+	contents, err := os.ReadFile(f.Name())
 	if err != nil {
 		t.Fatalf("reading tmp file: %v", err)
 	}
@@ -160,7 +159,7 @@ func TestSaveEventsToFile(t *testing.T) {
 }
 
 func TestSaveLastLog(t *testing.T) {
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("getting temp file: %v", err)
 	}
@@ -194,7 +193,7 @@ func TestSaveLastLog(t *testing.T) {
 	}
 
 	// ensure that the events in the file match the event log
-	b, err := ioutil.ReadFile(f.Name())
+	b, err := os.ReadFile(f.Name())
 	if err != nil {
 		t.Fatalf("reading tmp file: %v", err)
 	}

--- a/pkg/skaffold/generate_pipeline/profile.go
+++ b/pkg/skaffold/generate_pipeline/profile.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -72,7 +71,7 @@ confirmLoop:
 		return fmt.Errorf("marshaling new profile: %w", err)
 	}
 
-	fileContents, err := ioutil.ReadFile(configFile.Path)
+	fileContents, err := os.ReadFile(configFile.Path)
 	if err != nil {
 		return fmt.Errorf("reading file contents: %w", err)
 	}
@@ -97,7 +96,7 @@ confirmLoop:
 
 	fileContents = []byte((strings.Join(fileStrings, "\n")))
 
-	if err := ioutil.WriteFile(configFile.Path, fileContents, 0644); err != nil {
+	if err := os.WriteFile(configFile.Path, fileContents, 0644); err != nil {
 		return fmt.Errorf("writing profile to skaffold config: %w", err)
 	}
 

--- a/pkg/skaffold/generate_pipeline/profile_test.go
+++ b/pkg/skaffold/generate_pipeline/profile_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package generatepipeline
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -167,7 +167,7 @@ func TestGenerateProfile(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			profile, err := generateProfile(ioutil.Discard, test.namespace, test.skaffoldConfig)
+			profile, err := generateProfile(io.Discard, test.namespace, test.skaffoldConfig)
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expectedProfile, profile)
 		})
 	}

--- a/pkg/skaffold/helm/util.go
+++ b/pkg/skaffold/helm/util.go
@@ -19,7 +19,6 @@ package helm
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
@@ -38,7 +37,7 @@ func writeBuildArtifacts(builds []graph.Artifact) (string, func(), error) {
 		return "", nil, fmt.Errorf("cannot marshal build artifacts: %w", err)
 	}
 
-	f, err := ioutil.TempFile("", "builds*.yaml")
+	f, err := os.CreateTemp("", "builds*.yaml")
 	if err != nil {
 		return "", nil, fmt.Errorf("cannot create temp file: %w", err)
 	}

--- a/pkg/skaffold/helm/util_test.go
+++ b/pkg/skaffold/helm/util_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package helm
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
@@ -50,7 +50,7 @@ func TestWriteBuildArtifacts(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			file, cleanup, err := WriteBuildArtifacts(test.builds)
 			t.CheckError(false, err)
-			if content, err := ioutil.ReadFile(file); err != nil {
+			if content, err := os.ReadFile(file); err != nil {
 				t.Errorf("error reading file %q: %v", file, err)
 			} else {
 				t.CheckDeepEqual(test.result, string(content))

--- a/pkg/skaffold/initializer/deploy/helm.go
+++ b/pkg/skaffold/initializer/deploy/helm.go
@@ -18,7 +18,6 @@ package deploy
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -35,7 +34,7 @@ const (
 
 // for testing
 var (
-	readFile = ioutil.ReadFile
+	readFile = os.ReadFile
 )
 
 // helm implements deploymentInitializer for the helm deployer.

--- a/pkg/skaffold/initializer/init.go
+++ b/pkg/skaffold/initializer/init.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/tips"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/analyze"
@@ -128,13 +128,13 @@ func WriteData(out io.Writer, c config.Config, newConfig *latest.SkaffoldConfig,
 	}
 
 	for path, manifest := range newManifests {
-		if err = ioutil.WriteFile(path, manifest, 0644); err != nil {
+		if err = os.WriteFile(path, manifest, 0644); err != nil {
 			return fmt.Errorf("writing k8s manifest to file: %w", err)
 		}
 		fmt.Fprintf(out, "Generated manifest %s was written\n", path)
 	}
 
-	if err = ioutil.WriteFile(c.Opts.ConfigurationFile, pipeline, 0644); err != nil {
+	if err = os.WriteFile(c.Opts.ConfigurationFile, pipeline, 0644); err != nil {
 		return fmt.Errorf("writing config to file: %w", err)
 	}
 

--- a/pkg/skaffold/initializer/prompt/prompt_test.go
+++ b/pkg/skaffold/initializer/prompt/prompt_test.go
@@ -19,7 +19,7 @@ package prompt
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -70,7 +70,7 @@ func TestWriteSkaffoldConfig(t *testing.T) {
 				return nil
 			})
 
-			done, err := WriteSkaffoldConfig(ioutil.Discard, []byte{}, nil, "")
+			done, err := WriteSkaffoldConfig(io.Discard, []byte{}, nil, "")
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expectedDone, done)
 		})
 	}
@@ -166,7 +166,7 @@ func TestPortForwardResource(t *testing.T) {
 				return nil
 			})
 
-			port, err := portForwardResource(ioutil.Discard, "image-name")
+			port, err := portForwardResource(io.Discard, "image-name")
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, port)
 		})
 	}
@@ -214,7 +214,7 @@ func TestConfirmInitOptions(t *testing.T) {
 				return nil
 			})
 
-			done, err := ConfirmInitOptions(ioutil.Discard, test.config)
+			done, err := ConfirmInitOptions(io.Discard, test.config)
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expectedDone, done)
 		})
 	}

--- a/pkg/skaffold/initializer/render/helm.go
+++ b/pkg/skaffold/initializer/render/helm.go
@@ -18,7 +18,6 @@ package render
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -38,8 +37,8 @@ const (
 
 // for testing
 var (
-	readFile    = ioutil.ReadFile
-	tempDir     = ioutil.TempDir
+	readFile    = os.ReadFile
+	tempDir     = os.MkdirTemp
 	osRemoveAll = os.RemoveAll
 )
 

--- a/pkg/skaffold/inspect/helper.go
+++ b/pkg/skaffold/inspect/helper.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 
 	yamlv3 "gopkg.in/yaml.v3"
 
@@ -33,7 +33,7 @@ import (
 var (
 	ReadFileFunc  = util.ReadConfiguration
 	WriteFileFunc = func(filename string, data []byte) error {
-		return ioutil.WriteFile(filename, data, 0644)
+		return os.WriteFile(filename, data, 0644)
 	}
 )
 

--- a/pkg/skaffold/instrumentation/export.go
+++ b/pkg/skaffold/instrumentation/export.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -44,7 +43,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/api/option"
 
-	fs "github.com/GoogleContainerTools/skaffold/fs"
+	"github.com/GoogleContainerTools/skaffold/fs"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/user"
@@ -73,7 +72,7 @@ func exportMetrics(ctx context.Context, filename string, meter skaffoldMeter) er
 		return err
 	}
 
-	b, err := ioutil.ReadFile(filename)
+	b, err := os.ReadFile(filename)
 	fileExists := err == nil
 	if err != nil && !os.IsNotExist(err) {
 		return err
@@ -86,7 +85,7 @@ func exportMetrics(ctx context.Context, filename string, meter skaffoldMeter) er
 	meters = append(meters, meter)
 	if !isOnline {
 		b, _ = json.Marshal(meters)
-		return ioutil.WriteFile(filename, b, 0666)
+		return os.WriteFile(filename, b, 0666)
 	}
 
 	start := time.Now()
@@ -98,7 +97,7 @@ func exportMetrics(ctx context.Context, filename string, meter skaffoldMeter) er
 		log.Entry(ctx).Debugf("error uploading metrics: %s", err)
 		log.Entry(ctx).Debugf("writing to file %s instead", filename)
 		b, _ = json.Marshal(meters)
-		return ioutil.WriteFile(filename, b, 0666)
+		return os.WriteFile(filename, b, 0666)
 	}
 	log.Entry(ctx).Debugf("metrics uploading complete in %s", time.Since(start).String())
 

--- a/pkg/skaffold/instrumentation/export_test.go
+++ b/pkg/skaffold/instrumentation/export_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -187,7 +186,7 @@ func TestExportMetrics(t *testing.T) {
 			}
 
 			_ = exportMetrics(context.Background(), tmp.Path(filename), test.meter)
-			b, err := ioutil.ReadFile(tmp.Path(filename))
+			b, err := os.ReadFile(tmp.Path(filename))
 
 			if !test.isOnline {
 				_ = json.Unmarshal(b, &actual)
@@ -198,7 +197,7 @@ func TestExportMetrics(t *testing.T) {
 				t.CheckDeepEqual(expected, actual)
 			} else {
 				t.CheckDeepEqual(true, os.IsNotExist(err))
-				b, err := ioutil.ReadFile(tmp.Path(openTelFilename))
+				b, err := os.ReadFile(tmp.Path(openTelFilename))
 				t.CheckError(false, err)
 				checkOutput(t, append(savedMetrics, test.meter), b)
 			}
@@ -385,7 +384,7 @@ func TestUserMetricReported(t *testing.T) {
 
 			_ = exportMetrics(context.Background(), tmp.Path(filename), test.meter)
 
-			b, err := ioutil.ReadFile(tmp.Path(openTelFilename))
+			b, err := os.ReadFile(tmp.Path(openTelFilename))
 			t.CheckNoError(err)
 			checkUser(t, test.expectedUser, b)
 		})

--- a/pkg/skaffold/kubernetes/context/context_test.go
+++ b/pkg/skaffold/kubernetes/context/context_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package context
 
 import (
-	"io/ioutil"
+	"os"
 	"sync"
 	"testing"
 
@@ -159,7 +159,7 @@ func TestGetRestClientConfig(t *testing.T) {
 		t.CheckNoError(err)
 		t.CheckDeepEqual("https://bar.com", cfg.Host)
 
-		if err = ioutil.WriteFile(kubeConfig, []byte(changedKubeConfig), 0644); err != nil {
+		if err = os.WriteFile(kubeConfig, []byte(changedKubeConfig), 0644); err != nil {
 			t.Error(err)
 		}
 

--- a/pkg/skaffold/kubernetes/loader/load_test.go
+++ b/pkg/skaffold/kubernetes/loader/load_test.go
@@ -19,7 +19,7 @@ package loader
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
@@ -89,7 +89,7 @@ func TestLoadImagesInKindNodes(t *testing.T) {
 	}
 
 	runImageLoadingTests(t, tests, func(i *ImageLoader, test ImageLoadingTest) error {
-		return i.loadImagesInKindNodes(context.Background(), ioutil.Discard, test.cluster, test.deployed)
+		return i.loadImagesInKindNodes(context.Background(), io.Discard, test.cluster, test.deployed)
 	})
 }
 
@@ -143,7 +143,7 @@ func TestLoadImagesInK3dNodes(t *testing.T) {
 	}
 
 	runImageLoadingTests(t, tests, func(i *ImageLoader, test ImageLoadingTest) error {
-		return i.loadImagesInK3dNodes(context.Background(), ioutil.Discard, test.cluster, test.deployed)
+		return i.loadImagesInK3dNodes(context.Background(), io.Discard, test.cluster, test.deployed)
 	})
 }
 

--- a/pkg/skaffold/kubernetes/logger/log_test.go
+++ b/pkg/skaffold/kubernetes/logger/log_test.go
@@ -18,7 +18,7 @@ package logger
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"testing"
 	"time"
 
@@ -97,7 +97,7 @@ func TestLogAggregatorZeroValue(t *testing.T) {
 	var m *LogAggregator
 
 	// Should not raise a nil dereference
-	m.Start(context.Background(), ioutil.Discard)
+	m.Start(context.Background(), io.Discard)
 	m.Mute()
 	m.Unmute()
 	m.Stop()

--- a/pkg/skaffold/kubernetes/manifest/util.go
+++ b/pkg/skaffold/kubernetes/manifest/util.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -43,7 +42,7 @@ func Write(manifests string, output string, manifestOut io.Writer) error {
 		_, err := fmt.Fprintln(manifestOut, manifests)
 		return err
 	case strings.HasPrefix(output, gcsPrefix):
-		tempDir, err := ioutil.TempDir("", manifestsStagingFolder)
+		tempDir, err := os.MkdirTemp("", manifestsStagingFolder)
 		if err != nil {
 			return writeErr(fmt.Errorf("failed to create the tmp directory: %w", err))
 		}

--- a/pkg/skaffold/kubernetes/portforward/entry_manager_test.go
+++ b/pkg/skaffold/kubernetes/portforward/entry_manager_test.go
@@ -19,7 +19,7 @@ package portforward
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 	"sync"
 	"testing"
@@ -47,8 +47,8 @@ func TestStop(t *testing.T) {
 
 	fakeForwarder := newTestForwarder()
 	em := NewEntryManager(fakeForwarder)
-	em.forwardPortForwardEntry(context.Background(), ioutil.Discard, pfe1)
-	em.forwardPortForwardEntry(context.Background(), ioutil.Discard, pfe2)
+	em.forwardPortForwardEntry(context.Background(), io.Discard, pfe1)
+	em.forwardPortForwardEntry(context.Background(), io.Discard, pfe2)
 
 	testutil.CheckDeepEqual(t, 2, length(&fakeForwarder.forwardedResources))
 	testutil.CheckDeepEqual(t, 2, fakeForwarder.forwardedPorts.Length())

--- a/pkg/skaffold/kubernetes/portforward/forwarder_manager_test.go
+++ b/pkg/skaffold/kubernetes/portforward/forwarder_manager_test.go
@@ -18,7 +18,7 @@ package portforward
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -76,7 +76,7 @@ func TestForwarderManagerZeroValue(t *testing.T) {
 	var m *ForwarderManager
 
 	// Should not raise a nil dereference
-	m.Start(context.Background(), ioutil.Discard)
+	m.Start(context.Background(), io.Discard)
 	m.Stop()
 }
 

--- a/pkg/skaffold/kubernetes/portforward/kubectl_forwarder_test.go
+++ b/pkg/skaffold/kubernetes/portforward/kubectl_forwarder_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"runtime"
 	"sort"
 	"strings"
@@ -472,7 +472,7 @@ func TestStartAndForward(t *testing.T) {
 		testutil.Run(t, test.description, func(_ *testutil.T) {
 			k := &KubectlForwarder{}
 			if test.startFirst {
-				k.Start(ioutil.Discard)
+				k.Start(io.Discard)
 				testutil.CheckDeepEqual(t, k.started, int32(1))
 			} else {
 				err := k.Forward(context.Background(), nil)
@@ -484,7 +484,7 @@ func TestStartAndForward(t *testing.T) {
 
 func TestForwardReturnsNilOnContextCancelled(t *testing.T) {
 	k := NewKubectlForwarder(&kubectl.CLI{})
-	k.Start(ioutil.Discard)
+	k.Start(io.Discard)
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{}, 1)
 	go func() {

--- a/pkg/skaffold/kubernetes/portforward/pod_forwarder_test.go
+++ b/pkg/skaffold/kubernetes/portforward/pod_forwarder_test.go
@@ -18,7 +18,7 @@ package portforward
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"reflect"
 	"testing"
 	"time"
@@ -414,7 +414,7 @@ func TestAutomaticPortForwardPod(t *testing.T) {
 			entryManager.entryForwarder = test.forwarder
 
 			p := NewWatchingPodForwarder(entryManager, "", kubernetes.NewImageList(), allPorts)
-			p.Start(context.Background(), ioutil.Discard, nil)
+			p.Start(context.Background(), io.Discard, nil)
 			for _, pod := range test.pods {
 				err := p.portForwardPod(context.Background(), pod)
 				t.CheckError(test.shouldErr, err)
@@ -494,7 +494,7 @@ func TestStartPodForwarder(t *testing.T) {
 			entryManager := NewEntryManager(fakeForwarder)
 
 			p := NewWatchingPodForwarder(entryManager, "", imageList, allPorts)
-			p.Start(context.Background(), ioutil.Discard, nil)
+			p.Start(context.Background(), io.Discard, nil)
 
 			// wait for the pod resource to be forwarded
 			err := wait.PollImmediate(10*time.Millisecond, 100*time.Millisecond, func() (bool, error) {

--- a/pkg/skaffold/kubernetes/portforward/resource_forwarder_test.go
+++ b/pkg/skaffold/kubernetes/portforward/resource_forwarder_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"sync"
 	"testing"
 	"time"
@@ -134,7 +133,7 @@ func TestStart(t *testing.T) {
 			entryManager := NewEntryManager(fakeForwarder)
 
 			rf := NewServicesForwarder(entryManager, "", "")
-			if err := rf.Start(context.Background(), ioutil.Discard, []string{"test"}); err != nil {
+			if err := rf.Start(context.Background(), io.Discard, []string{"test"}); err != nil {
 				t.Fatalf("error starting resource forwarder: %v", err)
 			}
 
@@ -324,7 +323,7 @@ func TestUserDefinedResources(t *testing.T) {
 			}
 
 			rf := NewUserDefinedForwarder(entryManager, "", test.userResources)
-			if err := rf.Start(context.Background(), ioutil.Discard, test.namespaces); err != nil {
+			if err := rf.Start(context.Background(), io.Discard, test.namespaces); err != nil {
 				t.Fatalf("error starting resource forwarder: %v", err)
 			}
 

--- a/pkg/skaffold/lint/dockerfiles_test.go
+++ b/pkg/skaffold/lint/dockerfiles_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 	"text/template"
@@ -187,7 +187,7 @@ func TestGetDockerfilesLintResults(t *testing.T) {
 				module := fmt.Sprintf("cfg%d", i)
 				skaffoldyamlText := test.moduleAndSkaffoldYamls[module]
 				fp := filepath.Join(tmpdir, fmt.Sprintf("%s.yaml", module))
-				err := ioutil.WriteFile(fp, []byte(skaffoldyamlText), 0644)
+				err := os.WriteFile(fp, []byte(skaffoldyamlText), 0644)
 				if err != nil {
 					t.Fatalf("error creating skaffold.yaml file with name %s: %v", fp, err)
 				}
@@ -201,7 +201,7 @@ func TestGetDockerfilesLintResults(t *testing.T) {
 				if err != nil {
 					t.Fatalf("error executing dockerfileText go template: %v", err)
 				}
-				err = ioutil.WriteFile(dfp, b.Bytes(), 0644)
+				err = os.WriteFile(dfp, b.Bytes(), 0644)
 				if err != nil {
 					t.Fatalf("error creating Dockerfile %s: %v", dfp, err)
 				}

--- a/pkg/skaffold/lint/k8smanifests_test.go
+++ b/pkg/skaffold/lint/k8smanifests_test.go
@@ -19,7 +19,7 @@ package lint
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -124,12 +124,12 @@ func TestGetK8sManifestsLintResults(t *testing.T) {
 				module := fmt.Sprintf("cfg%d", i)
 				skaffoldyamlText := test.moduleAndSkaffoldYamls[module]
 				fp := filepath.Join(tmpdir, fmt.Sprintf("%s.yaml", module))
-				err := ioutil.WriteFile(fp, []byte(skaffoldyamlText), 0644)
+				err := os.WriteFile(fp, []byte(skaffoldyamlText), 0644)
 				if err != nil {
 					t.Fatalf("error creating skaffold.yaml file with name %s: %v", fp, err)
 				}
 				mp := filepath.Join(tmpdir, "deployment.yaml")
-				err = ioutil.WriteFile(mp, []byte(test.k8sManifestText), 0644)
+				err = os.WriteFile(mp, []byte(test.k8sManifestText), 0644)
 				if err != nil {
 					t.Fatalf("error creating deployment.yaml %s: %v", mp, err)
 				}

--- a/pkg/skaffold/lint/output.go
+++ b/pkg/skaffold/lint/output.go
@@ -22,7 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"strings"
 	"text/template"
 
@@ -67,7 +67,7 @@ func genColPointerLine(colIdx int) string {
 }
 
 func generatePlainTextOutput(res *Result) (string, error) {
-	text, err := ioutil.ReadFile(res.AbsFilePath)
+	text, err := os.ReadFile(res.AbsFilePath)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/skaffold/lint/output_test.go
+++ b/pkg/skaffold/lint/output_test.go
@@ -19,7 +19,7 @@ package lint
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"go.lsp.dev/protocol"
@@ -87,7 +87,7 @@ func TestLintOutput(t *testing.T) {
 			})
 			resultList := test.results.([]Result)
 			tmpdir := t.TempDir()
-			f, err := ioutil.TempFile(tmpdir, "TestLintOutput-tmpfile")
+			f, err := os.CreateTemp(tmpdir, "TestLintOutput-tmpfile")
 			if err != nil {
 				t.Fatalf("error creating dockerfile: %v", err)
 			}

--- a/pkg/skaffold/lint/skaffoldyamls_test.go
+++ b/pkg/skaffold/lint/skaffoldyamls_test.go
@@ -19,7 +19,7 @@ package lint
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -194,12 +194,12 @@ func TestGetSkaffoldYamlsLintResults(t *testing.T) {
 				module := fmt.Sprintf("cfg%d", i)
 				skaffoldyamlText := test.moduleAndSkaffoldYamls[module]
 				fp := filepath.Join(tmpdir, fmt.Sprintf("%s.yaml", module))
-				err := ioutil.WriteFile(fp, []byte(skaffoldyamlText), 0644)
+				err := os.WriteFile(fp, []byte(skaffoldyamlText), 0644)
 				if err != nil {
 					t.Fatalf("error creating skaffold.yaml file with name %s: %v", fp, err)
 				}
 				mp := filepath.Join(tmpdir, fmt.Sprintf("%s.yaml", "deployment"))
-				err = ioutil.WriteFile(mp, []byte(testManifest), 0644)
+				err = os.WriteFile(mp, []byte(testManifest), 0644)
 				if err != nil {
 					t.Fatalf("error creating deployment.yaml file with name %s: %v", fp, err)
 				}

--- a/pkg/skaffold/output/output_test.go
+++ b/pkg/skaffold/output/output_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -65,7 +64,7 @@ func TestIsStdOut(t *testing.T) {
 		{
 			description: "invalid colorableWriter passed",
 			out: skaffoldWriter{
-				MainWriter: NewColorWriter(ioutil.Discard),
+				MainWriter: NewColorWriter(io.Discard),
 			},
 			expected: false,
 		},
@@ -98,11 +97,11 @@ func TestGetUnderlyingWriter(t *testing.T) {
 			expected: os.Stdout,
 		},
 		{
-			description: "return ioutil.Discard from skaffoldWriter",
+			description: "return io.Discard from skaffoldWriter",
 			out: skaffoldWriter{
-				MainWriter: NewColorWriter(ioutil.Discard),
+				MainWriter: NewColorWriter(io.Discard),
 			},
-			expected: ioutil.Discard,
+			expected: io.Discard,
 		},
 		{
 			description: "os.Stdout returned from colorableWriter",
@@ -134,20 +133,20 @@ func TestWithEventContext(t *testing.T) {
 		{
 			name: "skaffoldWriter update info",
 			writer: skaffoldWriter{
-				MainWriter:  ioutil.Discard,
+				MainWriter:  io.Discard,
 				EventWriter: eventV2.NewLogger(constants.Build, "1"),
 			},
 			phase:     constants.Test,
 			subtaskID: "2",
 			expected: skaffoldWriter{
-				MainWriter:  ioutil.Discard,
+				MainWriter:  io.Discard,
 				EventWriter: eventV2.NewLogger(constants.Test, "2"),
 			},
 		},
 		{
 			name:     "non skaffoldWriter returns same",
-			writer:   ioutil.Discard,
-			expected: ioutil.Discard,
+			writer:   io.Discard,
+			expected: io.Discard,
 		},
 	}
 
@@ -170,7 +169,7 @@ func TestWriteWithTimeStamps(t *testing.T) {
 			writer: func(out io.Writer) io.Writer {
 				return skaffoldWriter{
 					MainWriter:  colorableWriter{out},
-					EventWriter: ioutil.Discard,
+					EventWriter: io.Discard,
 					timestamps:  true,
 				}
 			},
@@ -181,7 +180,7 @@ func TestWriteWithTimeStamps(t *testing.T) {
 			writer: func(out io.Writer) io.Writer {
 				return skaffoldWriter{
 					MainWriter:  colorableWriter{out},
-					EventWriter: ioutil.Discard,
+					EventWriter: io.Discard,
 				}
 			},
 			expectedLen: len("\u001B[32mtesting!\u001B[0m"),
@@ -191,7 +190,7 @@ func TestWriteWithTimeStamps(t *testing.T) {
 			writer: func(out io.Writer) io.Writer {
 				return skaffoldWriter{
 					MainWriter:  out,
-					EventWriter: ioutil.Discard,
+					EventWriter: io.Discard,
 					timestamps:  true,
 				}
 			},
@@ -202,7 +201,7 @@ func TestWriteWithTimeStamps(t *testing.T) {
 			writer: func(out io.Writer) io.Writer {
 				return skaffoldWriter{
 					MainWriter:  out,
-					EventWriter: ioutil.Discard,
+					EventWriter: io.Discard,
 				}
 			},
 			expectedLen: len("testing!"),

--- a/pkg/skaffold/render/generate/generate.go
+++ b/pkg/skaffold/render/generate/generate.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -156,7 +155,7 @@ func (g Generator) Generate(ctx context.Context, out io.Writer) (manifest.Manife
 				continue
 			}
 		}
-		manifestFileContent, err := ioutil.ReadFile(nkPath)
+		manifestFileContent, err := os.ReadFile(nkPath)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/skaffold/render/renderer/kpt/kpt.go
+++ b/pkg/skaffold/render/renderer/kpt/kpt.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -130,7 +129,7 @@ func (r *Kpt) Render(ctx context.Context, out io.Writer, builds []graph.Artifact
 	}
 	endTrace()
 	_, endTrace = instrumentation.StartTrace(ctx, "Render_readKptfile")
-	kptfileBytes, err := ioutil.ReadFile(kptfilePath)
+	kptfileBytes, err := os.ReadFile(kptfilePath)
 	if err != nil {
 		endTrace(instrumentation.TraceEndError(fmt.Errorf("read Kptfile from %v: %w",
 			filepath.Dir(kptfilePath), err)))
@@ -169,7 +168,7 @@ func (r *Kpt) Render(ctx context.Context, out io.Writer, builds []graph.Artifact
 	if err != nil {
 		return nil, err
 	}
-	if err = ioutil.WriteFile(kptfilePath, configByte, 0644); err != nil {
+	if err = os.WriteFile(kptfilePath, configByte, 0644); err != nil {
 		return manifests, err
 	}
 	endTrace()

--- a/pkg/skaffold/render/renderer/util/util.go
+++ b/pkg/skaffold/render/renderer/util/util.go
@@ -19,7 +19,7 @@ package util
 import (
 	"context"
 	"io"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	apim "k8s.io/apimachinery/pkg/runtime/schema"
@@ -90,7 +90,7 @@ func ConsolidateTransformConfiguration(cfg render.Config) (map[apim.GroupKind]la
 	// add user flag values, override user schema values and defaults
 	// TODO(aaron-prindle) see if workdir needs to be considered in this read
 	if cfg.TransformRulesFile() != "" {
-		transformRulesFromFile, err := ioutil.ReadFile(cfg.TransformRulesFile())
+		transformRulesFromFile, err := os.ReadFile(cfg.TransformRulesFile())
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/skaffold/runner/v2/deploy_test.go
+++ b/pkg/skaffold/runner/v2/deploy_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -86,7 +86,7 @@ func TestSkaffoldDeployRenderOnly(t *testing.T) {
 		}
 		var builds []graph.Artifact
 
-		err = r.Deploy(context.Background(), ioutil.Discard, builds, nil)
+		err = r.Deploy(context.Background(), io.Discard, builds, nil)
 
 		t.CheckNoError(err)
 	})

--- a/pkg/skaffold/runner/v2/dev_test.go
+++ b/pkg/skaffold/runner/v2/dev_test.go
@@ -19,7 +19,7 @@ package v2
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -161,7 +161,7 @@ func TestDevFailFirstCycle(t *testing.T) {
 			r := createRunner(t, test.testBench, test.monitor, artifacts, nil)
 			test.testBench.firstMonitor = test.monitor.Run
 
-			err := r.Dev(context.Background(), ioutil.Discard, artifacts)
+			err := r.Dev(context.Background(), io.Discard, artifacts)
 
 			t.CheckErrorAndDeepEqual(true, err, test.expectedActions, test.testBench.Actions())
 		})
@@ -324,7 +324,7 @@ func TestDev(t *testing.T) {
 				testBench: test.testBench,
 			}, artifacts, nil)
 
-			err := r.Dev(context.Background(), ioutil.Discard, artifacts)
+			err := r.Dev(context.Background(), io.Discard, artifacts)
 
 			t.CheckNoError(err)
 			t.CheckDeepEqual(test.expectedActions, test.testBench.Actions())
@@ -479,7 +479,7 @@ func TestDevAutoTriggers(t *testing.T) {
 
 			testBench.intents = r.intents
 
-			err := r.Dev(context.Background(), ioutil.Discard, artifacts)
+			err := r.Dev(context.Background(), io.Discard, artifacts)
 
 			t.CheckNoError(err)
 			t.CheckDeepEqual(append([]Actions{firstAction}, test.expectedActions...), testBench.Actions())
@@ -586,7 +586,7 @@ func TestDevSync(t *testing.T) {
 				testBench: test.testBench,
 			}, artifacts, nil)
 
-			err := r.Dev(context.Background(), ioutil.Discard, artifacts)
+			err := r.Dev(context.Background(), io.Discard, artifacts)
 
 			t.CheckNoError(err)
 			t.CheckDeepEqual(test.expectedActions, test.testBench.Actions())

--- a/pkg/skaffold/schema/validation/samples_test.go
+++ b/pkg/skaffold/schema/validation/samples_test.go
@@ -19,7 +19,7 @@ package validation
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -72,7 +72,7 @@ func TestParseSamples(t *testing.T) {
 
 		testutil.Run(t, name, func(t *testutil.T) {
 			t.Logf("Checking %s...", path)
-			buf, err := ioutil.ReadFile(path)
+			buf, err := os.ReadFile(path)
 			t.CheckNoError(err)
 
 			checkSkaffoldConfig(t, addHeader(buf))
@@ -113,7 +113,7 @@ func parseConfigFiles(t *testing.T, root string) {
 		testutil.Run(t, name, func(t *testutil.T) {
 			var data []string
 			for _, path := range paths {
-				buf, err := ioutil.ReadFile(path)
+				buf, err := os.ReadFile(path)
 				t.CheckNoError(err)
 				data = append(data, string(buf))
 			}

--- a/pkg/skaffold/status/status_mux_test.go
+++ b/pkg/skaffold/status/status_mux_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -52,7 +51,7 @@ func TestMonitorMux(t *testing.T) {
 			for i := 0; i < 3; i++ {
 				m = append(m, &MockMonitor{monitor: test.monitor})
 			}
-			err := m.Check(context.Background(), ioutil.Discard)
+			err := m.Check(context.Background(), io.Discard)
 			if test.shouldErr {
 				t.CheckError(true, err)
 			} else {

--- a/pkg/skaffold/tag/git_commit_test.go
+++ b/pkg/skaffold/tag/git_commit_test.go
@@ -21,14 +21,13 @@ package tag
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
-	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 
@@ -417,7 +416,7 @@ func TestGitCommit_GenerateTag(t *testing.T) {
 		{
 			description: "non git repo",
 			createGitRepo: func(dir string) {
-				ioutil.WriteFile(filepath.Join(dir, "source.go"), []byte("code"), os.ModePerm)
+				os.WriteFile(filepath.Join(dir, "source.go"), []byte("code"), os.ModePerm)
 			},
 			shouldErr: true,
 		},
@@ -496,7 +495,7 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 		{
 			description: "non git repo",
 			createGitRepo: func(dir string) {
-				ioutil.WriteFile(filepath.Join(dir, "source.go"), []byte("code"), os.ModePerm)
+				os.WriteFile(filepath.Join(dir, "source.go"), []byte("code"), os.ModePerm)
 			},
 			shouldErr: true,
 		},
@@ -703,7 +702,7 @@ func (g *gitRepo) mkdir(folder string) *gitRepo {
 }
 
 func (g *gitRepo) write(file string, content string) *gitRepo {
-	err := ioutil.WriteFile(filepath.Join(g.dir, file), []byte(content), os.ModePerm)
+	err := os.WriteFile(filepath.Join(g.dir, file), []byte(content), os.ModePerm)
 	failNowIfError(g.t, err)
 	return g
 }

--- a/pkg/skaffold/tag/input_digest_test.go
+++ b/pkg/skaffold/tag/input_digest_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package tag
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -36,7 +35,7 @@ func TestInputDigest(t *testing.T) {
 		defer func() { t.RequireNoError(os.Chdir(cwdBackup)) }()
 
 		file := "temp.file"
-		t.RequireNoError(ioutil.WriteFile(file, fileContents1, 0644))
+		t.RequireNoError(os.WriteFile(file, fileContents1, 0644))
 
 		relPathHash, err := fileHasher(file, ".")
 		t.CheckErrorAndDeepEqual(false, err, "3cced2dec96a8b41b22875686d8941a9", relPathHash)
@@ -47,8 +46,8 @@ func TestInputDigest(t *testing.T) {
 	testutil.Run(t, "SameDigestForTwoDifferentAbsPaths", func(t *testutil.T) {
 		dir1, dir2 := t.TempDir(), t.TempDir()
 		file1, file2 := filepath.Join(dir1, "temp.file"), filepath.Join(dir2, "temp.file")
-		t.RequireNoError(ioutil.WriteFile(file1, fileContents1, 0644))
-		t.RequireNoError(ioutil.WriteFile(file2, fileContents1, 0644))
+		t.RequireNoError(os.WriteFile(file1, fileContents1, 0644))
+		t.RequireNoError(os.WriteFile(file2, fileContents1, 0644))
 
 		hash1, err := fileHasher(file1, dir1)
 		t.CheckErrorAndDeepEqual(false, err, "3cced2dec96a8b41b22875686d8941a9", hash1)
@@ -59,8 +58,8 @@ func TestInputDigest(t *testing.T) {
 	testutil.Run(t, "DifferentDigestForDifferentFilenames", func(t *testutil.T) {
 		dir1, dir2 := t.TempDir(), t.TempDir()
 		file1, file2 := filepath.Join(dir1, "temp1.file"), filepath.Join(dir2, "temp2.file")
-		t.RequireNoError(ioutil.WriteFile(file1, fileContents1, 0644))
-		t.RequireNoError(ioutil.WriteFile(file2, fileContents1, 0644))
+		t.RequireNoError(os.WriteFile(file1, fileContents1, 0644))
+		t.RequireNoError(os.WriteFile(file2, fileContents1, 0644))
 
 		hash1, err := fileHasher(file1, dir1)
 		t.CheckNoError(err)
@@ -72,8 +71,8 @@ func TestInputDigest(t *testing.T) {
 	testutil.Run(t, "DifferentDigestForDifferentContent", func(t *testutil.T) {
 		dir1, dir2 := t.TempDir(), t.TempDir()
 		file1, file2 := filepath.Join(dir1, "temp.file"), filepath.Join(dir2, "temp.file")
-		t.RequireNoError(ioutil.WriteFile(file1, fileContents1, 0644))
-		t.RequireNoError(ioutil.WriteFile(file2, fileContents2, 0644))
+		t.RequireNoError(os.WriteFile(file1, fileContents1, 0644))
+		t.RequireNoError(os.WriteFile(file2, fileContents2, 0644))
 
 		hash1, err := fileHasher(file1, dir1)
 		t.CheckNoError(err)

--- a/pkg/skaffold/test/custom/custom_test.go
+++ b/pkg/skaffold/test/custom/custom_test.go
@@ -19,7 +19,7 @@ package custom
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -71,7 +71,7 @@ func TestNewCustomTestRunner(t *testing.T) {
 
 		testRunner, err := New(cfg, testCase.ImageName, testCase.Workspace, custom)
 		t.CheckNoError(err)
-		err = testRunner.Test(context.Background(), ioutil.Discard, "image:tag")
+		err = testRunner.Test(context.Background(), io.Discard, "image:tag")
 
 		t.CheckNoError(err)
 	})
@@ -133,7 +133,7 @@ func TestCustomCommandError(t *testing.T) {
 
 			testRunner, err := New(cfg, testCase.ImageName, testCase.Workspace, test.custom)
 			t.CheckNoError(err)
-			err = testRunner.Test(context.Background(), ioutil.Discard, "image:tag")
+			err = testRunner.Test(context.Background(), io.Discard, "image:tag")
 
 			// TODO(modali): Update the logic to check for error code instead of error string.
 			t.CheckError(test.shouldErr, err)

--- a/pkg/skaffold/test/structure/structure_test.go
+++ b/pkg/skaffold/test/structure/structure_test.go
@@ -19,7 +19,7 @@ package structure
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/blang/semver"
@@ -54,7 +54,7 @@ func TestNewRunner(t *testing.T) {
 
 		testRunner, err := New(context.Background(), cfg, testCase, true)
 		t.CheckNoError(err)
-		err = testRunner.Test(context.Background(), ioutil.Discard, "image:tag")
+		err = testRunner.Test(context.Background(), io.Discard, "image:tag")
 		t.CheckNoError(err)
 	})
 }
@@ -123,7 +123,7 @@ func TestCustomParams(t *testing.T) {
 
 			testRunner, err := New(context.Background(), cfg, testCase, true)
 			t.CheckNoError(err)
-			err = testRunner.Test(context.Background(), ioutil.Discard, "image:tag")
+			err = testRunner.Test(context.Background(), io.Discard, "image:tag")
 			t.CheckNoError(err)
 		})
 	}

--- a/pkg/skaffold/test/test_factory_test.go
+++ b/pkg/skaffold/test/test_factory_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -88,7 +88,7 @@ func TestWrongPattern(t *testing.T) {
 		t.CheckError(true, err)
 		testEvent.InitializeState([]latest.Pipeline{{}})
 
-		err = tester.Test(context.Background(), ioutil.Discard, []graph.Artifact{{
+		err = tester.Test(context.Background(), io.Discard, []graph.Artifact{{
 			ImageName: "image",
 			Tag:       "image:tag",
 		}})
@@ -103,7 +103,7 @@ func TestNoTest(t *testing.T) {
 		tester, err := NewTester(context.Background(), cfg, func(imageName string) (bool, error) { return true, nil })
 		t.CheckNoError(err)
 
-		err = tester.Test(context.Background(), ioutil.Discard, nil)
+		err = tester.Test(context.Background(), io.Discard, nil)
 
 		t.CheckNoError(err)
 	})
@@ -141,7 +141,7 @@ func TestTestSuccess(t *testing.T) {
 		imagesAreLocal := true
 		tester, err := NewTester(context.Background(), cfg, func(imageName string) (bool, error) { return imagesAreLocal, nil })
 		t.CheckNoError(err)
-		err = tester.Test(context.Background(), ioutil.Discard, []graph.Artifact{{
+		err = tester.Test(context.Background(), io.Discard, []graph.Artifact{{
 			ImageName: "image",
 			Tag:       "image:tag",
 		}})
@@ -168,7 +168,7 @@ func TestTestSuccessRemoteImage(t *testing.T) {
 		tester, err := NewTester(context.Background(), cfg, func(imageName string) (bool, error) { return imagesAreLocal, nil })
 		t.CheckNoError(err)
 
-		err = tester.Test(context.Background(), ioutil.Discard, []graph.Artifact{{
+		err = tester.Test(context.Background(), io.Discard, []graph.Artifact{{
 			ImageName: "image",
 			Tag:       "image:tag",
 		}})
@@ -196,7 +196,7 @@ func TestTestFailureRemoteImage(t *testing.T) {
 		tester, err := NewTester(context.Background(), cfg, func(imageName string) (bool, error) { return imagesAreLocal, nil })
 		t.CheckNoError(err)
 
-		err = tester.Test(context.Background(), ioutil.Discard, []graph.Artifact{{
+		err = tester.Test(context.Background(), io.Discard, []graph.Artifact{{
 			ImageName: "image",
 			Tag:       "image:tag",
 		}})
@@ -226,7 +226,7 @@ func TestTestFailure(t *testing.T) {
 		tester, err := NewTester(context.Background(), cfg, func(imageName string) (bool, error) { return true, nil })
 		t.CheckNoError(err)
 
-		err = tester.Test(context.Background(), ioutil.Discard, []graph.Artifact{{
+		err = tester.Test(context.Background(), io.Discard, []graph.Artifact{{
 			ImageName: "broken-image",
 			Tag:       "broken-image:tag",
 		}})

--- a/pkg/skaffold/util/config.go
+++ b/pkg/skaffold/util/config.go
@@ -19,7 +19,7 @@ package util
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -42,7 +42,7 @@ func ReadConfiguration(filePath string) ([]byte, error) {
 	case filePath == "-":
 		if len(stdin) == 0 {
 			var err error
-			stdin, err = ioutil.ReadAll(os.Stdin)
+			stdin, err = io.ReadAll(os.Stdin)
 			if err != nil {
 				return []byte{}, err
 			}

--- a/pkg/skaffold/util/http.go
+++ b/pkg/skaffold/util/http.go
@@ -18,7 +18,7 @@ package util
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
@@ -39,5 +39,5 @@ func Download(url string) ([]byte, error) {
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("http %d, error %q", resp.StatusCode, resp.Status)
 	}
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }

--- a/pkg/skaffold/util/tar_test.go
+++ b/pkg/skaffold/util/tar_test.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"io"
-	"io/ioutil"
 	"runtime"
 	"testing"
 	"time"
@@ -53,7 +52,7 @@ func TestCreateTar(t *testing.T) {
 			}
 			t.CheckNoError(err)
 
-			content, err := ioutil.ReadAll(tr)
+			content, err := io.ReadAll(tr)
 			t.CheckNoError(err)
 
 			tarFiles[hdr.Name] = string(content)
@@ -88,7 +87,7 @@ func TestCreateTarWithParents(t *testing.T) {
 			t.CheckDeepEqual(10, hdr.Uid)
 			t.CheckDeepEqual(100, hdr.Gid)
 
-			content, err := ioutil.ReadAll(tr)
+			content, err := io.ReadAll(tr)
 			t.CheckNoError(err)
 
 			tarFiles[hdr.Name] = string(content)
@@ -128,7 +127,7 @@ func TestCreateTarGz(t *testing.T) {
 			}
 			t.CheckNoError(err)
 
-			content, err := ioutil.ReadAll(tr)
+			content, err := io.ReadAll(tr)
 			t.CheckNoError(err)
 
 			tarFiles[hdr.Name] = string(content)
@@ -161,7 +160,7 @@ func TestCreateTarSubDirectory(t *testing.T) {
 			}
 			t.CheckNoError(err)
 
-			content, err := ioutil.ReadAll(tr)
+			content, err := io.ReadAll(tr)
 			t.CheckNoError(err)
 
 			tarFiles["sub/"+hdr.Name] = string(content)
@@ -224,7 +223,7 @@ func TestCreateTarWithAbsolutePaths(t *testing.T) {
 			}
 			t.CheckNoError(err)
 
-			content, err := ioutil.ReadAll(tr)
+			content, err := io.ReadAll(tr)
 			t.CheckNoError(err)
 
 			tarFiles[hdr.Name] = string(content)

--- a/testutil/cmd_helper.go
+++ b/testutil/cmd_helper.go
@@ -19,7 +19,7 @@ package testutil
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"os/exec"
 	"strings"
 	"testing"
@@ -235,7 +235,7 @@ func (c *FakeCmd) assertInput(cmd *exec.Cmd, r *run, command string) error {
 		return nil
 	}
 
-	buf, err := ioutil.ReadAll(cmd.Stdin)
+	buf, err := io.ReadAll(cmd.Stdin)
 	if err != nil {
 		return err
 	}

--- a/testutil/fake_image_api.go
+++ b/testutil/fake_image_api.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"strings"
@@ -33,7 +32,7 @@ import (
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/client"
 	reg "github.com/docker/docker/registry"
-	digest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -123,10 +122,10 @@ func (f errReader) Read([]byte) (int, error) { return 0, fmt.Errorf("") }
 
 func (f *FakeAPIClient) body(digest string) io.ReadCloser {
 	if f.ErrStream {
-		return ioutil.NopCloser(&errReader{})
+		return io.NopCloser(&errReader{})
 	}
 
-	return ioutil.NopCloser(strings.NewReader(fmt.Sprintf(`{"aux":{"digest":"%s"}}`, digest)))
+	return io.NopCloser(strings.NewReader(fmt.Sprintf(`{"aux":{"digest":"%s"}}`, digest)))
 }
 
 func (f *FakeAPIClient) ImageBuild(_ context.Context, _ io.Reader, options types.ImageBuildOptions) (types.ImageBuildResponse, error) {
@@ -310,11 +309,11 @@ func (f *FakeAPIClient) Close() error { return nil }
 
 // TODO(dgageot): create something that looks more like an actual tar file.
 func CreateFakeImageTar(ref string, path string) error {
-	return ioutil.WriteFile(path, []byte(ref), os.ModePerm)
+	return os.WriteFile(path, []byte(ref), os.ModePerm)
 }
 
 func ReadRefFromFakeTar(input io.Reader) (string, error) {
-	buf, err := ioutil.ReadAll(input)
+	buf, err := io.ReadAll(input)
 	if err != nil {
 		return "", fmt.Errorf("reading tar")
 	}

--- a/testutil/tmp.go
+++ b/testutil/tmp.go
@@ -17,7 +17,6 @@ limitations under the License.
 package testutil
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -30,14 +29,14 @@ import (
 
 // TempFile creates a temporary file with a given content. Returns the file name.
 func TempFile(t *testing.T, prefix string, content []byte) string {
-	file, err := ioutil.TempFile("", prefix)
+	file, err := os.CreateTemp("", prefix)
 	if err != nil {
 		t.Error(err)
 	}
 
 	t.Cleanup(func() { syscall.Unlink(file.Name()) })
 
-	if err = ioutil.WriteFile(file.Name(), content, 0644); err != nil {
+	if err = os.WriteFile(file.Name(), content, 0644); err != nil {
 		t.Error(err)
 	}
 
@@ -53,7 +52,7 @@ type TempDir struct {
 // NewTempDir creates a temporary directory and a teardown function
 // that should be called to properly delete the directory content.
 func NewTempDir(t *testing.T) *TempDir {
-	root, err := ioutil.TempDir("", "skaffold")
+	root, err := os.MkdirTemp("", "skaffold")
 	if err != nil {
 		t.Error(err)
 	}
@@ -89,7 +88,7 @@ func (h *TempDir) Mkdir(dir string) *TempDir {
 // Write write content to a file in the temp directory.
 func (h *TempDir) Write(file, content string) *TempDir {
 	h.failIfErr(os.MkdirAll(filepath.Dir(h.Path(file)), os.ModePerm))
-	return h.failIfErr(ioutil.WriteFile(h.Path(file), []byte(content), os.ModePerm))
+	return h.failIfErr(os.WriteFile(h.Path(file), []byte(content), os.ModePerm))
 }
 
 // WriteFiles write a list of files (path->content) in the temp directory.

--- a/testutil/util.go
+++ b/testutil/util.go
@@ -19,7 +19,6 @@ package testutil
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -389,7 +388,7 @@ func CheckFileExistAndContent(t *testing.T, path string, expectedContent []byte)
 	if _, err := os.Stat(absPath); os.IsNotExist(err) {
 		t.Fatalf("file %v does not exist", path)
 	}
-	actualContent, err := ioutil.ReadFile(absPath)
+	actualContent, err := os.ReadFile(absPath)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
**Description**
As of Go 1.16, the same functionality is now provided by package io or
package os, and those implementations should be preferred in new code.

So replacing all usage of `ioutil` pkg with `io` & `os`.