### PR TITLE
chore: update skaffold deps image dependencies to latest approved releases 

### DIFF
--- a/deploy/skaffold/Dockerfile.deps
+++ b/deploy/skaffold/Dockerfile.deps
@@ -17,9 +17,9 @@ ARG ARCH=amd64
 # Download kubectl
 FROM alpine:3.10 as download-kubectl
 ARG ARCH
-# Track default version installed by Google Cloud SDK: 358.0.0 moved to 1.20(.10)
+# Track default version installed by Google Cloud SDK: 393.0.0 moved to 1.22(.12)
 # https://cloud.google.com/sdk/docs/release-notes
-ENV KUBECTL_VERSION v1.20.10
+ENV KUBECTL_VERSION v1.22.12
 ENV KUBECTL_URL https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl
 # SHAs at gs://kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/
 COPY deploy/skaffold/digests/kubectl.${ARCH}.sha512 .
@@ -30,7 +30,7 @@ RUN chmod +x kubectl
 FROM alpine:3.10 as download-helm
 ARG ARCH
 RUN echo arch=$ARCH
-ENV HELM_VERSION v3.8.0
+ENV HELM_VERSION v3.9.2
 ENV HELM_URL https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz
 COPY deploy/skaffold/digests/helm.${ARCH}.sha256 .
 RUN wget -O helm.tar.gz "${HELM_URL}" && sha256sum -c helm.${ARCH}.sha256
@@ -93,7 +93,7 @@ RUN chmod +x k3d
 # Download gcloud
 FROM alpine:3.10 as download-gcloud
 ARG ARCH
-ENV GCLOUD_VERSION 360.0.0
+ENV GCLOUD_VERSION 393.0.0
 ENV GCLOUD_URL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GCLOUD_VERSION}-linux-GCLOUDARCH.tar.gz
 # SHAs listed at https://cloud.google.com/sdk/docs/downloads-versioned-archives
 COPY deploy/skaffold/digests/gcloud.${ARCH}.sha256 .

--- a/deploy/skaffold/Dockerfile.deps.lts
+++ b/deploy/skaffold/Dockerfile.deps.lts
@@ -17,9 +17,9 @@ ARG ARCH=amd64
 # Download kubectl
 FROM alpine:3.10 as download-kubectl
 ARG ARCH
-# Track default version installed by Google Cloud SDK: 358.0.0 moved to 1.20(.10)
+# Track default version installed by Google Cloud SDK: 393.0.0 moved to 1.22(.12)
 # https://cloud.google.com/sdk/docs/release-notes
-ENV KUBECTL_VERSION v1.20.10
+ENV KUBECTL_VERSION v1.22.12
 ENV KUBECTL_URL https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl
 # SHAs at gs://kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/
 COPY deploy/skaffold/digests/kubectl.${ARCH}.sha512 .
@@ -30,7 +30,7 @@ RUN chmod +x kubectl
 FROM alpine:3.10 as download-helm
 ARG ARCH
 RUN echo arch=$ARCH
-ENV HELM_VERSION v3.8.0
+ENV HELM_VERSION v3.9.2
 ENV HELM_URL https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz
 COPY deploy/skaffold/digests/helm.${ARCH}.sha256 .
 RUN wget -O helm.tar.gz "${HELM_URL}" && sha256sum -c helm.${ARCH}.sha256
@@ -57,7 +57,7 @@ RUN chmod +x kpt
 # Download gcloud
 FROM alpine:3.10 as download-gcloud
 ARG ARCH
-ENV GCLOUD_VERSION 360.0.0
+ENV GCLOUD_VERSION 393.0.0
 ENV GCLOUD_URL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GCLOUD_VERSION}-linux-GCLOUDARCH.tar.gz
 # SHAs listed at https://cloud.google.com/sdk/docs/downloads-versioned-archives
 COPY deploy/skaffold/digests/gcloud.${ARCH}.sha256 .


### PR DESCRIPTION
bump skaffold docker image deps to be up date (1.39.1 branch)