### PR TITLE
docs: add skaffold verify feature maturity

### DIFF
--- a/docs-v2/data/maturity.json
+++ b/docs-v2/data/maturity.json
@@ -231,6 +231,15 @@
     "maturity": "alpha",
     "description": "User can generate a starter tekton pipeline using skaffold"
   },
+  "verify": {
+    "dev": "x",
+    "debug": "x",
+    "run": "x",
+    "deploy": "x",
+    "area": "skaffold verify",
+    "maturity": "beta",
+    "description": "User can run post deployment tests via skaffold monitored test containers"
+  },
   "global_config": {
     "dev": "x",
     "build": "x",


### PR DESCRIPTION
Add `skaffold verify` feature maturity (`beta`) to `https://skaffold-v2.web.app/docs/references/deprecation/`