### PR TITLE
test: diag.ContainerError.Make method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ pkg/skaffold/output/debug.test
 fs/assets/*_generated
 fs/assets/check.txt
 secrets/keys.json
+integration/testdata/dev/foo
+pkg/skaffold/build/app.tar

--- a/pkg/diag/recommender/container_errors.go
+++ b/pkg/diag/recommender/container_errors.go
@@ -20,12 +20,9 @@ import (
 	"github.com/GoogleContainerTools/skaffold/proto/v1"
 )
 
-type ContainerError struct {
-}
+type ContainerError struct{}
 
-var (
-	NilSuggestion = proto.Suggestion{SuggestionCode: proto.SuggestionCode_NIL}
-)
+var NilSuggestion = proto.Suggestion{SuggestionCode: proto.SuggestionCode_NIL}
 
 func (r ContainerError) Make(errCode proto.StatusCode) *proto.Suggestion {
 	switch errCode {

--- a/pkg/diag/recommender/recommender_test.go
+++ b/pkg/diag/recommender/recommender_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package recommender
 
 import (

--- a/pkg/diag/recommender/recommender_test.go
+++ b/pkg/diag/recommender/recommender_test.go
@@ -3,10 +3,11 @@ package recommender
 import (
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/proto/v1"
-	"github.com/GoogleContainerTools/skaffold/testutil"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/testing/protocmp"
+
+	"github.com/GoogleContainerTools/skaffold/proto/v1"
+	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
 func TestContainerErrorMake(t *testing.T) {

--- a/pkg/diag/recommender/recommender_test.go
+++ b/pkg/diag/recommender/recommender_test.go
@@ -25,7 +25,7 @@ func TestContainerErrorMake(t *testing.T) {
 			},
 		},
 		{
-			description: "makes err suggestion unhealhty status check (357)",
+			description: "makes err suggestion unhealthy status check (357)",
 			errCode:     proto.StatusCode_STATUSCHECK_UNHEALTHY,
 			expected: &proto.Suggestion{
 				SuggestionCode: proto.SuggestionCode_CHECK_READINESS_PROBE,
@@ -49,8 +49,12 @@ func TestContainerErrorMake(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			r := ContainerError{}
-			t.CheckDeepEqual(test.expected, r.Make(test.errCode), cmp.AllowUnexported(proto.Suggestion{}), protocmp.Transform())
+			t.CheckDeepEqual(
+				test.expected,
+				ContainerError{}.Make(test.errCode),
+				cmp.AllowUnexported(proto.Suggestion{}),
+				protocmp.Transform(),
+			)
 		})
 	}
 }

--- a/pkg/diag/recommender/recommender_test.go
+++ b/pkg/diag/recommender/recommender_test.go
@@ -1,0 +1,55 @@
+package recommender
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/proto/v1"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func TestContainerErrorMake(t *testing.T) {
+	tests := []struct {
+		description string
+		errCode     proto.StatusCode
+		expected    *proto.Suggestion
+	}{
+		{
+			description: "makes err suggestion for terminated containers (303)",
+			errCode:     proto.StatusCode_STATUSCHECK_CONTAINER_TERMINATED,
+			expected: &proto.Suggestion{
+				SuggestionCode: proto.SuggestionCode_CHECK_CONTAINER_LOGS,
+				Action:         "Try checking container logs",
+			},
+		},
+		{
+			description: "makes err suggestion unhealhty status check (357)",
+			errCode:     proto.StatusCode_STATUSCHECK_UNHEALTHY,
+			expected: &proto.Suggestion{
+				SuggestionCode: proto.SuggestionCode_CHECK_READINESS_PROBE,
+				Action:         "Try checking container config `readinessProbe`",
+			},
+		},
+		{
+			description: "makes err suggestion for failed image pulls (300)",
+			errCode:     proto.StatusCode_STATUSCHECK_IMAGE_PULL_ERR,
+			expected: &proto.Suggestion{
+				SuggestionCode: proto.SuggestionCode_CHECK_CONTAINER_IMAGE,
+				Action:         "Try checking container config `image`",
+			},
+		},
+		{
+			description: "returns nil suggestion if no case matches",
+			errCode:     proto.StatusCode_BUILD_CANCELLED,
+			expected:    &NilSuggestion,
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			r := ContainerError{}
+			t.CheckDeepEqual(test.expected, r.Make(test.errCode), cmp.AllowUnexported(proto.Suggestion{}), protocmp.Transform())
+		})
+	}
+}

--- a/pkg/diag/validator/validator_test.go
+++ b/pkg/diag/validator/validator_test.go
@@ -56,12 +56,14 @@ func TestRun(t *testing.T) {
 	}{
 		{
 			description: "pod don't exist in test namespace",
-			pods: []*v1.Pod{{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo",
-					Namespace: "foo-ns",
+			pods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "foo-ns",
+					},
+					TypeMeta: metav1.TypeMeta{Kind: "Pod"},
 				},
-				TypeMeta: metav1.TypeMeta{Kind: "Pod"}},
 			},
 			expected: nil,
 		},
@@ -261,16 +263,20 @@ func TestRun(t *testing.T) {
 								Terminated: &v1.ContainerStateTerminated{ExitCode: 1, Message: "panic caused"},
 							},
 						},
-					}},
+					},
+				},
 			}},
 			expected: []Resource{NewResource("test", "Pod", "foo", "Running",
 				&proto.ActionableErr{
 					Message: "container foo-container terminated with exit code 1",
 					ErrCode: proto.StatusCode_STATUSCHECK_CONTAINER_TERMINATED,
 					Suggestions: []*proto.Suggestion{
-						{SuggestionCode: proto.SuggestionCode_CHECK_CONTAINER_LOGS,
-							Action: "Try checking container logs"},
-					}}, []string{})},
+						{
+							SuggestionCode: proto.SuggestionCode_CHECK_CONTAINER_LOGS,
+							Action:         "Try checking container logs",
+						},
+					},
+				}, []string{})},
 		},
 		{
 			description: "one of the pod containers is in Terminated State with non zero exit code",
@@ -291,16 +297,20 @@ func TestRun(t *testing.T) {
 								Terminated: &v1.ContainerStateTerminated{ExitCode: 1, Message: "panic caused"},
 							},
 						},
-					}},
+					},
+				},
 			}},
 			expected: []Resource{NewResource("test", "Pod", "foo", "Running",
 				&proto.ActionableErr{
 					Message: "container foo-container terminated with exit code 1",
 					ErrCode: proto.StatusCode_STATUSCHECK_CONTAINER_TERMINATED,
 					Suggestions: []*proto.Suggestion{
-						{SuggestionCode: proto.SuggestionCode_CHECK_CONTAINER_LOGS,
-							Action: "Try checking container logs"},
-					}}, []string{})},
+						{
+							SuggestionCode: proto.SuggestionCode_CHECK_CONTAINER_LOGS,
+							Action:         "Try checking container logs",
+						},
+					},
+				}, []string{})},
 		},
 		{
 			description: "pod is in Stable State",
@@ -415,7 +425,8 @@ func TestRun(t *testing.T) {
 					}},
 				}, []string{
 					"[foo foo-container] main.go:57 ",
-					"[foo foo-container] go panic"},
+					"[foo foo-container] go panic",
+				},
 			)},
 		},
 		{
@@ -448,7 +459,8 @@ func TestRun(t *testing.T) {
 						Action:         "Try checking container logs",
 					}},
 				}, []string{
-					"Error retrieving logs for pod foo: error retrieving.\nTry `kubectl logs foo -n test -c foo-container`"},
+					"Error retrieving logs for pod foo: error retrieving.\nTry `kubectl logs foo -n test -c foo-container`",
+				},
 			)},
 		},
 		// Events Test cases
@@ -644,7 +656,8 @@ func TestRun(t *testing.T) {
 							Name:  "foo-container",
 							Image: "foo-image",
 							State: v1.ContainerState{
-								Waiting: &v1.ContainerStateWaiting{Reason: "CrashLoopBackOff",
+								Waiting: &v1.ContainerStateWaiting{
+									Reason:  "CrashLoopBackOff",
 									Message: "Back off restarting container",
 								},
 							},
@@ -680,7 +693,8 @@ func TestRun(t *testing.T) {
 							Name:  "foo-container",
 							Image: "foo-image",
 							State: v1.ContainerState{
-								Waiting: &v1.ContainerStateWaiting{Reason: "PodInitializing",
+								Waiting: &v1.ContainerStateWaiting{
+									Reason:  "PodInitializing",
 									Message: "waiting to initialize",
 								},
 							},
@@ -719,7 +733,8 @@ func TestRun(t *testing.T) {
 								Terminated: &v1.ContainerStateTerminated{ExitCode: 1, Message: "panic caused"},
 							},
 						},
-					}},
+					},
+				},
 			}},
 			logOutput: mockLogOutput{
 				output: []byte("standard_init_linux.go:219: exec user process caused: exec format error"),
@@ -752,7 +767,8 @@ func TestRun(t *testing.T) {
 								Terminated: &v1.ContainerStateTerminated{ExitCode: 1, Message: "panic caused"},
 							},
 						},
-					}},
+					},
+				},
 			}},
 		},
 	}


### PR DESCRIPTION
**Description**
- minor style changes
- create and pass test cases for [`diag.ContainerError.Make`](https://github.com/GoogleContainerTools/skaffold/blob/main/pkg/diag/recommender/container_errors.go)
- include non-pushable build artifacts in the `.gitignore`