### PR TITLE
fix: add flags for build platform selection heuristics

### DIFF
--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -658,6 +658,31 @@ var flagRegistry = []Flag{
 		DefinedOn:     []string{"dev", "render", "run", "debug", "deploy"},
 	},
 	{
+		Name:     "disable-multi-platform-build",
+		Usage:    "When set to true, forces only single platform image builds even when multiple target platforms are specified. Enabled by default for `dev` and `debug` modes, to keep dev-loop fast",
+		Value:    &opts.DisableMultiPlatformBuild,
+		DefValue: false,
+		DefValuePerCommand: map[string]interface{}{
+			"dev":   true,
+			"debug": true,
+		},
+		FlagAddMethod: "BoolVar",
+		DefinedOn:     []string{"build", "dev", "run", "debug"},
+	},
+	{
+		Name:     "check-cluster-node-platforms",
+		Usage:    "When set to true, images are built for the target platforms matching the active kubernetes cluster node platforms. Enabled by default for `dev`, `debug` and `run`",
+		Value:    &opts.CheckClusterNodePlatforms,
+		DefValue: false,
+		DefValuePerCommand: map[string]interface{}{
+			"dev":   true,
+			"debug": true,
+			"run":   true,
+		},
+		FlagAddMethod: "BoolVar",
+		DefinedOn:     []string{"build", "dev", "run", "debug"},
+	},
+	{
 		Name:          "cloud-run-project",
 		Shorthand:     "",
 		Usage:         "The GCP Project ID or Project Number to deploy for Cloud Run",

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -198,9 +198,11 @@ Options:
   -b, --build-image=[]: Only build artifacts with image names that contain the given substring. Default is to build sources for all artifacts
       --cache-artifacts=true: Set to false to disable default caching of artifacts
       --cache-file='': Specify the location of the cache file (default $HOME/.skaffold/cache)
+      --check-cluster-node-platforms=false: When set to true, images are built for the target platforms matching the active kubernetes cluster node platforms. Enabled by default for `dev`, `debug` and `run`
   -c, --config='': File for global configurations (defaults to $HOME/.skaffold/config)
   -d, --default-repo='': Default repository value (overrides global config)
       --detect-minikube=true: Use heuristics to detect a minikube cluster
+      --disable-multi-platform-build=false: When set to true, forces only single platform image builds even when multiple target platforms are specified. Enabled by default for `dev` and `debug` modes, to keep dev-loop fast
       --dry-run=false: Don't build images, just compute the tag for each artifact.
       --file-output='': Filename to write build images to
   -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
@@ -240,9 +242,11 @@ Env vars:
 * `SKAFFOLD_BUILD_IMAGE` (same as `--build-image`)
 * `SKAFFOLD_CACHE_ARTIFACTS` (same as `--cache-artifacts`)
 * `SKAFFOLD_CACHE_FILE` (same as `--cache-file`)
+* `SKAFFOLD_CHECK_CLUSTER_NODE_PLATFORMS` (same as `--check-cluster-node-platforms`)
 * `SKAFFOLD_CONFIG` (same as `--config`)
 * `SKAFFOLD_DEFAULT_REPO` (same as `--default-repo`)
 * `SKAFFOLD_DETECT_MINIKUBE` (same as `--detect-minikube`)
+* `SKAFFOLD_DISABLE_MULTI_PLATFORM_BUILD` (same as `--disable-multi-platform-build`)
 * `SKAFFOLD_DRY_RUN` (same as `--dry-run`)
 * `SKAFFOLD_FILE_OUTPUT` (same as `--file-output`)
 * `SKAFFOLD_FILENAME` (same as `--filename`)
@@ -408,12 +412,14 @@ Options:
       --build-concurrency=-1: Number of concurrently running builds. Set to 0 to run all builds in parallel. Doesn't violate build order among dependencies.
       --cache-artifacts=true: Set to false to disable default caching of artifacts
       --cache-file='': Specify the location of the cache file (default $HOME/.skaffold/cache)
+      --check-cluster-node-platforms=true: When set to true, images are built for the target platforms matching the active kubernetes cluster node platforms. Enabled by default for `dev`, `debug` and `run`
       --cleanup=true: Delete deployments after dev or debug mode is interrupted
       --cloud-run-location='': The GCP Region to deploy Cloud Run services to
       --cloud-run-project='': The GCP Project ID or Project Number to deploy for Cloud Run
   -c, --config='': File for global configurations (defaults to $HOME/.skaffold/config)
   -d, --default-repo='': Default repository value (overrides global config)
       --detect-minikube=true: Use heuristics to detect a minikube cluster
+      --disable-multi-platform-build=true: When set to true, forces only single platform image builds even when multiple target platforms are specified. Enabled by default for `dev` and `debug` modes, to keep dev-loop fast
       --enable-platform-node-affinity=true: If true, when deploying to a mixed node cluster, skaffold will add platform (os/arch) node affinity definition to rendered manifests based on the image platforms
   -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
       --force=false: Recreate Kubernetes resources if necessary for deployment, warning: might cause downtime!
@@ -469,12 +475,14 @@ Env vars:
 * `SKAFFOLD_BUILD_CONCURRENCY` (same as `--build-concurrency`)
 * `SKAFFOLD_CACHE_ARTIFACTS` (same as `--cache-artifacts`)
 * `SKAFFOLD_CACHE_FILE` (same as `--cache-file`)
+* `SKAFFOLD_CHECK_CLUSTER_NODE_PLATFORMS` (same as `--check-cluster-node-platforms`)
 * `SKAFFOLD_CLEANUP` (same as `--cleanup`)
 * `SKAFFOLD_CLOUD_RUN_LOCATION` (same as `--cloud-run-location`)
 * `SKAFFOLD_CLOUD_RUN_PROJECT` (same as `--cloud-run-project`)
 * `SKAFFOLD_CONFIG` (same as `--config`)
 * `SKAFFOLD_DEFAULT_REPO` (same as `--default-repo`)
 * `SKAFFOLD_DETECT_MINIKUBE` (same as `--detect-minikube`)
+* `SKAFFOLD_DISABLE_MULTI_PLATFORM_BUILD` (same as `--disable-multi-platform-build`)
 * `SKAFFOLD_ENABLE_PLATFORM_NODE_AFFINITY` (same as `--enable-platform-node-affinity`)
 * `SKAFFOLD_FILENAME` (same as `--filename`)
 * `SKAFFOLD_FORCE` (same as `--force`)
@@ -693,6 +701,7 @@ Options:
       --build-concurrency=-1: Number of concurrently running builds. Set to 0 to run all builds in parallel. Doesn't violate build order among dependencies.
       --cache-artifacts=true: Set to false to disable default caching of artifacts
       --cache-file='': Specify the location of the cache file (default $HOME/.skaffold/cache)
+      --check-cluster-node-platforms=true: When set to true, images are built for the target platforms matching the active kubernetes cluster node platforms. Enabled by default for `dev`, `debug` and `run`
       --cleanup=true: Delete deployments after dev or debug mode is interrupted
       --cloud-run-location='': The GCP Region to deploy Cloud Run services to
       --cloud-run-project='': The GCP Project ID or Project Number to deploy for Cloud Run
@@ -700,6 +709,7 @@ Options:
   -d, --default-repo='': Default repository value (overrides global config)
       --detect-minikube=true: Use heuristics to detect a minikube cluster
       --digest-source='': Set to 'remote' to skip builds and resolve the digest of images by tag from the remote registry. Set to 'local' to build images locally and use digests from built images. Set to 'tag' to use tags directly from the build. Set to 'none' to use tags directly from the Kubernetes manifests. If unspecified, defaults to 'remote' for remote clusters, and 'tag' for local clusters like kind or minikube.
+      --disable-multi-platform-build=true: When set to true, forces only single platform image builds even when multiple target platforms are specified. Enabled by default for `dev` and `debug` modes, to keep dev-loop fast
       --enable-platform-node-affinity=true: If true, when deploying to a mixed node cluster, skaffold will add platform (os/arch) node affinity definition to rendered manifests based on the image platforms
   -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
       --force=false: Recreate Kubernetes resources if necessary for deployment, warning: might cause downtime!
@@ -754,6 +764,7 @@ Env vars:
 * `SKAFFOLD_BUILD_CONCURRENCY` (same as `--build-concurrency`)
 * `SKAFFOLD_CACHE_ARTIFACTS` (same as `--cache-artifacts`)
 * `SKAFFOLD_CACHE_FILE` (same as `--cache-file`)
+* `SKAFFOLD_CHECK_CLUSTER_NODE_PLATFORMS` (same as `--check-cluster-node-platforms`)
 * `SKAFFOLD_CLEANUP` (same as `--cleanup`)
 * `SKAFFOLD_CLOUD_RUN_LOCATION` (same as `--cloud-run-location`)
 * `SKAFFOLD_CLOUD_RUN_PROJECT` (same as `--cloud-run-project`)
@@ -761,6 +772,7 @@ Env vars:
 * `SKAFFOLD_DEFAULT_REPO` (same as `--default-repo`)
 * `SKAFFOLD_DETECT_MINIKUBE` (same as `--detect-minikube`)
 * `SKAFFOLD_DIGEST_SOURCE` (same as `--digest-source`)
+* `SKAFFOLD_DISABLE_MULTI_PLATFORM_BUILD` (same as `--disable-multi-platform-build`)
 * `SKAFFOLD_ENABLE_PLATFORM_NODE_AFFINITY` (same as `--enable-platform-node-affinity`)
 * `SKAFFOLD_FILENAME` (same as `--filename`)
 * `SKAFFOLD_FORCE` (same as `--force`)
@@ -1042,6 +1054,7 @@ Options:
   -b, --build-image=[]: Only build artifacts with image names that contain the given substring. Default is to build sources for all artifacts
       --cache-artifacts=true: Set to false to disable default caching of artifacts
       --cache-file='': Specify the location of the cache file (default $HOME/.skaffold/cache)
+      --check-cluster-node-platforms=true: When set to true, images are built for the target platforms matching the active kubernetes cluster node platforms. Enabled by default for `dev`, `debug` and `run`
       --cleanup=true: Delete deployments after dev or debug mode is interrupted
       --cloud-run-location='': The GCP Region to deploy Cloud Run services to
       --cloud-run-project='': The GCP Project ID or Project Number to deploy for Cloud Run
@@ -1049,6 +1062,7 @@ Options:
   -d, --default-repo='': Default repository value (overrides global config)
       --detect-minikube=true: Use heuristics to detect a minikube cluster
       --digest-source='': Set to 'remote' to skip builds and resolve the digest of images by tag from the remote registry. Set to 'local' to build images locally and use digests from built images. Set to 'tag' to use tags directly from the build. Set to 'none' to use tags directly from the Kubernetes manifests. If unspecified, defaults to 'remote' for remote clusters, and 'tag' for local clusters like kind or minikube.
+      --disable-multi-platform-build=false: When set to true, forces only single platform image builds even when multiple target platforms are specified. Enabled by default for `dev` and `debug` modes, to keep dev-loop fast
       --enable-platform-node-affinity=true: If true, when deploying to a mixed node cluster, skaffold will add platform (os/arch) node affinity definition to rendered manifests based on the image platforms
   -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
       --force=false: Recreate Kubernetes resources if necessary for deployment, warning: might cause downtime!
@@ -1098,6 +1112,7 @@ Env vars:
 * `SKAFFOLD_BUILD_IMAGE` (same as `--build-image`)
 * `SKAFFOLD_CACHE_ARTIFACTS` (same as `--cache-artifacts`)
 * `SKAFFOLD_CACHE_FILE` (same as `--cache-file`)
+* `SKAFFOLD_CHECK_CLUSTER_NODE_PLATFORMS` (same as `--check-cluster-node-platforms`)
 * `SKAFFOLD_CLEANUP` (same as `--cleanup`)
 * `SKAFFOLD_CLOUD_RUN_LOCATION` (same as `--cloud-run-location`)
 * `SKAFFOLD_CLOUD_RUN_PROJECT` (same as `--cloud-run-project`)
@@ -1105,6 +1120,7 @@ Env vars:
 * `SKAFFOLD_DEFAULT_REPO` (same as `--default-repo`)
 * `SKAFFOLD_DETECT_MINIKUBE` (same as `--detect-minikube`)
 * `SKAFFOLD_DIGEST_SOURCE` (same as `--digest-source`)
+* `SKAFFOLD_DISABLE_MULTI_PLATFORM_BUILD` (same as `--disable-multi-platform-build`)
 * `SKAFFOLD_ENABLE_PLATFORM_NODE_AFFINITY` (same as `--enable-platform-node-affinity`)
 * `SKAFFOLD_FILENAME` (same as `--filename`)
 * `SKAFFOLD_FORCE` (same as `--force`)

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -59,6 +59,8 @@ type SkaffoldOptions struct {
 	Tail                       bool
 	WaitForConnection          bool
 	EnablePlatformNodeAffinity bool
+	DisableMultiPlatformBuild  bool
+	CheckClusterNodePlatforms  bool
 	MakePathsAbsolute          *bool
 	MultiLevelRepo             *bool
 	CloudRunProject            string

--- a/pkg/skaffold/runner/runcontext/v2/context.go
+++ b/pkg/skaffold/runner/runcontext/v2/context.go
@@ -232,6 +232,8 @@ func (rc *RunContext) GetWorkingDir() string                         { return rc
 func (rc *RunContext) GetCluster() config.Cluster                    { return rc.Cluster }
 func (rc *RunContext) GetNamespace() string                          { return rc.Opts.Namespace }
 func (rc *RunContext) AutoBuild() bool                               { return rc.Opts.AutoBuild }
+func (rc *RunContext) DisableMultiPlatformBuild() bool               { return rc.Opts.DisableMultiPlatformBuild }
+func (rc *RunContext) CheckClusterNodePlatforms() bool               { return rc.Opts.CheckClusterNodePlatforms }
 func (rc *RunContext) AutoDeploy() bool                              { return rc.Opts.AutoDeploy }
 func (rc *RunContext) AutoSync() bool                                { return rc.Opts.AutoSync }
 func (rc *RunContext) ContainerDebugging() bool                      { return rc.Opts.ContainerDebugging }

--- a/pkg/skaffold/runner/v2/new.go
+++ b/pkg/skaffold/runner/v2/new.go
@@ -92,7 +92,14 @@ func NewForConfig(ctx context.Context, runCtx *runcontext.RunContext) (*Skaffold
 		endTrace(instrumentation.TraceEndError(err))
 		return nil, fmt.Errorf("creating deployer: %w", err)
 	}
-	platforms, err := platform.NewResolver(ctx, runCtx.Pipelines.All(), runCtx.Opts.Platforms, runCtx.Mode(), runCtx.KubeContext)
+	rOpts := platform.ResolverOpts{
+		KubeContext:               runCtx.KubeContext,
+		CliPlatformsSelection:     runCtx.Opts.Platforms,
+		CheckClusterNodePlatforms: runCtx.CheckClusterNodePlatforms(),
+		DisableMultiPlatformBuild: runCtx.DisableMultiPlatformBuild(),
+	}
+
+	platforms, err := platform.NewResolver(ctx, runCtx.Pipelines.All(), rOpts)
 	if err != nil {
 		endTrace(instrumentation.TraceEndError(err))
 		return nil, fmt.Errorf("getting target platforms: %w", err)


### PR DESCRIPTION
Cross-platform and Multi-platform build uses two heuristics to determine the final target platforms:
- In `dev`, `debug` and `run` modes, it checks the active kubernetes cluster nodes and takes the intersection of that with the target platforms list.
- In `dev` and `debug` modes, it disables multi-platform builds to keep the iterative build-render-deploy loop fast.

This PR refactors these two things into flags `disable-multi-platform-build` and `check-cluster-node-platforms` with the same default behavior as before, so that they can be explicitly turned off.

**Testing instructions:**
- In the project, `integration/examples/cross-platform-builds`, run:
  ```
  skaffold build --default-repo=gcr.io/k8s-skaffold --platform=linux/amd64,linux/arm64 -t latest
  ```
  This should build and push the multi-platform image, that can be verified running:
  ```
  docker manifest inspect gcr.io/k8s-skaffold/skaffold-example:latest
  ```
  The output should be a manifest list:
  ```
  ...
  "platform": {
       "architecture": "arm64",
       "os": "linux"
  }
  ...
  "platform": {
       "architecture": "amd64",
       "os": "linux"
  }
  ```
- In the same project, set the active kubernetes context to [`linux/amd64` nodes](https://pantheon.corp.google.com/kubernetes/clusters/details/us-central1-a/integration-tests/details?project=k8s-skaffold) cluster, and run:
  ```
  skaffold dev --default-repo=gcr.io/k8s-skaffold -t latest
  ```
  Skaffold should detect the active kubernetes cluster node platform, and build for `linux/amd64`. The deploy logs should show the same:
  ```
  [getting-started] Hello world! Running on linux/amd64
  [getting-started] Hello world! Running on linux/amd64
  ```

- Now set the active kubernetes context to [`linux/arm64` nodes](https://pantheon.corp.google.com/kubernetes/clusters/details/us-central1-a/integration-tests-arm/details?project=k8s-skaffold) cluster, and run:
  ```
  skaffold dev --default-repo=gcr.io/k8s-skaffold -t latest
  ```
  Skaffold should now build for `linux/arm64`. The deploy logs should show the same:
  ```
  [getting-started] Hello world! Running on linux/arm64
  [getting-started] Hello world! Running on linux/arm64
  ```