### PR TITLE
fix: examples/* to use go 1.18 (vs 1.15) to match integration/examples and fix breakages

### DIFF
--- a/examples/compose/Dockerfile
+++ b/examples/compose/Dockerfile
@@ -1,8 +1,10 @@
-FROM golang:1.15 as builder
+FROM golang:1.18 as builder
+WORKDIR /code
 COPY main.go .
+COPY go.mod .
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
-RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app main.go
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app main.go
 
 FROM alpine:3
 # Define GOTRACEBACK to mark this container as using the Go language runtime

--- a/examples/compose/go.mod
+++ b/examples/compose/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/examples/compose
+
+go 1.18

--- a/examples/cross-platform-builds/Dockerfile
+++ b/examples/cross-platform-builds/Dockerfile
@@ -1,10 +1,12 @@
-FROM --platform=$BUILDPLATFORM golang:1.15 as builder
+FROM --platform=$BUILDPLATFORM golang:1.18 as builder
+WORKDIR /code
 COPY main.go .
+COPY go.mod .
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG TARGETOS
 ARG TARGETARCH
 ARG SKAFFOLD_GO_GCFLAGS
-RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app main.go
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app main.go
 
 FROM alpine:3
 # Define GOTRACEBACK to mark this container as using the Go language runtime

--- a/examples/cross-platform-builds/go.mod
+++ b/examples/cross-platform-builds/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/examples/cross-platform-builds
+
+go 1.18

--- a/examples/custom-buildx/Dockerfile
+++ b/examples/custom-buildx/Dockerfile
@@ -5,13 +5,15 @@
 # TARGET{PLATFORM,OS,ARCH} are set to the desired platform
 FROM --platform=$BUILDPLATFORM golang:alpine AS builder
 
+WORKDIR /code
 COPY main.go .
+COPY go.mod .
 
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
 ARG TARGETOS
 ARG TARGETARCH
-RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app main.go
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app main.go
 
 FROM alpine:3
 # Define GOTRACEBACK to mark this container as using the Go language runtime

--- a/examples/custom-tests/Dockerfile
+++ b/examples/custom-tests/Dockerfile
@@ -1,8 +1,10 @@
-FROM golang:1.15 as builder
+FROM golang:1.18 as builder
+WORKDIR /code
 COPY main.go .
+COPY go.mod .
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
-RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app main.go
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app main.go
 
 FROM alpine:3
 # Define GOTRACEBACK to mark this container as using the Go language runtime

--- a/examples/custom-tests/go.mod
+++ b/examples/custom-tests/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/examples/custom-tests
+
+go 1.18

--- a/examples/docker-deploy/bert/Dockerfile
+++ b/examples/docker-deploy/bert/Dockerfile
@@ -1,8 +1,10 @@
-FROM golang:1.15 as builder
+FROM golang:1.18 as builder
+WORKDIR /code
 COPY main.go .
+COPY go.mod .
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
-RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app main.go
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app main.go
 
 FROM alpine:3.10
 # Define GOTRACEBACK to mark this container as using the Go language runtime

--- a/examples/docker-deploy/bert/go.mod
+++ b/examples/docker-deploy/bert/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/examples/docker-deploy/bert
+
+go 1.18

--- a/examples/docker-deploy/ernie/Dockerfile
+++ b/examples/docker-deploy/ernie/Dockerfile
@@ -1,8 +1,10 @@
-FROM golang:1.15 as builder
+FROM golang:1.18 as builder
+WORKDIR /code
 COPY main.go .
+COPY go.mod .
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
-RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app main.go
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app main.go
 
 FROM alpine:3.10
 # Define GOTRACEBACK to mark this container as using the Go language runtime

--- a/examples/docker-deploy/ernie/go.mod
+++ b/examples/docker-deploy/ernie/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/examples/docker-deploy/ernie
+
+go 1.18

--- a/examples/gcb-kaniko/Dockerfile
+++ b/examples/gcb-kaniko/Dockerfile
@@ -1,8 +1,10 @@
-FROM golang:1.15 as builder
+FROM golang:1.18 as builder
+WORKDIR /code
 COPY main.go .
+COPY go.mod .
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
-RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app main.go
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app main.go
 
 FROM alpine:3
 # Define GOTRACEBACK to mark this container as using the Go language runtime

--- a/examples/gcb-kaniko/go.mod
+++ b/examples/gcb-kaniko/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/examples/gcb-kaniko
+
+go 1.18

--- a/examples/generate-pipeline/Dockerfile
+++ b/examples/generate-pipeline/Dockerfile
@@ -1,8 +1,10 @@
-FROM golang:1.15 as builder
+FROM golang:1.18 as builder
+WORKDIR /code
 COPY main.go .
+COPY go.mod .
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
-RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app main.go
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app main.go
 
 FROM alpine:3
 # Define GOTRACEBACK to mark this container as using the Go language runtime

--- a/examples/generate-pipeline/go.mod
+++ b/examples/generate-pipeline/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/examples/generate-pipeline
+
+go 1.18

--- a/examples/getting-started-kustomize/app/Dockerfile
+++ b/examples/getting-started-kustomize/app/Dockerfile
@@ -1,8 +1,10 @@
-FROM golang:1.15 as builder
+FROM golang:1.18 as builder
+WORKDIR /code
 COPY main.go .
+COPY go.mod .
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
-RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app main.go
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app main.go
 
 FROM alpine:3.10
 # Define GOTRACEBACK to mark this container as using the Go language runtime

--- a/examples/getting-started-kustomize/app/go.mod
+++ b/examples/getting-started-kustomize/app/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/examples/getting-started-kustomize
+
+go 1.18

--- a/examples/getting-started/Dockerfile
+++ b/examples/getting-started/Dockerfile
@@ -1,8 +1,10 @@
-FROM golang:1.15 as builder
+FROM golang:1.18 as builder
+WORKDIR /code
 COPY main.go .
+COPY go.mod .
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
-RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app main.go
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app main.go
 
 FROM alpine:3
 # Define GOTRACEBACK to mark this container as using the Go language runtime

--- a/examples/getting-started/go.mod
+++ b/examples/getting-started/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/examples/getting-started
+
+go 1.18

--- a/examples/google-cloud-build/Dockerfile
+++ b/examples/google-cloud-build/Dockerfile
@@ -1,8 +1,10 @@
-FROM golang:1.15 as builder
+FROM golang:1.18 as builder
+WORKDIR /code
 COPY main.go .
+COPY go.mod .
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
-RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app main.go
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app main.go
 
 FROM alpine:3
 # Define GOTRACEBACK to mark this container as using the Go language runtime

--- a/examples/google-cloud-build/go.mod
+++ b/examples/google-cloud-build/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/examples/google-cloud-build
+
+go 1.18

--- a/examples/helm-deployment/Dockerfile
+++ b/examples/helm-deployment/Dockerfile
@@ -1,8 +1,10 @@
-FROM golang:1.15 as builder
+FROM golang:1.18 as builder
+WORKDIR /code
 COPY main.go .
+COPY go.mod .
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
-RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app main.go
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app main.go
 
 FROM alpine:3.10
 # Define GOTRACEBACK to mark this container as using the Go language runtime

--- a/examples/helm-deployment/go.mod
+++ b/examples/helm-deployment/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/examples/helm-deployment
+
+go 1.18

--- a/examples/kaniko/Dockerfile
+++ b/examples/kaniko/Dockerfile
@@ -1,8 +1,10 @@
-FROM golang:1.15 as builder
+FROM golang:1.18 as builder
+WORKDIR /code
 COPY main.go .
+COPY go.mod .
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
-RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app main.go
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app main.go
 
 FROM alpine:3
 # Define GOTRACEBACK to mark this container as using the Go language runtime

--- a/examples/kaniko/go.mod
+++ b/examples/kaniko/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/examples/kaniko
+
+go 1.18

--- a/examples/lifecycle-hooks/Dockerfile
+++ b/examples/lifecycle-hooks/Dockerfile
@@ -1,8 +1,10 @@
-FROM golang:1.15 as builder
+FROM golang:1.18 as builder
+WORKDIR /code
 COPY main.go .
+COPY go.mod .
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
-RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app main.go
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app main.go
 
 FROM alpine:3
 # Define GOTRACEBACK to mark this container as using the Go language runtime

--- a/examples/lifecycle-hooks/go.mod
+++ b/examples/lifecycle-hooks/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/examples/lifecycle-hooks
+
+go 1.18

--- a/examples/microservices/leeroy-app/Dockerfile
+++ b/examples/microservices/leeroy-app/Dockerfile
@@ -1,9 +1,11 @@
 ARG BASE
-FROM golang:1.15 as builder
+FROM golang:1.18 as builder
+WORKDIR /code
 COPY app.go .
+COPY go.mod .
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
-RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app .
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app .
 
 FROM $BASE
 COPY --from=builder /app .

--- a/examples/microservices/leeroy-app/go.mod
+++ b/examples/microservices/leeroy-app/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/examples/microservices/leeroy-app
+
+go 1.18

--- a/examples/microservices/leeroy-web/Dockerfile
+++ b/examples/microservices/leeroy-web/Dockerfile
@@ -1,9 +1,11 @@
 ARG BASE
-FROM golang:1.15 as builder
+FROM golang:1.18 as builder
+WORKDIR /code
 COPY web.go .
+COPY go.mod .
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
-RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app .
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app .
 
 FROM $BASE
 COPY --from=builder /app .

--- a/examples/microservices/leeroy-web/go.mod
+++ b/examples/microservices/leeroy-web/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/examples/microservices/leeroy-web
+
+go 1.18

--- a/examples/multi-config-microservices/leeroy-app/Dockerfile
+++ b/examples/multi-config-microservices/leeroy-app/Dockerfile
@@ -1,9 +1,11 @@
 ARG BASE
-FROM golang:1.15 as builder
+FROM golang:1.18 as builder
+WORKDIR /code
 COPY app.go .
+COPY go.mod .
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
-RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app .
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app .
 
 FROM $BASE
 COPY --from=builder /app .

--- a/examples/multi-config-microservices/leeroy-app/go.mod
+++ b/examples/multi-config-microservices/leeroy-app/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/examples/multi-config-microservices/leeroy-app
+
+go 1.18

--- a/examples/multi-config-microservices/leeroy-web/Dockerfile
+++ b/examples/multi-config-microservices/leeroy-web/Dockerfile
@@ -1,9 +1,11 @@
 ARG BASE
-FROM golang:1.15 as builder
+FROM golang:1.18 as builder
+WORKDIR /code
 COPY web.go .
+COPY go.mod .
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
-RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app .
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app .
 
 FROM $BASE
 COPY --from=builder /app .

--- a/examples/multi-config-microservices/leeroy-web/go.mod
+++ b/examples/multi-config-microservices/leeroy-web/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/examples/multi-config-microservices/leeroy-web
+
+go 1.18

--- a/examples/profile-patches/base-service/Dockerfile
+++ b/examples/profile-patches/base-service/Dockerfile
@@ -1,8 +1,10 @@
-FROM golang:1.15 as builder
+FROM golang:1.18 as builder
+WORKDIR /code
 COPY main.go .
+COPY go.mod .
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
-RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app main.go
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app main.go
 
 FROM alpine:3
 # Define GOTRACEBACK to mark this container as using the Go language runtime

--- a/examples/profile-patches/base-service/go.mod
+++ b/examples/profile-patches/base-service/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/examples/profile-patches/base-service
+
+go 1.18

--- a/examples/profile-patches/hello-service/Dockerfile
+++ b/examples/profile-patches/hello-service/Dockerfile
@@ -1,8 +1,10 @@
-FROM golang:1.15 as builder
+FROM golang:1.18 as builder
+WORKDIR /code
 COPY main.go .
+COPY go.mod .
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
-RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app main.go
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app main.go
 
 FROM alpine:3
 # Define GOTRACEBACK to mark this container as using the Go language runtime

--- a/examples/profile-patches/hello-service/go.mod
+++ b/examples/profile-patches/hello-service/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/examples/profile-patches/hello-service
+
+go 1.18

--- a/examples/profile-patches/world-service/Dockerfile
+++ b/examples/profile-patches/world-service/Dockerfile
@@ -1,8 +1,10 @@
-FROM golang:1.15 as builder
+FROM golang:1.18 as builder
+WORKDIR /code
 COPY main.go .
+COPY go.mod .
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
-RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app main.go
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app main.go
 
 FROM alpine:3
 # Define GOTRACEBACK to mark this container as using the Go language runtime

--- a/examples/profile-patches/world-service/go.mod
+++ b/examples/profile-patches/world-service/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/examples/profile-patches/world-service
+
+go 1.18

--- a/examples/profiles/hello-service/Dockerfile
+++ b/examples/profiles/hello-service/Dockerfile
@@ -1,8 +1,10 @@
-FROM golang:1.15 as builder
+FROM golang:1.18 as builder
+WORKDIR /code
 COPY main.go .
+COPY go.mod .
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
-RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app main.go
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app main.go
 
 FROM alpine:3
 # Define GOTRACEBACK to mark this container as using the Go language runtime

--- a/examples/profiles/hello-service/go.mod
+++ b/examples/profiles/hello-service/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/examples/profiles/hello-service
+
+go 1.18

--- a/examples/profiles/world-service/Dockerfile
+++ b/examples/profiles/world-service/Dockerfile
@@ -1,8 +1,10 @@
-FROM golang:1.15 as builder
+FROM golang:1.18 as builder
+WORKDIR /code
 COPY main.go .
+COPY go.mod .
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
-RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app main.go
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app main.go
 
 FROM alpine:3
 # Define GOTRACEBACK to mark this container as using the Go language runtime

--- a/examples/profiles/world-service/go.mod
+++ b/examples/profiles/world-service/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/examples/profiles/world-service
+
+go 1.18

--- a/examples/simple-artifact-dependency/app/Dockerfile
+++ b/examples/simple-artifact-dependency/app/Dockerfile
@@ -1,9 +1,11 @@
 ARG BASE
-FROM golang:1.15 as builder
+FROM golang:1.18 as builder
+WORKDIR /code
 COPY main.go .
+COPY go.mod .
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
-RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app .
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app .
 
 FROM $BASE
 # Define GOTRACEBACK to mark this container as using the Go language runtime

--- a/examples/simple-artifact-dependency/app/go.mod
+++ b/examples/simple-artifact-dependency/app/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/examples/simple-artifact-dependency
+
+go 1.18

--- a/examples/structure-tests/Dockerfile
+++ b/examples/structure-tests/Dockerfile
@@ -1,8 +1,10 @@
-FROM golang:1.15 as builder
+FROM golang:1.18 as builder
+WORKDIR /code
 COPY main.go .
+COPY go.mod .
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
-RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app main.go
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app main.go
 
 FROM alpine:3
 # Define GOTRACEBACK to mark this container as using the Go language runtime

--- a/examples/structure-tests/go.mod
+++ b/examples/structure-tests/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/examples/structure-tests
+
+go 1.18

--- a/examples/tagging-with-environment-variables/Dockerfile
+++ b/examples/tagging-with-environment-variables/Dockerfile
@@ -1,8 +1,10 @@
-FROM golang:1.15 as builder
+FROM golang:1.18 as builder
+WORKDIR /code
 COPY main.go .
+COPY go.mod .
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
-RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app main.go
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app main.go
 
 FROM alpine:3
 # Define GOTRACEBACK to mark this container as using the Go language runtime

--- a/examples/tagging-with-environment-variables/go.mod
+++ b/examples/tagging-with-environment-variables/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/examples/tagging-with-environment-variable
+
+go 1.18


### PR DESCRIPTION
examples/lifecycle-hooks currenlty is broken @ HEAD:
```
aprindle@aprindle ~/skaffold/examples/lifecycle-hooks  [main]$ skaffold build --file-output build.artifacts --default-repo=gcr.io/aprindle-test-cluster
Generating tags...
 - hooks-example -> gcr.io/aprindle-test-cluster/hooks-example:v1.38.0-142-g12d9a22d6
Checking cache...
 - hooks-example: Not found. Building
Starting build...
Building [hooks-example]...
Starting pre-build hooks...
Build specification:
    DefaultRepo:    gcr.io/aprindle-test-cluster
    MultiLevelRepo: 
    RPCPort:        
    HTTPPort:       
    WorkDir:        /usr/local/google/home/aprindle/skaffold/examples/lifecycle-hooks
    Image:          gcr.io/aprindle-test-cluster/hooks-example:v1.38.0-142-g12d9a22d6
    PushImage:      true
    ImageRepo:      gcr.io/aprindle-test-cluster
    ImageTag:       v1.38.0-142-g12d9a22d6
    BuildContext:   /usr/local/google/home/aprindle/skaffold/examples/lifecycle-hooks
Completed pre-build hooks
Sending build context to Docker daemon  4.608kB
Step 1/9 : FROM golang:1.15 as builder
 ---> 40349a2425ef
Step 2/9 : COPY main.go .
 ---> 950a3b34c264
Step 3/9 : ARG SKAFFOLD_GO_GCFLAGS
 ---> Running in ff9a3acb5cad
 ---> fa89a6aa34ed
Step 4/9 : RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app main.go
 ---> Running in 4148658e3f1b
# command-line-arguments
./main.go:14:15: undefined: os.ReadFile
./main.go:21:16: undefined: os.ReadFile
docker build failure: The command '/bin/sh -c go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app main.go' returned a non-zero code: 2. Please fix the Dockerfile and try again..
```

This is a result of a regexp replace that removed ioutil.Readfile -> os.Readfile only this example uses go 1.15 which doesn't support this.  This PR changes the go version to be go 1.17 (used in CI) to no longer fail on build 