### PR TITLE
feat: Add `clearCache` option for buildpacks

### DIFF
--- a/pkg/skaffold/build/buildpacks/lifecycle.go
+++ b/pkg/skaffold/build/buildpacks/lifecycle.go
@@ -48,6 +48,7 @@ var images pulledImages
 
 func (b *Builder) build(ctx context.Context, out io.Writer, a *latest.Artifact, tag string) (string, error) {
 	artifact := a.BuildpackArtifact
+	clearCache := artifact.ClearCache
 	workspace := a.Workspace
 
 	// Read `project.toml` if it exists.
@@ -105,6 +106,7 @@ func (b *Builder) build(ctx context.Context, out io.Writer, a *latest.Artifact, 
 		Image:           latest,
 		PullPolicy:      pullPolicy,
 		TrustBuilder:    func(_ string) bool { return artifact.TrustBuilder },
+		ClearCache:      clearCache,
 		ContainerConfig: cc,
 		// TODO(dgageot): Support project.toml include/exclude.
 		// FileFilter: func(string) bool { return true },

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -1091,6 +1091,10 @@ type BuildpackArtifact struct {
 	// TrustBuilder indicates that the builder should be trusted.
 	TrustBuilder bool `yaml:"trustBuilder,omitempty"`
 
+	// Removes old cache volume associated with the specific image
+	// and supplies a clean cache volume for build
+	ClearCache bool `yaml:"clearCache,omitempty"`
+
 	// ProjectDescriptor is the path to the project descriptor file.
 	// Defaults to `project.toml` if it exists.
 	ProjectDescriptor string `yaml:"projectDescriptor,omitempty"`


### PR DESCRIPTION
Fixes: #7346

**Description**

Adds a `clearCache` flag for buildpacks. See issue description for additional context.

**User facing changes**

Users now should be able to set `clearCache` flag in yaml like this

``` yaml
...
...
build:
  artifacts:
  - image: skaffold-buildpacks-node
    buildpacks:
      builder: "gcr.io/buildpacks/builder:v1"
      trustBuilder: true
      clearCache: true 
...
```

**Follow-up Work**

- Mentioning feature in docs
- Potentially including an example

