### PR TITLE
fix: default to builder supported platform with a warning instead of erroring

### DIFF
--- a/pkg/skaffold/build/local/local.go
+++ b/pkg/skaffold/build/local/local.go
@@ -18,7 +18,6 @@ package local
 
 import (
 	"context"
-	"fmt"
 	"io"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
@@ -114,7 +113,8 @@ func (b *Builder) runBuildForArtifact(ctx context.Context, out io.Writer, a *lat
 		if p := platforms.Intersect(supported); p.IsNotEmpty() {
 			platforms = p
 		} else {
-			return "", fmt.Errorf("builder for artifact %q doesn't support building for target platforms: %q. Supported platforms are %q", a.ImageName, platforms, supported)
+			log.Entry(ctx).Warnf("builder for artifact %q doesn't support building for target platforms: %q. Building for supported platforms %q instead.", a.ImageName, platforms, supported)
+			platforms = supported
 		}
 	}
 	return builder.Build(ctx, out, a, tag, platforms)


### PR DESCRIPTION
Using Skaffold with the `buildpacks` builder on an M1 Mac against the `minikube` cluster, there are two scenarios:
1. User specifies the platform explicitly using `--platform=linux/amd64`.
This was previously erroring out, due to Skaffold disallowing builds for a platform that doesn't match the active kubernetes cluster nodes. However, local clusters like `minikube` and `docker-desktop` on Apple M1 can run `linux/amd64` images using `qemu binfmt_misc extensions`. So we changed this error condition to a warning message instead in #7402.

2. Users don't specify platform explicitly
In this case Skaffold selects the platform `linux/arm64` based on the active kubernetes cluster node platform type. However, since `buildpacks` doesn't support building for this platform the build fails. We instead change this to a warning message and select the builder supported platforms instead. **This is fixed in this PR.**