### PR TITLE
chore: add-render-event-in-runner

### DIFF
--- a/pkg/skaffold/runner/render.go
+++ b/pkg/skaffold/runner/render.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
+	eventV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/v2"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
@@ -39,6 +40,7 @@ func (r *SkaffoldRunner) Render(ctx context.Context, out io.Writer, builds []gra
 	}
 	defer postRenderFn()
 
+	eventV2.TaskInProgress(constants.Render, "")
 	if r.runCtx.RenderOnly() {
 		// Fetch the digest and append it to the tag with the format of "tag@digest"
 		if r.runCtx.DigestSource() == constants.RemoteDigestSource {
@@ -46,6 +48,7 @@ func (r *SkaffoldRunner) Render(ctx context.Context, out io.Writer, builds []gra
 				// remote digest to platform dependant build not supported
 				digest, err := docker.RemoteDigest(a.Tag, r.runCtx, nil)
 				if err != nil {
+					eventV2.TaskFailed(constants.Render, err)
 					return manifest.ManifestListByConfig{}, fmt.Errorf("failed to resolve the digest of %s: does the image exist remotely?", a.Tag)
 				}
 				builds[i].Tag = build.TagWithDigest(a.Tag, digest)
@@ -59,10 +62,12 @@ func (r *SkaffoldRunner) Render(ctx context.Context, out io.Writer, builds []gra
 	ctx, endTrace := instrumentation.StartTrace(ctx, "Render")
 	manifestList, err := r.renderer.Render(ctx, renderOut, builds, offline)
 	if err != nil {
+		eventV2.TaskFailed(constants.Render, err)
 		endTrace(instrumentation.TraceEndError(err))
 		return manifest.ManifestListByConfig{}, err
 	}
 
 	endTrace()
+	eventV2.TaskSucceeded(constants.Render)
 	return manifestList, nil
 }


### PR DESCRIPTION
<!-- Include if applicable: -->
Fixes:#7755
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
 - add Render event task in Runner.Render method to keep it consistent with other stage. 

**Test Plan**
 - run ``skaffold dev --rpc-port=8080 --event-log-file=logs.json`` in getting-started example then check contenct in logs.json.v2 file. 
 - expect to see something like 
 ```bash
{"timestamp":"2022-08-16T19:58:36.648627Z","taskEvent":{"id":"Render-1","task":"Render","iteration":1,"status":"InProgress"}}
{"timestamp":"2022-08-16T19:58:36.648634Z","renderEvent":{"id":"0","taskId":"Render-1","status":"InProgress"}}
{"timestamp":"2022-08-16T19:58:36.649267Z","renderEvent":{"id":"0","taskId":"Render-1","status":"Succeeded"}}
{"timestamp":"2022-08-16T19:58:36.649273Z","taskEvent":{"id":"Render-1","task":"Render","iteration":1,"status":"Succeeded"}}
```


**User facing changes (remove if N/A)**
 - User should be able to see Render task event in dev flow from event logs. 


**Follow-up Work (remove if N/A)**
 - document v2 event -> v1 event mapping. 
 


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
