### PR TITLE
feat: add hooks support to render schema and phase

### DIFF
--- a/docs-v2/content/en/schemas/v3alpha1.json
+++ b/docs-v2/content/en/schemas/v3alpha1.json
@@ -3364,6 +3364,11 @@
           "description": "defines the helm charts used in the application. NOTE: Defines cherts in this section to render via helm but deployed via kubectl or kpt deployer. To use helm to deploy, please see deploy.helm section.",
           "x-intellij-html-description": "defines the helm charts used in the application. NOTE: Defines cherts in this section to render via helm but deployed via kubectl or kpt deployer. To use helm to deploy, please see deploy.helm section."
         },
+        "hooks": {
+          "$ref": "#/definitions/RenderHooks",
+          "description": "describes a set of lifecycle hooks that are executed before and after every render.",
+          "x-intellij-html-description": "describes a set of lifecycle hooks that are executed before and after every render."
+        },
         "kpt": {
           "items": {
             "type": "string"
@@ -3406,6 +3411,7 @@
         "kustomize",
         "helm",
         "kpt",
+        "hooks",
         "transform",
         "validate",
         "output"
@@ -3414,6 +3420,50 @@
       "type": "object",
       "description": "contains all the configuration needed by the render steps.",
       "x-intellij-html-description": "contains all the configuration needed by the render steps."
+    },
+    "RenderHookItem": {
+      "properties": {
+        "host": {
+          "$ref": "#/definitions/HostHook",
+          "description": "describes a single lifecycle hook to run on the host machine.",
+          "x-intellij-html-description": "describes a single lifecycle hook to run on the host machine."
+        }
+      },
+      "preferredOrder": [
+        "host"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "describes a single lifecycle hook to execute before or after each deployer step.",
+      "x-intellij-html-description": "describes a single lifecycle hook to execute before or after each deployer step."
+    },
+    "RenderHooks": {
+      "properties": {
+        "after": {
+          "items": {
+            "$ref": "#/definitions/RenderHookItem"
+          },
+          "type": "array",
+          "description": "describes the list of lifecycle hooks to execute *after* each render step.",
+          "x-intellij-html-description": "describes the list of lifecycle hooks to execute <em>after</em> each render step."
+        },
+        "before": {
+          "items": {
+            "$ref": "#/definitions/RenderHookItem"
+          },
+          "type": "array",
+          "description": "describes the list of lifecycle hooks to execute *before* each render step. Container hooks will only run if the container exists from a previous deployment step (for instance the successive iterations of a dev-loop during `skaffold dev`).",
+          "x-intellij-html-description": "describes the list of lifecycle hooks to execute <em>before</em> each render step. Container hooks will only run if the container exists from a previous deployment step (for instance the successive iterations of a dev-loop during <code>skaffold dev</code>)."
+        }
+      },
+      "preferredOrder": [
+        "before",
+        "after"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "describes the list of lifecycle hooks to execute before and after each render step.",
+      "x-intellij-html-description": "describes the list of lifecycle hooks to execute before and after each render step."
     },
     "ResourceFilter": {
       "required": [

--- a/integration/examples/lifecycle-hooks/k8s-pod.yaml
+++ b/integration/examples/lifecycle-hooks/k8s-pod.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: getting-started
+spec:
+  containers:
+  - name: getting-started
+    image: skaffold-example

--- a/integration/examples/lifecycle-hooks/skaffold.yaml
+++ b/integration/examples/lifecycle-hooks/skaffold.yaml
@@ -1,5 +1,15 @@
 apiVersion: skaffold/v3alpha1
 kind: Config
+manifests:
+  rawYaml:
+  - k8s-pod.yaml
+  hooks:
+    before:
+      - host:
+          command: ["sh", "-c", "echo pre-render host hook running on $(hostname)!"]
+    after:
+      - host:
+          command: ["sh", "-c", "echo post-render host hook running on $(hostname)!"]
 build:
   artifacts:
   - image: hooks-example
@@ -31,9 +41,6 @@ build:
         after:
           - container:
               command: ["sh", "-c", "set -x; kill -HUP 1"]
-manifests:
-  rawYaml:
-  - deployment.yaml
 deploy:
   kubectl:
     hooks:
@@ -49,6 +56,7 @@ deploy:
       after:
         - host:
             command: ["sh", "-c", "echo post-deploy host hook running on $(hostname)!"]
+            os: [darwin, linux]
         - container:
             command: ["sh", "-c", "echo post-deploy container hook running on $(hostname)!"]
             containerName: hooks-example* # use a glob pattern to prefix-match the container name and pod name for deployments, stateful-sets, etc.

--- a/pkg/skaffold/hooks/deploy_test.go
+++ b/pkg/skaffold/hooks/deploy_test.go
@@ -32,6 +32,8 @@ import (
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
+const testKubeContext = "context1"
+
 func TestDeployHooks(t *testing.T) {
 	testutil.Run(t, "TestDeployHooks", func(t *testutil.T) {
 		hooks := latest.DeployHooks{
@@ -91,10 +93,9 @@ func TestDeployHooks(t *testing.T) {
 			LifecycleHooks: hooks,
 		}
 		namespaces := []string{"np1", "np2"}
-		kubeContext := "context1"
-		opts := NewDeployEnvOpts("run_id", kubeContext, namespaces)
+		opts := NewDeployEnvOpts("run_id", testKubeContext, namespaces)
 		formatter := func(corev1.Pod, corev1.ContainerStatus, func() bool) log.Formatter { return mockLogFormatter{} }
-		runner := NewDeployRunner(&kubectl.CLI{KubeContext: kubeContext}, deployer.LifecycleHooks, &namespaces, formatter, opts)
+		runner := NewDeployRunner(&kubectl.CLI{KubeContext: testKubeContext}, deployer.LifecycleHooks, &namespaces, formatter, opts)
 
 		t.Override(&util.DefaultExecCommand,
 			testutil.CmdRunWithOutput("kubectl --context context1 exec pod1 --namespace np1 -c container1 -- foo pre-hook", preContainerHookOut).

--- a/pkg/skaffold/hooks/env.go
+++ b/pkg/skaffold/hooks/env.go
@@ -53,6 +53,12 @@ type SyncEnvOpts struct {
 	Namespaces           string
 }
 
+// RenderEnvOpts contains the environment variables to be set in a deploy type lifecycle hook executor.
+type RenderEnvOpts struct {
+	KubeContext string
+	Namespaces  string
+}
+
 // DeployEnvOpts contains the environment variables to be set in a deploy type lifecycle hook executor.
 type DeployEnvOpts struct {
 	RunID       string

--- a/pkg/skaffold/hooks/render.go
+++ b/pkg/skaffold/hooks/render.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+)
+
+// for testing
+var (
+	NewRenderRunner = newRenderRunner
+)
+
+func newRenderRunner(r latest.RenderHooks, namespaces *[]string, opts RenderEnvOpts) Runner {
+	return renderRunner{r, namespaces, opts, new(sync.Map)}
+}
+
+func NewRenderEnvOpts(kubeContext string, namespaces []string) RenderEnvOpts {
+	return RenderEnvOpts{
+		KubeContext: kubeContext,
+		Namespaces:  strings.Join(namespaces, ","),
+	}
+}
+
+type renderRunner struct {
+	latest.RenderHooks
+	namespaces        *[]string
+	opts              RenderEnvOpts
+	visitedContainers *sync.Map // maintain a list of previous iteration containers, so that they can be skipped
+}
+
+func (r renderRunner) RunPreHooks(ctx context.Context, out io.Writer) error {
+	return r.run(ctx, out, r.PreHooks, phases.PreRender)
+}
+
+func (r renderRunner) RunPostHooks(ctx context.Context, out io.Writer) error {
+	return r.run(ctx, out, r.PostHooks, phases.PostRender)
+}
+
+func (r renderRunner) getEnv() []string {
+	common := getEnv(staticEnvOpts)
+	render := getEnv(r.opts)
+	return append(common, render...)
+}
+
+func (r renderRunner) run(ctx context.Context, out io.Writer, hooks []latest.RenderHookItem, phase phase) error {
+	if len(hooks) > 0 {
+		output.Default.Fprintln(out, fmt.Sprintf("Starting %s hooks...", phase))
+	}
+	env := r.getEnv()
+	for _, h := range hooks {
+		if h.HostHook != nil {
+			hook := hostHook{*h.HostHook, env}
+			if err := hook.run(ctx, out); err != nil {
+				return err
+			}
+		}
+	}
+	if len(hooks) > 0 {
+		output.Default.Fprintln(out, fmt.Sprintf("Completed %s hooks", phase))
+	}
+	return nil
+}

--- a/pkg/skaffold/hooks/render_test.go
+++ b/pkg/skaffold/hooks/render_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	kubernetesclient "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestRenderHooks(t *testing.T) {
+	testutil.Run(t, "TestRenderHooks", func(t *testutil.T) {
+		hooks := latest.RenderHooks{
+			PreHooks: []latest.RenderHookItem{
+				{
+					HostHook: &latest.HostHook{
+						OS:      []string{"linux", "darwin"},
+						Command: []string{"sh", "-c", "echo pre-hook running with SKAFFOLD_KUBE_CONTEXT=$SKAFFOLD_KUBE_CONTEXT,SKAFFOLD_NAMESPACES=$SKAFFOLD_NAMESPACES"},
+					},
+				},
+				{
+					HostHook: &latest.HostHook{
+						OS:      []string{"windows"},
+						Command: []string{"cmd.exe", "/C", "echo pre-hook running with SKAFFOLD_KUBE_CONTEXT=%SKAFFOLD_KUBE_CONTEXT%,SKAFFOLD_NAMESPACES=%SKAFFOLD_NAMESPACES%"},
+					},
+				},
+			},
+			PostHooks: []latest.RenderHookItem{
+				{
+					HostHook: &latest.HostHook{
+						OS:      []string{"linux", "darwin"},
+						Command: []string{"sh", "-c", "echo post-hook running with SKAFFOLD_KUBE_CONTEXT=$SKAFFOLD_KUBE_CONTEXT,SKAFFOLD_NAMESPACES=$SKAFFOLD_NAMESPACES"},
+					},
+				},
+				{
+					HostHook: &latest.HostHook{
+						OS:      []string{"windows"},
+						Command: []string{"cmd.exe", "/C", "echo post-hook running with SKAFFOLD_KUBE_CONTEXT=%SKAFFOLD_KUBE_CONTEXT%,SKAFFOLD_NAMESPACES=%SKAFFOLD_NAMESPACES%"},
+					},
+				},
+			},
+		}
+		preHostHookOut := "pre-hook running with SKAFFOLD_KUBE_CONTEXT=context1,SKAFFOLD_NAMESPACES=np1,np2"
+		postHostHookOut := "post-hook running with SKAFFOLD_KUBE_CONTEXT=context1,SKAFFOLD_NAMESPACES=np1,np2"
+		namespaces := []string{"np1", "np2"}
+		opts := NewRenderEnvOpts(testKubeContext, namespaces)
+		runner := newRenderRunner(hooks, &namespaces, opts)
+		t.Override(&kubernetesclient.Client, fakeKubernetesClient)
+		var preOut, postOut bytes.Buffer
+		err := runner.RunPreHooks(context.Background(), &preOut)
+		t.CheckNoError(err)
+		t.CheckContains(preHostHookOut, preOut.String())
+		err = runner.RunPostHooks(context.Background(), &postOut)
+		t.CheckNoError(err)
+		t.CheckContains(postHostHookOut, postOut.String())
+	})
+}

--- a/pkg/skaffold/hooks/types.go
+++ b/pkg/skaffold/hooks/types.go
@@ -36,6 +36,8 @@ var phases = struct {
 	PostBuild  phase
 	PreSync    phase
 	PostSync   phase
+	PreRender  phase
+	PostRender phase
 	PreDeploy  phase
 	PostDeploy phase
 }{
@@ -43,6 +45,8 @@ var phases = struct {
 	PostBuild:  "post-build",
 	PreSync:    "pre-sync",
 	PostSync:   "post-sync",
+	PreRender:  "pre-render",
+	PostRender: "post-render",
 	PreDeploy:  "pre-deploy",
 	PostDeploy: "post-deploy",
 }

--- a/pkg/skaffold/render/renderer/kubectl/kubectl.go
+++ b/pkg/skaffold/render/renderer/kubectl/kubectl.go
@@ -65,7 +65,7 @@ func New(cfg render.Config, rCfg latest.RenderConfig, labels map[string]string, 
 
 func (r Kubectl) Render(ctx context.Context, out io.Writer, builds []graph.Artifact, offline bool) (manifest.ManifestListByConfig, error) {
 	_, endTrace := instrumentation.StartTrace(ctx, "Render_KubectlManifests")
-	log.Entry(ctx).Infof("rendering using kubectl")
+	log.Entry(ctx).Infof("starting render process")
 	instrumentation.AddAttributesToCurrentSpanFromContext(ctx, map[string]string{
 		"RendererType": "kubectl",
 	})

--- a/pkg/skaffold/render/renderer/render_mux_test.go
+++ b/pkg/skaffold/render/renderer/render_mux_test.go
@@ -41,24 +41,31 @@ func TestRenderMux_Render(t *testing.T) {
 		{
 			name: "concatenates render results with separator",
 			renderers: GroupRenderer{
-				mock{configName: "config1", manifests: "manifest-1", deps: []string{"file1.txt", "file2.txt"}},
-				mock{configName: "config2", manifests: "manifest-2", deps: []string{"file2.txt", "file3.txt"}}},
+				Renderers: []Renderer{
+					mock{configName: "config1", manifests: "manifest-1", deps: []string{"file1.txt", "file2.txt"}},
+					mock{configName: "config2", manifests: "manifest-2", deps: []string{"file2.txt", "file3.txt"}},
+				},
+			},
 			expected:     "manifest-1\n---\nmanifest-2",
 			expectedDeps: []string{"file1.txt", "file2.txt", "file3.txt"},
 		},
 		{
 			name: "returns empty string when any call fails",
 			renderers: GroupRenderer{
-				mock{manifests: "manifest-1", deps: []string{"file1.txt"}},
-				mock{deps: []string{"file2.txt"}, shouldErr: true}},
+				Renderers: []Renderer{
+					mock{manifests: "manifest-1", deps: []string{"file1.txt"}},
+					mock{deps: []string{"file2.txt"}, shouldErr: true}},
+			},
 			expectedDeps: []string{"file1.txt", "file2.txt"},
 			shouldErr:    true,
 		},
 		{
 			name: "short-circuits when first call fails",
 			renderers: GroupRenderer{
-				mock{deps: []string{"file1.txt"}, shouldErr: true},
-				mock{manifests: "manifest-2", deps: []string{"file2.txt"}}},
+				Renderers: []Renderer{
+					mock{deps: []string{"file1.txt"}, shouldErr: true},
+					mock{manifests: "manifest-2", deps: []string{"file2.txt"}}},
+			},
 			expectedDeps: []string{"file1.txt", "file2.txt"},
 			shouldErr:    true,
 		},

--- a/pkg/skaffold/runner/renderer_test.go
+++ b/pkg/skaffold/runner/renderer_test.go
@@ -22,8 +22,6 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/renderer"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/renderer/helm"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/renderer/kpt"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/renderer/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -82,32 +80,50 @@ func TestGetRenderer(tOuter *testing.T) {
 						},
 					},
 				},
-				expected: renderer.NewRenderMux([]renderer.Renderer{
-					t.RequireNonNilResult(helm.New(rc, helmConfig, labels, "")).(renderer.Renderer)}),
+				// expected: renderer.NewRenderMux([]renderer.Renderer{
+				// 	t.RequireNonNilResult(helm.New(rc, helmConfig, labels, "")).(renderer.Renderer)}),
+				expected: renderer.NewRenderMux(
+					renderer.GroupRenderer{
+						Renderers: []renderer.Renderer{
+							t.RequireNonNilResult(helm.New(rc, helmConfig, labels, "")).(renderer.Renderer)},
+					},
+				),
 			},
 			{
 				description: "helm renderer",
 				cfg: latest.Pipeline{
 					Render: helmConfig,
 				},
-				expected: renderer.NewRenderMux([]renderer.Renderer{
-					t.RequireNonNilResult(helm.New(rc, helmConfig, labels, "")).(renderer.Renderer)}),
+				expected: renderer.NewRenderMux(
+					renderer.GroupRenderer{
+						Renderers: []renderer.Renderer{
+							t.RequireNonNilResult(helm.New(rc, helmConfig, labels, "")).(renderer.Renderer)},
+					},
+				),
 			},
 			{
 				description: "kubectl renderer",
 				cfg: latest.Pipeline{
 					Render: kubectlCfg,
 				},
-				expected: renderer.NewRenderMux([]renderer.Renderer{
-					t.RequireNonNilResult(kubectl.New(rc, kubectlCfg, labels, "", "")).(renderer.Renderer)}),
+				expected: renderer.NewRenderMux(
+					renderer.GroupRenderer{
+						Renderers: []renderer.Renderer{
+							t.RequireNonNilResult(helm.New(rc, kubectlCfg, labels, "")).(renderer.Renderer)},
+					},
+				),
 			},
 			{
 				description: "kpt renderer",
 				cfg: latest.Pipeline{
 					Render: kptConfig,
 				},
-				expected: renderer.NewRenderMux([]renderer.Renderer{
-					t.RequireNonNilResult(kpt.New(rc, kptConfig, "", labels, "", "")).(renderer.Renderer)}),
+				expected: renderer.NewRenderMux(
+					renderer.GroupRenderer{
+						Renderers: []renderer.Renderer{
+							t.RequireNonNilResult(helm.New(rc, kptConfig, labels, "")).(renderer.Renderer)},
+					},
+				),
 			},
 			{
 				description: "kpt renderer when validate configured",
@@ -117,8 +133,12 @@ func TestGetRenderer(tOuter *testing.T) {
 						Validate: &[]latest.Validator{{Name: "kubeval"}},
 					},
 				},
-				expected: renderer.NewRenderMux([]renderer.Renderer{
-					t.RequireNonNilResult(kpt.New(rc, kptConfig, "", labels, "", "")).(renderer.Renderer)}),
+				expected: renderer.NewRenderMux(
+					renderer.GroupRenderer{
+						Renderers: []renderer.Renderer{
+							t.RequireNonNilResult(helm.New(rc, kptConfig, labels, "")).(renderer.Renderer)},
+					},
+				),
 			},
 		}
 		for _, test := range tests {

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -601,6 +601,9 @@ type Generate struct {
 
 	// Kpt defines the kpt resources in the application.
 	Kpt []string `yaml:"kpt,omitempty" skaffold:"filepath"`
+
+	// LifecycleHooks describes a set of lifecycle hooks that are executed before and after every render.
+	LifecycleHooks RenderHooks `yaml:"hooks,omitempty"`
 }
 
 // Kustomize defines the paths to be modified with kustomize, along with
@@ -1520,6 +1523,20 @@ type SyncHooks struct {
 	PreHooks []SyncHookItem `yaml:"before,omitempty"`
 	// PostHooks describes the list of lifecycle hooks to execute *after* each artifact sync step.
 	PostHooks []SyncHookItem `yaml:"after,omitempty"`
+}
+
+// RenderHookItem describes a single lifecycle hook to execute before or after each deployer step.
+type RenderHookItem struct {
+	// HostHook describes a single lifecycle hook to run on the host machine.
+	HostHook *HostHook `yaml:"host,omitempty" yamltags:"oneOf=render_hook"`
+}
+
+// RenderHooks describes the list of lifecycle hooks to execute before and after each render step.
+type RenderHooks struct {
+	// PreHooks describes the list of lifecycle hooks to execute *before* each render step. Container hooks will only run if the container exists from a previous deployment step (for instance the successive iterations of a dev-loop during `skaffold dev`).
+	PreHooks []RenderHookItem `yaml:"before,omitempty"`
+	// PostHooks describes the list of lifecycle hooks to execute *after* each render step.
+	PostHooks []RenderHookItem `yaml:"after,omitempty"`
 }
 
 // DeployHookItem describes a single lifecycle hook to execute before or after each deployer step.


### PR DESCRIPTION
Fixes #7749 

Adds support for `render` phase Lifecycle hooks at 
`manifests.hooks`

NOTE: these hooks are pre/post the render phase and not per renderer