### PR TITLE
feat: upgrade profiles when running skaffold fix

### DIFF
--- a/pkg/skaffold/schema/v2beta29/upgrade.go
+++ b/pkg/skaffold/schema/v2beta29/upgrade.go
@@ -60,10 +60,7 @@ func (c *SkaffoldConfig) Upgrade() (util.VersionedConfig, error) {
 		if err != nil {
 			return &newConfig, err
 		}
-		err = upgradePatches(p.Patches, newProfiles[i].Patches)
-		if err != nil {
-			return &newConfig, err
-		}
+		upgradePatches(p.Patches, newProfiles[i].Patches)
 	}
 
 	newConfig.Profiles = newProfiles
@@ -156,16 +153,15 @@ func upgradeOnePipeline(oldPipeline, newPipeline interface{}) error {
 	return nil
 }
 
-func upgradePatches(olds []JSONPatch, news []next.JSONPatch) error {
+func upgradePatches(olds []JSONPatch, news []next.JSONPatch) {
 	for i, old := range olds {
 		for str, repStr := range migrations {
 			if strings.Contains(old.Path, str) {
-				news[i].Path = strings.Replace(old.Path, str, repStr, 0)
+				news[i].Path = strings.Replace(old.Path, str, repStr, -1)
 			}
 			if strings.Contains(old.Path, "/deploy/kpt") {
 				fmt.Println("skip migrating kpt deploy sections. Please migrate these over manually")
 			}
 		}
 	}
-	return nil
 }

--- a/pkg/skaffold/schema/v2beta29/upgrade.go
+++ b/pkg/skaffold/schema/v2beta29/upgrade.go
@@ -30,10 +30,10 @@ import (
 )
 
 var migrations = map[string]string{
-	"/deploy/kubectl/manifests":   "/manifests/rawYaml",
+	"/deploy/kubectl":             "/manifests/rawYaml",
 	"/deploy/kustomize/paths":     "/manifests/kustomize/paths",
 	"/deploy/kustomize/buildArgs": "/manifests/kustomize/buildArgs",
-	"/deploy/helm/releases":       "/manifests/helm/releases",
+	"/deploy/helm":                "/manifests/helm",
 }
 
 // Upgrade upgrades a configuration to the next version.
@@ -50,17 +50,13 @@ func (c *SkaffoldConfig) Upgrade() (util.VersionedConfig, error) {
 	}
 
 	var newProfiles []next.Profile
-	// convert Profiles (should be the same)
+	// seed with existing Profiles
 	if c.Profiles != nil {
-		pkgutil.CloneThroughJSON(c.Profiles, &newProfiles)
+		pkgutil.CloneThroughJSON(newConfig.Profiles, &newProfiles)
 	}
 
-	// Update profiles
+	// Update profiles patches
 	for i, p := range c.Profiles {
-		err = upgradeOnePipeline(&p.Pipeline, &newProfiles[i].Pipeline)
-		if err != nil {
-			return &newConfig, err
-		}
 		upgradePatches(p.Patches, newProfiles[i].Patches)
 	}
 

--- a/pkg/skaffold/schema/v2beta29/upgrade.go
+++ b/pkg/skaffold/schema/v2beta29/upgrade.go
@@ -157,7 +157,7 @@ func upgradePatches(olds []JSONPatch, news []next.JSONPatch) {
 				news[i].Path = strings.ReplaceAll(old.Path, str, repStr)
 			}
 			if strings.Contains(old.Path, "/deploy/kpt") {
-				log.Entry(context.TODO()).Printf("skip migrating kpt deploy sections. Please migrate these over manually")
+				log.Entry(context.TODO()).Warn("skip migrating kpt deploy sections. Please migrate these over manually")
 			}
 		}
 	}

--- a/pkg/skaffold/schema/v2beta29/upgrade.go
+++ b/pkg/skaffold/schema/v2beta29/upgrade.go
@@ -17,12 +17,13 @@ limitations under the License.
 package v2beta29
 
 import (
+	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 
 	"github.com/pkg/errors"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output/log"
 	next "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	pkgutil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -157,10 +158,10 @@ func upgradePatches(olds []JSONPatch, news []next.JSONPatch) {
 	for i, old := range olds {
 		for str, repStr := range migrations {
 			if strings.Contains(old.Path, str) {
-				news[i].Path = strings.Replace(old.Path, str, repStr, -1)
+				news[i].Path = strings.ReplaceAll(old.Path, str, repStr)
 			}
 			if strings.Contains(old.Path, "/deploy/kpt") {
-				fmt.Println("skip migrating kpt deploy sections. Please migrate these over manually")
+				log.Entry(context.TODO()).Printf("skip migrating kpt deploy sections. Please migrate these over manually")
 			}
 		}
 	}


### PR DESCRIPTION
fixes #7773 

In PR, add code to walk through profiles and upgrade the patches in profile as well pipeline config. 

Config considered so far
1) deploy.kubectl.manifests
2) deploy.kustomize.paths
3) deploy.kustomize.buildArgs
4) deploy.helm.releases

Testing instructions. 
1) Checkout this PR and LOCAL=true make
2) `cd integration/testdata/debug`
3) cp the following [skaffold.yaml](https://github.com/GoogleContainerTools/skaffold/blob/v1.39.2/integration/testdata/debug/skaffold.yaml)
via 
```
git fetch origin   v1.39.2
git restore --source  origin/v1.39.2 skaffold.yaml
```
3) run `skaffold fix --overwrite=true`
4) 
```
➜  debug git:(fix_sk_fix) ✗ ../../../out/skaffold fix --overwrite=true 
Backed up previous skaffold.yaml at  skaffold.yaml.v2
New config at version skaffold/v3alpha1 generated and written to skaffold.yaml
```

5) Verify the patches are upgraded correctly
```
➜  debug git:(fix_sk_fix) ✗ tail skaffold.yaml skaffold.yaml.v2               
==> skaffold.yaml <==
  - op: remove
    path: /manifests/rawYaml
  build:
    artifacts:
    - image: skaffold-debug-nodejs
      context: nodejs
  deploy:
    docker:
      images:
      - skaffold-debug-nodejs

==> skaffold.yaml.v2 <==
  patches:
  - op: remove
    path: /deploy/kubectl
  build:
    artifacts:
    - image: skaffold-debug-nodejs
      context: nodejs
  deploy:
    docker:
      images: [skaffold-debug-nodejs
```