### PR TITLE
use absolute paths to the container_image.tar in bazel build.

### DIFF
--- a/pkg/skaffold/build/bazel/build.go
+++ b/pkg/skaffold/build/bazel/build.go
@@ -85,7 +85,7 @@ func (b *Builder) buildTar(ctx context.Context, out io.Writer, workspace string,
 		return "", fmt.Errorf("getting bazel tar path: %w", err)
 	}
 
-	return filepath.Join(workspace, tarPath), nil
+	return tarPath, nil
 }
 
 func (b *Builder) loadImage(ctx context.Context, out io.Writer, tarPath string, a *latest.BazelArtifact, tag string) (string, error) {
@@ -129,7 +129,19 @@ func bazelTarPath(ctx context.Context, workspace string, a *latest.BazelArtifact
 		return "", err
 	}
 
-	return strings.TrimSpace(string(buf)), nil
+	targetPath := strings.TrimSpace(string(buf))
+
+	cmd = exec.CommandContext(ctx, "bazel", "info", "execution_root")
+	cmd.Dir = workspace
+
+	buf, err = util.RunCmdOut(ctx, cmd)
+	if err != nil {
+		return "", err
+	}
+
+	execRoot := strings.TrimSpace(string(buf))
+
+	return filepath.Join(execRoot, targetPath), nil
 }
 
 func trimTarget(buildTarget string) string {

--- a/pkg/skaffold/build/bazel/build_test.go
+++ b/pkg/skaffold/build/bazel/build_test.go
@@ -33,7 +33,7 @@ func TestBuildBazel(t *testing.T) {
 		t.NewTempDir().Mkdir("bin").Chdir()
 		t.Override(&util.DefaultExecCommand, testutil.CmdRun("bazel build //:app.tar --color=no").AndRunOut(
 			"bazel cquery //:app.tar --output starlark --starlark:expr target.files.to_list()[0].path",
-			"bin/app.tar"))
+			"bin/app.tar").AndRunOut("bazel info execution_root", ""))
 		testutil.CreateFakeImageTar("bazel:app", "bin/app.tar")
 
 		artifact := &latest.Artifact{
@@ -52,11 +52,11 @@ func TestBuildBazel(t *testing.T) {
 	})
 }
 
-func TestBazelTarPathFRespectWorkspace(t *testing.T) {
+func TestBazelTarPathPrependExecutionRoot(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
 		t.Override(&util.DefaultExecCommand, testutil.CmdRun("bazel build //:app.tar --color=no").AndRunOut(
 			"bazel cquery //:app.tar --output starlark --starlark:expr target.files.to_list()[0].path",
-			"app.tar"))
+			"app.tar").AndRunOut("bazel info execution_root", ".."))
 		testutil.CreateFakeImageTar("bazel:app", "../app.tar")
 
 		artifact := &latest.Artifact{
@@ -93,11 +93,11 @@ func TestBuildBazelFailInvalidTarget(t *testing.T) {
 }
 
 func TestBazelTarPath(t *testing.T) {
-	testutil.Run(t, "", func(t *testutil.T) {
+	testutil.Run(t, "EmptyExecutionRoot", func(t *testutil.T) {
 		t.Override(&util.DefaultExecCommand, testutil.CmdRunOut(
 			"bazel cquery //:skaffold_example.tar --output starlark --starlark:expr target.files.to_list()[0].path --arg1 --arg2",
 			"/absolute/path/bin\n",
-		))
+		).AndRunOut("bazel info execution_root", ""))
 
 		bazelBin, err := bazelTarPath(context.Background(), ".", &latest.BazelArtifact{
 			BuildArgs:   []string{"--arg1", "--arg2"},
@@ -106,6 +106,20 @@ func TestBazelTarPath(t *testing.T) {
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual("/absolute/path/bin", bazelBin)
+	})
+	testutil.Run(t, "AbsoluteExecutionRoot", func(t *testutil.T) {
+		t.Override(&util.DefaultExecCommand, testutil.CmdRunOut(
+			"bazel cquery //:skaffold_example.tar --output starlark --starlark:expr target.files.to_list()[0].path --arg1 --arg2",
+			"bazel-bin/darwin-fastbuild-ST-confighash/path/to/bin\n",
+		).AndRunOut("bazel info execution_root", "/var/tmp/bazel-execution-roots/abcdefg/execroot/workspace_name"))
+
+		bazelBin, err := bazelTarPath(context.Background(), ".", &latest.BazelArtifact{
+			BuildArgs:   []string{"--arg1", "--arg2"},
+			BuildTarget: "//:skaffold_example.tar",
+		})
+
+		t.CheckNoError(err)
+		t.CheckDeepEqual("/var/tmp/bazel-execution-roots/abcdefg/execroot/workspace_name/bazel-bin/darwin-fastbuild-ST-confighash/path/to/bin", bazelBin)
 	})
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #7600
**Related**: #7251, #7281, #7430

**Description**

This PR changes the bazel build task to get an absolute path to the built container image. The correct path is the concatenation of the bazel `execution_root` and the result of the cquery for the output path of the configured target.

As per #7600, the current approach is broken if workspace symlinks are disabled. It's actually also broken if workspace symlinks are anything other than `bazel-`. The current approach is also broken if `skaffold.yaml` is not in the workspace root and `Artifact.Workspace` does not refer to the directory that contains the workspace symlinks. Previously, the `Artifact.Workspace` did not need to refer to the root of the workspace for a bazel build target, since the target can be an absolute path and it will build regardless of where bazel is invoked.

I believe using the absolute path is more robust and handles more use cases than the current approach.

**User facing changes**

* skaffold bazel builds and pushes with `--symlink_prefix` passed to bazel will work.
* skaffold bazel builds and pushes in directories that are not the root of the bazel workspace and where `context:` is not set to navigate to the root of the bazel workspace will work.
