### PR TITLE
fix: add node unschedulable to retriable errors

### DIFF
--- a/pkg/skaffold/kubernetes/status/resource/deployment.go
+++ b/pkg/skaffold/kubernetes/status/resource/deployment.go
@@ -384,7 +384,9 @@ func isErrAndNotRetryAble(statusCode proto.StatusCode) bool {
 	return statusCode != proto.StatusCode_STATUSCHECK_KUBECTL_CONNECTION_ERR &&
 		statusCode != proto.StatusCode_STATUSCHECK_DEPLOYMENT_ROLLOUT_PENDING &&
 		statusCode != proto.StatusCode_STATUSCHECK_STANDALONE_PODS_PENDING &&
-		statusCode != proto.StatusCode_STATUSCHECK_CONFIG_CONNECTOR_IN_PROGRESS
+		statusCode != proto.StatusCode_STATUSCHECK_CONFIG_CONNECTOR_IN_PROGRESS &&
+		statusCode != proto.StatusCode_STATUSCHECK_NODE_UNSCHEDULABLE &&
+		statusCode != proto.StatusCode_STATUSCHECK_UNKNOWN_UNSCHEDULABLE
 }
 
 // HasEncounteredUnrecoverableError goes through all pod statuses and return true

--- a/pkg/skaffold/kubernetes/status/resource/deployment_test.go
+++ b/pkg/skaffold/kubernetes/status/resource/deployment_test.go
@@ -205,6 +205,14 @@ func TestIsErrAndNotRetriable(t *testing.T) {
 			expected:    true,
 		},
 		{
+			description: "un schedule error code",
+			statusCode:  proto.StatusCode_STATUSCHECK_NODE_UNSCHEDULABLE,
+		},
+		{
+			description: "un schedule unknown error",
+			statusCode:  proto.StatusCode_STATUSCHECK_UNKNOWN_UNSCHEDULABLE,
+		},
+		{
 			description: "rollout status nil error",
 			statusCode:  proto.StatusCode_STATUSCHECK_SUCCESS,
 			expected:    true,

--- a/pkg/skaffold/kubernetes/status/resource/deployment_test.go
+++ b/pkg/skaffold/kubernetes/status/resource/deployment_test.go
@@ -205,11 +205,11 @@ func TestIsErrAndNotRetriable(t *testing.T) {
 			expected:    true,
 		},
 		{
-			description: "un schedule error code",
+			description: "unschedule error code",
 			statusCode:  proto.StatusCode_STATUSCHECK_NODE_UNSCHEDULABLE,
 		},
 		{
-			description: "un schedule unknown error",
+			description: "unschedule unknown error",
 			statusCode:  proto.StatusCode_STATUSCHECK_UNKNOWN_UNSCHEDULABLE,
 		},
 		{


### PR DESCRIPTION
fixes #7782 

With autopilot clusters, the cluster start up time can vary. In order for skaffold to not error out when nodes are still being brought up, adding the following two error codes to retriable errors. 