### PR TITLE
fix: skaffold render correct output when using helm renderer

### DIFF
--- a/pkg/skaffold/render/renderer/renderer.go
+++ b/pkg/skaffold/render/renderer/renderer.go
@@ -39,8 +39,8 @@ type Renderer interface {
 }
 
 // New creates a new Renderer object from the latestV2 API schema.
-func New(cfg render.Config, renderCfg latest.RenderConfig, hydrationDir string, labels map[string]string, usingLegacyHelmDeploy bool, configName string) (Renderer, error) {
-	if usingLegacyHelmDeploy {
+func New(cfg render.Config, renderCfg latest.RenderConfig, hydrationDir string, labels map[string]string, usingLegacyHelmDeploy bool, command string, configName string) (Renderer, error) {
+	if usingLegacyHelmDeploy && command != "render" {
 		return noop.New(renderCfg, cfg.GetWorkingDir(), hydrationDir, labels)
 	}
 	if renderCfg.Validate == nil && renderCfg.Transform == nil && renderCfg.Helm != nil {

--- a/pkg/skaffold/runner/renderer.go
+++ b/pkg/skaffold/runner/renderer.go
@@ -29,7 +29,7 @@ func GetRenderer(ctx context.Context, runCtx *runcontext.RunContext, hydrationDi
 
 	var renderers []renderer.Renderer
 	for configName, p := range ps {
-		r, err := renderer.New(runCtx, p.Render, hydrationDir, labels, usingLegacyHelmDeploy, configName)
+		r, err := renderer.New(runCtx, p.Render, hydrationDir, labels, usingLegacyHelmDeploy, runCtx.Opts.Command, configName)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Fixes an issue where currently if `skaffold render` with a V2 skaffold binary is run against a v2beta* skaffold.yaml file, it outputs the empty string when it should instead output the rendered manifests.  This will break anyone using the helm deployer w/ `skaffold render` + `skaffold apply` workflows (eg: cd, etc).  This error is because prior to this PR, this if statement was being triggered:
https://github.com/GoogleContainerTools/skaffold/blob/main/pkg/skaffold/render/renderer/renderer.go#L43-L45
```
	if usingLegacyHelmDeploy {
		return noop.New(renderCfg, cfg.GetWorkingDir(), hydrationDir, labels)
	}
```
causing the noop renderer to be used when the helm renderer should be used.  This PR makes it so that the clause is now:
```
	if usingLegacyHelmDeploy && command != "render" {
		return noop.New(renderCfg, cfg.GetWorkingDir(), hydrationDir, labels)
	}
```
which fixes the `render` -> `apply` use case for users migrating from V1 -> V2 (which is broken atm)