### PR TITLE
fix: handle skaffold label in Cloud Run revision template

### DIFF
--- a/pkg/skaffold/deploy/cloudrun/deploy.go
+++ b/pkg/skaffold/deploy/cloudrun/deploy.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/skaffold/deploy/cloudrun/deploy.go
+++ b/pkg/skaffold/deploy/cloudrun/deploy.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/skaffold/deploy/cloudrun/deploy.go
+++ b/pkg/skaffold/deploy/cloudrun/deploy.go
@@ -172,11 +172,14 @@ func (d *Deployer) deployToCloudRun(ctx context.Context, out io.Writer, manifest
 		delete(service.Metadata.Labels, "skaffold.dev/run-id")
 		service.Metadata.Labels["run-id"] = runID
 	}
-	runID, foundID = service.Spec.Template.Metadata.Labels["skaffold.dev/run-id"]
-	if foundID {
-		delete(service.Spec.Template.Metadata.Labels, "skaffold.dev/run-id")
-		service.Spec.Template.Metadata.Labels["run-id"] = runID
+	if service.Spec != nil && service.Spec.Template != nil && service.Spec.Template.Metadata != nil {
+		runID, foundID = service.Spec.Template.Metadata.Labels["skaffold.dev/run-id"]
+		if foundID {
+			delete(service.Spec.Template.Metadata.Labels, "skaffold.dev/run-id")
+			service.Spec.Template.Metadata.Labels["run-id"] = runID
+		}
 	}
+
 	resName := RunResourceName{
 		Project: service.Metadata.Namespace,
 		Region:  d.Region,

--- a/pkg/skaffold/deploy/cloudrun/deploy.go
+++ b/pkg/skaffold/deploy/cloudrun/deploy.go
@@ -172,6 +172,11 @@ func (d *Deployer) deployToCloudRun(ctx context.Context, out io.Writer, manifest
 		delete(service.Metadata.Labels, "skaffold.dev/run-id")
 		service.Metadata.Labels["run-id"] = runID
 	}
+	runID, foundID = service.Spec.Template.Metadata.Labels["skaffold.dev/run-id"]
+	if foundID {
+		delete(service.Spec.Template.Metadata.Labels, "skaffold.dev/run-id")
+		service.Spec.Template.Metadata.Labels["run-id"] = runID
+	}
 	resName := RunResourceName{
 		Project: service.Metadata.Namespace,
 		Region:  d.Region,

--- a/pkg/skaffold/deploy/cloudrun/deploy_test.go
+++ b/pkg/skaffold/deploy/cloudrun/deploy_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/skaffold/deploy/cloudrun/deploy_test.go
+++ b/pkg/skaffold/deploy/cloudrun/deploy_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
**Description**

Skaffold automatically adds a label, skaffold.dev/run-id to all k8s manifests it processes. Cloud Run tries to map its labels to GCP labels, but that label id is not a valid GCP label id so it needs to be renamed in order for the deploy to succeed.

This change was already being made to service.metadata.labels, but if service.spec.template.metadata is present, Skaffold will also add the label there so it's propagated to the Cloud Run Revision resource. This change renames the label in the second location if it's present.
