### PR TITLE
docs: helm render docs and few fixes

### DIFF
--- a/docs-v2/content/en/docs/pipeline-stages/deployers/docker.md
+++ b/docs-v2/content/en/docs/pipeline-stages/deployers/docker.md
@@ -1,7 +1,7 @@
 ---
 title: "Docker"
 linkTitle: "Docker"
-weight: 20
+weight: 50
 featureId: deploy.docker
 ---
 

--- a/docs-v2/content/en/docs/pipeline-stages/renderers/helm.md
+++ b/docs-v2/content/en/docs/pipeline-stages/renderers/helm.md
@@ -5,6 +5,50 @@ weight: 40
 featureId: render
 ---
 
+[`helm`](https://helm.sh/) is a package manager for Kubernetes that helps you
+manage Kubernetes applications. Skaffold natively supports iterative development
+for projects configured to use helm.
+
 {{< alert title="Note" >}}
-The helm renderer is still a work in progress, we will update the documentation here when the implementation has been merged
+To use `helm` with Skaffold, the `helm` binary must be installed on your machine. Skaffold will not install it for you.
 {{< /alert >}}
+
+# Rendering with helm
+[`helm template`](https://helm.sh/docs/helm/helm_template/) allows Kubernetes
+developers to locally render templates. Skaffold relies on `helm temple --post-render`functionality to substitute the images
+in the rendered charts with Skaffold built images.
+
+
+{{< alert title="Note" >}}
+If you wish to deploy using helm, please see [Configuring Helm Deployer Section](../deployers/helm.md)
+{{< /alert >}}
+
+### Configuration
+
+To use render using helm but deploy via kubectl deployer define your helm charts under
+`helm` in `manifests` section of `skaffold.yaml`.
+
+
+### Example
+The following `manifests` section instructs Skaffold to render
+artifacts using helm.
+
+### `skaffold.yaml` Configuration
+
+The `helm` type offers the following options:
+
+{{< schema root="manifests-helm" >}}
+
+Each `release` includes the following fields:
+
+{{< schema root="HelmRelease" >}}
+
+
+
+{{% readfile file="samples/renderers/kustomize.yaml" %}}
+
+{{< alert title="Note" >}}
+kustomize CLI must be installed on your machine. Skaffold will not
+install it.
+{{< /alert >}}
+

--- a/docs-v2/content/en/docs/pipeline-stages/renderers/helm.md
+++ b/docs-v2/content/en/docs/pipeline-stages/renderers/helm.md
@@ -33,6 +33,9 @@ To use render using helm but deploy via kubectl deployer define your helm charts
 The following `manifests` section instructs Skaffold to render
 artifacts using helm.
 
+{{% readfile file="samples/renderers/helm.yaml" %}}
+
+
 ### `skaffold.yaml` Configuration
 
 The `helm` type offers the following options:
@@ -42,13 +45,4 @@ The `helm` type offers the following options:
 Each `release` includes the following fields:
 
 {{< schema root="HelmRelease" >}}
-
-
-
-{{% readfile file="samples/renderers/kustomize.yaml" %}}
-
-{{< alert title="Note" >}}
-kustomize CLI must be installed on your machine. Skaffold will not
-install it.
-{{< /alert >}}
 

--- a/docs-v2/content/en/samples/deployers/kpt.yaml
+++ b/docs-v2/content/en/samples/deployers/kpt.yaml
@@ -1,6 +1,2 @@
 deploy:
   kpt: {}
-# The deploy section above is equal to
-# deploy:
-#   kpt:
-#     paths: ["."]

--- a/docs-v2/content/en/samples/renderers/helm.yaml
+++ b/docs-v2/content/en/samples/renderers/helm.yaml
@@ -1,2 +1,5 @@
-# TODO(aaron-prindle) currently helm renderer is still WIP, update this when complete
-# NOTE: this file isn't referenced in the docs, just a placeholder reminder until it is needed
+manifests:
+  helm:
+    releases:
+    - name: skaffold-helm
+      chartPath: skaffold-helm

--- a/docs-v2/content/en/schemas/v3alpha1.json
+++ b/docs-v2/content/en/schemas/v3alpha1.json
@@ -3320,16 +3320,16 @@
       "properties": {
         "helm": {
           "$ref": "#/definitions/Helm",
-          "description": "TODO: add description.",
-          "x-intellij-html-description": "TODO: add description."
+          "description": "defines the helm charts used in the application. NOTE: Defines cherts in this section to render via helm but deployed via kubectl or kpt deployer. To use helm to deploy, please see deploy.helm section.",
+          "x-intellij-html-description": "defines the helm charts used in the application. NOTE: Defines cherts in this section to render via helm but deployed via kubectl or kpt deployer. To use helm to deploy, please see deploy.helm section."
         },
         "kpt": {
           "items": {
             "type": "string"
           },
           "type": "array",
-          "description": "TODO: add description.",
-          "x-intellij-html-description": "TODO: add description.",
+          "description": "defines the kpt resources in the application.",
+          "x-intellij-html-description": "defines the kpt resources in the application.",
           "default": "[]"
         },
         "kustomize": {
@@ -3347,8 +3347,8 @@
             "type": "string"
           },
           "type": "array",
-          "description": "TODO: add description.",
-          "x-intellij-html-description": "TODO: add description.",
+          "description": "defines the raw kubernetes resources.",
+          "x-intellij-html-description": "defines the raw kubernetes resources.",
           "default": "[]"
         },
         "transform": {

--- a/docs-v2/data/maturity.json
+++ b/docs-v2/data/maturity.json
@@ -158,7 +158,7 @@
     "run": "x",
     "debug": "x",
     "area": "Deploy",
-    "maturity": "GA",
+    "maturity": "beta",
     "description": "Deploy a set of deployables as your applications and replace the image name with the built images ",
     "url": "/docs/pipeline-stages/deployers"
   },
@@ -189,18 +189,18 @@
     "debug": "x",
     "area": "Deploy",
     "feature": "Status check",
-    "maturity": "GA",
+    "maturity": "beta",
     "description": "User can wait for deployments to stabilize",
     "url": "/docs/pipeline-stages/status-check/"
   },
   "render": {
     "dev": "x",
     "deploy": "x",
-    "render": "x",
     "run": "x",
     "debug": "x",
+    "render": "x",
     "area": "Render",
-    "maturity": "Beta",
+    "maturity": "beta",
     "description": "Renders a set of resources in your applications and replace the image name with the built images ",
     "url": "/docs/pipeline-stages/renderers"
   },
@@ -316,20 +316,14 @@
     "debug": "x",
     "render": "x",
     "area": "Profiles",
-    "maturity": "beta",
+    "maturity": "GA",
     "description": "Create different pipeline configurations based on overrides and patches defined in one or more profiles",
     "url": "/docs/environment/profiles/"
-  },
-  "render": {
-    "deploy": "x",
-    "area": "Render",
-    "maturity": "beta",
-    "description": "Produce hydrated Kubernetes manifests that reference the built resources"
   },
   "run.cmd": {
     "run": "x",
     "area": "skaffold run",
-    "maturity": "beta",
+    "maturity": "GA",
     "description": "One-off build & deployment of the skaffold application",
     "url": "/docs/workflows/ci-cd"
   },
@@ -337,13 +331,13 @@
     "dev": "x",
     "area": "Filesync",
     "feature": "sync.infer",
-    "maturity": "beta",
+    "maturity": "GA",
     "description": "mark files as \"syncable\" - infer the destinations based on the Dockerfile"
   },
   "sync": {
     "dev": "x",
     "area": "Filesync",
-    "maturity": "beta",
+    "maturity": "GA",
     "description": "Instead of rebuilding, copy the changed files in the running container",
     "url": "/docs/pipeline-stages/filesync"
   },

--- a/docs-v2/data/maturity.json
+++ b/docs-v2/data/maturity.json
@@ -28,7 +28,7 @@
     "debug": "x",
     "area": "Build",
     "feature": "custom artifact Builder",
-    "maturity": "beta",
+    "maturity": "GA",
     "description": "build locally using a custom build script "
   },
   "build.dependencies": {
@@ -38,7 +38,7 @@
     "debug": "x",
     "area": "Build",
     "feature": "Build Artifact Dependencies",
-    "maturity": "beta",
+    "maturity": "GA",
     "description": "Define build artifact dependencies"
   },
   "build.ko": {
@@ -172,6 +172,16 @@
     "maturity": "beta",
     "description": "Deploy applications to the local Docker daemon"
   },
+  "deploy.cloudrun": {
+    "dev": "x",
+    "deploy": "x",
+    "run": "x",
+    "debug": "x",
+    "area": "Deploy",
+    "feature": "CloudRun Deployer",
+    "maturity": "alpha",
+    "description": "Deploy applications to the Google Cloud Run"
+  },
   "deploy.status_check": {
     "dev": "x",
     "deploy": "x",
@@ -182,7 +192,17 @@
     "maturity": "GA",
     "description": "User can wait for deployments to stabilize",
     "url": "/docs/pipeline-stages/status-check/"
-
+  },
+  "render": {
+    "dev": "x",
+    "deploy": "x",
+    "render": "x",
+    "run": "x",
+    "debug": "x",
+    "area": "Render",
+    "maturity": "Beta",
+    "description": "Renders a set of resources in your applications and replace the image name with the built images ",
+    "url": "/docs/pipeline-stages/renderers"
   },
   "dev": {
     "dev": "x",
@@ -193,7 +213,7 @@
   },
   "fix.cmd": {
     "area": "skaffold fix",
-    "maturity": "GA",
+    "maturity": "beta",
     "description": "Upgrade an older skaffold config to the current version"
   },
   "generate_pipeline.tekton": {
@@ -216,20 +236,20 @@
   },
   "init": {
     "area": "Init",
-    "maturity": "GA",
+    "maturity": "beta",
     "description": "Initialize a skaffold.yaml file based on the contents of the current directory",
     "url": "/docs/pipeline-stages/init"
   },
   "init.dockerfiles": {
     "area": "Init",
     "feature": "init for Dockerfiles ",
-    "maturity": "GA",
+    "maturity": "beta",
     "description": "skaffold init recognizes Dockerfiles"
   },
   "init.interactive": {
     "area": "Init",
     "feature": "interactive",
-    "maturity": "GA",
+    "maturity": "beta",
     "description": "skaffold init interactive for CLI users"
   },
   "init.json_api": {
@@ -241,7 +261,7 @@
   "init.k8s_manifests": {
     "area": "Init",
     "feature": "init for Kubernetes manifests",
-    "maturity": "GA",
+    "maturity": "beta",
     "description": "skaffold init parses images from Kubernetes manifests"
   },
   "init.generate_manifests": {
@@ -266,7 +286,7 @@
     "run": "x",
     "debug": "x",
     "area": "Lifecycle Hooks",
-    "maturity": "alpha",
+    "maturity": "beta",
     "description": "Run code triggered by different events during the skaffold process lifecycle.",
     "url": "/docs/pipeline-stages/lifecycle-hooks/"
   },
@@ -296,20 +316,20 @@
     "debug": "x",
     "render": "x",
     "area": "Profiles",
-    "maturity": "GA",
+    "maturity": "beta",
     "description": "Create different pipeline configurations based on overrides and patches defined in one or more profiles",
     "url": "/docs/environment/profiles/"
   },
   "render": {
     "deploy": "x",
     "area": "Render",
-    "maturity": "GA",
+    "maturity": "beta",
     "description": "Produce hydrated Kubernetes manifests that reference the built resources"
   },
   "run.cmd": {
     "run": "x",
     "area": "skaffold run",
-    "maturity": "GA",
+    "maturity": "beta",
     "description": "One-off build & deployment of the skaffold application",
     "url": "/docs/workflows/ci-cd"
   },
@@ -323,7 +343,7 @@
   "sync": {
     "dev": "x",
     "area": "Filesync",
-    "maturity": "GA",
+    "maturity": "beta",
     "description": "Instead of rebuilding, copy the changed files in the running container",
     "url": "/docs/pipeline-stages/filesync"
   },
@@ -378,7 +398,7 @@
     "test": "x",
     "area": "Test",
     "feature": "custom tester",
-    "maturity": "alpha",
+    "maturity": "beta",
     "description": "Run custom test command locally",
     "url": "/docs/pipeline-stages/testers/custom"
   },

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -572,17 +572,20 @@ type RenderConfig struct {
 
 // Generate defines the dry manifests from a variety of sources.
 type Generate struct {
-	// RawK8s TODO: add description.
+	// RawK8s defines the raw kubernetes resources.
 	RawK8s []string `yaml:"rawYaml,omitempty" skaffold:"filepath"`
 
 	// Kustomize defines the paths to be modified with kustomize, along with extra
 	// flags to be passed to kustomize.
 	Kustomize *Kustomize `yaml:"kustomize,omitempty"`
 
-	// Helm TODO: add description.
+	// Helm defines the helm charts used in the application.
+	// NOTE: Defines cherts in this section to render via helm but
+	// deployed via kubectl or kpt deployer.
+	// To use helm to deploy, please see deploy.helm section.
 	Helm *Helm `yaml:"helm,omitempty"`
 
-	// Kpt TODO: add description.
+	// Kpt defines the kpt resources in the application
 	Kpt []string `yaml:"kpt,omitempty" skaffold:"filepath"`
 }
 

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -585,7 +585,7 @@ type Generate struct {
 	// To use helm to deploy, please see deploy.helm section.
 	Helm *Helm `yaml:"helm,omitempty"`
 
-	// Kpt defines the kpt resources in the application
+	// Kpt defines the kpt resources in the application.
 	Kpt []string `yaml:"kpt,omitempty" skaffold:"filepath"`
 }
 


### PR DESCRIPTION
List of changes:

- Add helm render docs. 
- Add description to few keys in the config. 
- update maturity matrix. 
   - render, fix and init set back  to beta. 
   - build, tagging, profiles, log tailing, port-forwarding, test, filesync kept at GA.
   - keep docker deployer, ko, cloud run to alpha
 
- Fixed weights for some deployers so kubectl and kustomize appear before.