### PR TITLE
chore: support `artifactOverrides` schema functionality from v2beta* in v3alpha* via `setValue*`

### DIFF
--- a/examples/templated-fields/charts/values.yaml
+++ b/examples/templated-fields/charts/values.yaml
@@ -2,3 +2,4 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 replicaCount: 2
+image: skaffold-templated

--- a/examples/templated-fields/skaffold.yaml
+++ b/examples/templated-fields/skaffold.yaml
@@ -16,8 +16,6 @@ deploy:
     releases:
     - name: skaffold-templated
       chartPath: charts
-      artifactOverrides:
-        image: skaffold-templated
       setValueTemplates:
         imageRepo: "{{.IMAGE_REPO}}"
         imageTag: "{{.IMAGE_TAG}}"

--- a/pkg/skaffold/helm/args.go
+++ b/pkg/skaffold/helm/args.go
@@ -130,5 +130,9 @@ func envVarForImage(imageName string, digest string) map[string]string {
 	} else {
 		customMap["DIGEST_HEX"] = digest
 	}
+
+	// IMAGE_DOMAIN and IMAGE_REPO_NO_DOMAIN added for v2beta* 'helm+explicitRegistry' -> v3alpha* compatibility
+	customMap["IMAGE_DOMAIN"] = ref.Domain
+	customMap["IMAGE_REPO_NO_DOMAIN"] = strings.TrimPrefix(ref.BaseName, ref.Domain+"/")
 	return customMap
 }

--- a/pkg/skaffold/schema/v2beta29/upgrade.go
+++ b/pkg/skaffold/schema/v2beta29/upgrade.go
@@ -87,6 +87,43 @@ func upgradeOnePipeline(oldPipeline, newPipeline interface{}) error {
 		newPL.Render.Helm.Releases = newHelm.Releases
 		newPL.Render.Helm.Flags = newHelm.Flags
 
+		// Copy over removed artifactOverrides & imageStrategy field as identical setValues fields
+		for i := 0; i < len(newPL.Render.Helm.Releases); i++ {
+			// need to append, not override
+			svs := map[string]string(oldPL.Deploy.HelmDeploy.Releases[i].SetValues)
+			svts := map[string]string(oldPL.Deploy.HelmDeploy.Releases[i].SetValueTemplates)
+			aos := map[string]string(oldPL.Deploy.HelmDeploy.Releases[i].ArtifactOverrides)
+			if aos != nil && svs == nil {
+				svs = map[string]string{}
+			}
+			if oldPL.Deploy.HelmDeploy.Releases[i].ImageStrategy.HelmConventionConfig != nil {
+				// is 'helm' imageStrategy
+				for k, v := range aos {
+					if k == "image" {
+						if svts == nil {
+							svts = map[string]string{}
+						}
+						svts["image.tag"] = "{{.IMAGE_TAG}}@{{.IMAGE_DIGEST}}"
+						svts["image.repository"] = "{{.IMAGE_REPO}}"
+						if oldPL.Deploy.HelmDeploy.Releases[i].ImageStrategy.HelmConventionConfig.ExplicitRegistry {
+							// is 'helm' imageStrategy + explicitRegistry
+							svts["image.registry"] = "{{.IMAGE_DOMAIN}}"
+							svts["image.repository"] = "{{.IMAGE_REPO_NO_DOMAIN}}"
+						}
+						continue
+					}
+					svs[k] = v
+				}
+			} else {
+				// is 'fqn' imageStrategy
+				for k, v := range aos {
+					svs[k] = v
+				}
+			}
+			newPL.Render.Helm.Releases[i].SetValues = svs
+			newPL.Render.Helm.Releases[i].SetValueTemplates = svts
+		}
+
 		// Copy over lifecyle hooks for helm deployer
 		newPL.Deploy.LegacyHelmDeploy = &next.LegacyHelmDeploy{}
 		newPL.Deploy.LegacyHelmDeploy.LifecycleHooks = newHelm.LifecycleHooks


### PR DESCRIPTION
Fixes #7668 

Fixes https://github.com/GoogleContainerTools/skaffold/issues/6952
Uses the suggestion recommended by @briandealwis in the issue above to migrate `artifactOverrides` configuration to similar `setValues` and `setValueTemplates` configurations.  

Prior to this PR, users using `artifactOverrides` with v2beta* would have their projects broken as `artifactOverrides` config was dropped going v2beta* -> v3alpha1.  This PR parses the v2beta* `artifactsOverrides` and converts it to appropriate `setValues` and `setValueTemplates` config which v3alpha1 supports.  There still might be some possible errors with the currently implementation related to the error mentioned in the issue:
```
This may be a breaking change as some users may have been using image defaults that don't correspond to the image names in the build.artifacts[].image and so their deployments may cease to work.
```
```
 We could invoke helm template and then look for matched and unmatched image names. If we found mismatches, Skaffold could warn[or fail with error] the user or abort the upgrade and direct them to do a manual upgrade.
```
I will make a separate issue tracking the above case which still needs to be accounted for but this way the majority of `artifactOverrides` users will not be broken in the migration and won't have to manually update their `skaffold.yaml`

EDIT: Related to above ^^^^ statement.  Talked offline w/ Brian, the error referenced above would be an ongoing error and NOT a regression.  He is happy with the approach here and the above issue is not high priority (no regression)

NOTE: The changes to examples/templated-fields in this PR were lost when rebasing the v2 branch onto main from https://github.com/GoogleContainerTools/skaffold/issues/6952 and that is why they are added back here