### PR TITLE
fix: make helm renderer to use manifest.ManifestList 

### DIFF
--- a/pkg/skaffold/render/renderer/helm/helm.go
+++ b/pkg/skaffold/render/renderer/helm/helm.go
@@ -97,7 +97,7 @@ func (h Helm) Render(ctx context.Context, out io.Writer, builds []graph.Artifact
 }
 
 func (h Helm) generateHelmManifests(ctx context.Context, builds []graph.Artifact) (manifest.ManifestList, error) {
-	renderedManifests := new(bytes.Buffer)
+	var renderedManifests manifest.ManifestList
 	helmEnv := sUtil.OSEnviron()
 	var postRendererArgs []string
 
@@ -146,14 +146,10 @@ func (h Helm) generateHelmManifests(ctx context.Context, builds []graph.Artifact
 		if err := helm.Exec(ctx, h, outBuffer, false, helmEnv, args...); err != nil {
 			return nil, helm.UserErr("std out err", fmt.Errorf(outBuffer.String()))
 		}
-		renderedManifests.Write(outBuffer.Bytes())
-	}
-	manifests, err := manifest.Load(bytes.NewReader(renderedManifests.Bytes()))
-	if err != nil {
-		return nil, err
+		renderedManifests.Append(outBuffer.Bytes())
 	}
 
-	manifests, err = manifests.SetLabels(h.labels, manifest.NewResourceSelectorLabels(h.transformAllowlist, h.transformDenylist))
+	manifests, err := renderedManifests.SetLabels(h.labels, manifest.NewResourceSelectorLabels(h.transformAllowlist, h.transformDenylist))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #7793 <!-- tracking issues that this PR will close -->
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->

Running `skaffold render` triggers `helm template --post-renderer=skaffold`, and skaffold post-render the `helm template` output via hidden command `skaffold filter`.

However, output of `skaffold filter` is missing `---` at the beginning, which cause a bug when `skaffold.yaml` contains at least 2 helm charts.

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->

**Follow-up Work (remove if N/A)**
<!-- Mention any related follow up work to this PR. -->


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
