### PR TITLE
feat: cross-platform build support in GoogleCloudBuild

### DIFF
--- a/docs-v2/content/en/schemas/v3alpha1.json
+++ b/docs-v2/content/en/schemas/v3alpha1.json
@@ -1894,6 +1894,11 @@
           "x-intellij-html-description": "image that runs a Cloud Native Buildpacks build. See <a href=\"https://cloud.google.com/cloud-build/docs/cloud-builders\">Cloud Builders</a>.",
           "default": "gcr.io/k8s-skaffold/pack"
         },
+        "platformEmulatorInstallStep": {
+          "$ref": "#/definitions/PlatformEmulatorInstallStep",
+          "description": "specifies a pre-build step to install the required tooling for QEMU emulation on the GoogleCloudBuild containers. This enables performing cross-platform builds on GoogleCloudBuild. If unspecified, Skaffold uses the `docker/binfmt` image by default.",
+          "x-intellij-html-description": "specifies a pre-build step to install the required tooling for QEMU emulation on the GoogleCloudBuild containers. This enables performing cross-platform builds on GoogleCloudBuild. If unspecified, Skaffold uses the <code>docker/binfmt</code> image by default."
+        },
         "projectId": {
           "type": "string",
           "description": "ID of your Cloud Platform Project. If it is not provided, Skaffold will guess it from the image name. For example, given the artifact image name `gcr.io/myproject/image`, Skaffold will use the `myproject` GCP project.",
@@ -1930,7 +1935,8 @@
         "koImage",
         "concurrency",
         "workerPool",
-        "region"
+        "region",
+        "platformEmulatorInstallStep"
       ],
       "additionalProperties": false,
       "type": "object",
@@ -3138,6 +3144,41 @@
       "type": "object",
       "description": "describes a lifecycle hook definition to execute on a named container.",
       "x-intellij-html-description": "describes a lifecycle hook definition to execute on a named container."
+    },
+    "PlatformEmulatorInstallStep": {
+      "required": [
+        "image"
+      ],
+      "properties": {
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "specifies arguments passed to the emulator installer image.",
+          "x-intellij-html-description": "specifies arguments passed to the emulator installer image.",
+          "default": "[]"
+        },
+        "entrypoint": {
+          "type": "string",
+          "description": "specifies the ENTRYPOINT argument to the emulator installer image.",
+          "x-intellij-html-description": "specifies the ENTRYPOINT argument to the emulator installer image."
+        },
+        "image": {
+          "type": "string",
+          "description": "specifies the image that will install the required tooling for QEMU emulation on the GoogleCloudBuild containers.",
+          "x-intellij-html-description": "specifies the image that will install the required tooling for QEMU emulation on the GoogleCloudBuild containers."
+        }
+      },
+      "preferredOrder": [
+        "image",
+        "args",
+        "entrypoint"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "specifies a pre-build step to install the required tooling for QEMU emulation on the GoogleCloudBuild containers. This enables performing cross-platform builds on GoogleCloudBuild.",
+      "x-intellij-html-description": "specifies a pre-build step to install the required tooling for QEMU emulation on the GoogleCloudBuild containers. This enables performing cross-platform builds on GoogleCloudBuild."
     },
     "PortForwardResource": {
       "properties": {

--- a/pkg/skaffold/build/gcb/docker_test.go
+++ b/pkg/skaffold/build/gcb/docker_test.go
@@ -157,6 +157,8 @@ func TestDockerBuildSpec(t *testing.T) {
 					},
 				},
 				Steps: []*cloudbuild.BuildStep{{
+					Name: defaultPlatformEmulatorInstallStep.Image,
+				}, {
 					Name: "docker/docker",
 					Args: []string{"build", "--tag", "nginx", "-f", "Dockerfile", "--platform", "freebsd/arm", "--build-arg", "arg1=value1", "--build-arg", "arg2", "."},
 					Env:  []string{"DOCKER_BUILDKIT=1"},
@@ -269,6 +271,8 @@ func TestPullCacheFrom(t *testing.T) {
 			tag:       "nginx2",
 			platforms: platform.Matcher{Platforms: []v1.Platform{{Architecture: "arm", OS: "freebsd"}}},
 			expected: []*cloudbuild.BuildStep{{
+				Name: defaultPlatformEmulatorInstallStep.Image,
+			}, {
 				Name:       "docker/docker",
 				Entrypoint: "sh",
 				Args:       []string{"-c", "docker pull --platform freebsd/arm from/image1 || true"},

--- a/pkg/skaffold/platform/platform.go
+++ b/pkg/skaffold/platform/platform.go
@@ -90,6 +90,15 @@ func (m Matcher) Intersect(other Matcher) Matcher {
 	return res
 }
 
+// Contains returns if the Matcher contains the other platform
+func (m Matcher) Contains(other specs.Platform) bool {
+	if m.All {
+		return true
+	}
+	matcher := platforms.Any(m.Platforms...)
+	return matcher.Match(other)
+}
+
 func Parse(ps []string) (Matcher, error) {
 	var sl []specs.Platform
 	for _, p := range ps {

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -402,6 +402,20 @@ type GoogleCloudBuild struct {
 	// the build will be run in global(non-regional).
 	// See [Cloud Build locations](https://cloud.google.com/build/docs/locations).
 	Region string `yaml:"region,omitempty"`
+
+	// PlatformEmulatorInstallStep specifies a pre-build step to install the required tooling for QEMU emulation on the GoogleCloudBuild containers. This enables performing cross-platform builds on GoogleCloudBuild.
+	// If unspecified, Skaffold uses the `docker/binfmt` image by default.
+	PlatformEmulatorInstallStep *PlatformEmulatorInstallStep `yaml:"platformEmulatorInstallStep,omitempty"`
+}
+
+// PlatformEmulatorInstallStep specifies a pre-build step to install the required tooling for QEMU emulation on the GoogleCloudBuild containers. This enables performing cross-platform builds on GoogleCloudBuild.
+type PlatformEmulatorInstallStep struct {
+	// Image specifies the image that will install the required tooling for QEMU emulation on the GoogleCloudBuild containers.
+	Image string `yaml:"image" yamltags:"required"`
+	// Args specifies arguments passed to the emulator installer image.
+	Args []string `yaml:"args,omitempty"`
+	// Entrypoint specifies the ENTRYPOINT argument to the emulator installer image.
+	Entrypoint string `yaml:"entrypoint,omitempty"`
 }
 
 // KanikoCache configures Kaniko caching. If a cache is specified, Kaniko will


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #7555 <!-- tracking issues that this PR will close -->
**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
This PR implements support for running cross-platform builds on GoogleCloudBuild. It does this by injecting a prebuild step `platformEmulatorInstallStep` that runs `docker/binfmt` image to install required tooling for QEMU emulation on the GoogleCloudBuild containers. The user can also provide any alternate image explicitly in the `googleCloudBuild.platformEmulatorInstallStep` of the `skaffold.yaml` config.


**Testing instructions:**
* Use the project [`go-guestbook`](https://github.com/GoogleCloudPlatform/cloud-code-samples/tree/v1/golang/go-guestbook).
* Set the active kubernetes context to an ARM node cluster (googlers can use [this](https://pantheon.corp.google.com/kubernetes/clusters/details/us-central1-a/integration-tests-arm/details?project=k8s-skaffold) cluster).
* Run:
```
skaffold dev --default-repo=gcr.io/k8s-skaffold -p cloudbuild
```
**Expected**: Skaffold should build `linux/arm64` images on GoogleCloudBuild and deploy to the active k8s cluster.

---
**Follow-up Work (remove if N/A)**
<!-- Mention any related follow up work to this PR. -->
Add documentation and sample project.

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
