### PR TITLE
fix: render should be online for `dev`, `deploy` and `run`.

### DIFF
--- a/cmd/skaffold/app/cmd/deploy.go
+++ b/cmd/skaffold/app/cmd/deploy.go
@@ -52,7 +52,7 @@ func doDeploy(ctx context.Context, out io.Writer) error {
 			return err
 		}
 		// Render
-		manifests, errR := r.Render(ctx, out, buildArtifacts, true)
+		manifests, errR := r.Render(ctx, out, buildArtifacts, false)
 		if errR != nil {
 			return errR
 		}

--- a/cmd/skaffold/app/cmd/run.go
+++ b/cmd/skaffold/app/cmd/run.go
@@ -56,7 +56,7 @@ func doRun(ctx context.Context, out io.Writer) error {
 		}
 
 		// Render
-		manifestList, err := r.Render(ctx, out, bRes, true)
+		manifestList, err := r.Render(ctx, out, bRes, false)
 		if err != nil {
 			return fmt.Errorf("rendering manifests: %w", err)
 		}

--- a/integration/dev_test.go
+++ b/integration/dev_test.go
@@ -428,7 +428,7 @@ func TestDev_WithKubecontextOverride(t *testing.T) {
 		env := []string{fmt.Sprintf("KUBECONFIG=%s", kubeconfig)}
 
 		// n.b. for the sake of this test the namespace must not be given explicitly
-		skaffold.Run("--kube-context", kubecontext).InDir("examples/getting-started").WithEnv(env).RunOrFail(t.T)
+		skaffold.Run("--kube-context", kubecontext).InDir("examples/getting-started").WithEnv(env).InNs(ns.Name).RunOrFail(t.T)
 
 		client.WaitForPodsReady("getting-started")
 	})

--- a/pkg/skaffold/render/renderer/util/util.go
+++ b/pkg/skaffold/render/renderer/util/util.go
@@ -70,7 +70,7 @@ func GenerateHydratedManifests(ctx context.Context, out io.Writer, builds []grap
 		endTrace()
 	}
 
-	if opts.Offline || !opts.EnablePlatformNodeAffinity {
+	if !opts.EnablePlatformNodeAffinity {
 		// TODO (gaghosh): To support platform node affinity in offline mode, we'll need to save the image platform
 		// information in the build output file, and consume that here instead of looking up in the container registry.
 		return manifests, nil

--- a/pkg/skaffold/runner/v2/dev.go
+++ b/pkg/skaffold/runner/v2/dev.go
@@ -348,7 +348,7 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*la
 	r.deployer.GetLogger().SetSince(time.Now())
 
 	// First render
-	manifests, err := r.Render(ctx, out, r.Builds, true)
+	manifests, err := r.Render(ctx, out, r.Builds, false)
 	r.deployManifests = manifests
 	if err != nil {
 		event.DevLoopFailedInPhase(r.devIteration, constants.Render, err)


### PR DESCRIPTION
Render should be `online` by default for `dev`, `deploy` and `run`. 
It seems to only be configurable for the `render` command with the `--offline` flag, [and even that is `false` by default](https://github.com/GoogleContainerTools/skaffold/blob/c3fe38d25d0ab68aadf56b1a905eb8477b48dcb9/cmd/skaffold/app/cmd/render.go#L45). This is also the behavior on the [`v1` branch](https://github.com/GoogleContainerTools/skaffold/blob/6f1ffc3b59ff9748f7f8891d51628e894c92d385/pkg/skaffold/deploy/kubectl/kubectl.go#L213). So this is a regression in `v2`