### PR TITLE
chore: transform installation of go-licenses from go-get to go install

### DIFF
--- a/hack/generate-embedded-files.sh
+++ b/hack/generate-embedded-files.sh
@@ -32,8 +32,7 @@ elif ! [ -x "$(command -v ${LICENSES})" ]; then
     # from a dependency.
    echo "Installing go-licenses"
      pushd $(mktemp -d ${TMPDIR:-/tmp}/generate-embedded.XXXXXX)
-     #TODO(marlongamez): unpin this version once we're able to build using go 1.16.x
-     go mod init tmp; GOBIN=${BIN} go get github.com/google/go-licenses@9376cf9847a05cae04f4589fe4898b9bce37e684
+     go mod init tmp; GOBIN=${BIN} go install github.com/google/go-licenses@v1.0.0
      popd
 fi
 


### PR DESCRIPTION
**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->

Starting in Go 1.17, installing executables with go get is deprecated... Given the project is still using go 1.17, at some point, there might be a need to transform to go install. 
This PR was proposed as I had errors while I was trying to build the project locally...

before:
```shell
make
hack/generate-embedded-files.sh
Installing go-licenses
.
.
go: added gopkg.in/src-d/go-git.v4 v4.13.1
go: added gopkg.in/warnings.v0 v0.1.2
~/go/src/github.com/boranx/skaffold
Collecting licenses
hack/generate-embedded-files.sh: line 42: /home/boran/go/src/github.com/boranx/skaffold/hack/bin/go-licenses: No such file or directory
make: *** [Makefile:334: fs/assets/check.txt] Error 127
```

after: / expected
```shell
make
hack/generate-embedded-files.sh
Collecting licenses
Collecting schemas
mkdir -p ./out
GOOS=linux GOARCH=amd64 CGO_ENABLED=1 \
    go build -gcflags="all=-N -l" -tags "osusergo netgo static_build release " -ldflags "-X github.com/GoogleContainerTools/skaffold/pkg/skaffold/version.version=ac51b4a90 -X github.com/GoogleContainerTools/skaffold/pkg/skaffold/version.buildDate=2022-08-23T12:59:57Z -X github.com/GoogleContainerTools/skaffold/pkg/skaffold/version.gitCommit=ac51b4a90b45a75e43100bf4dda1877f277d7d09 -s -w -extldflags \"-static\"" -o out/skaffold github.com/GoogleContainerTools/skaffold/cmd/skaffold
```
