### PR TITLE
fix: check platform values for known OS and Arch, and fail fast

### DIFF
--- a/pkg/skaffold/platform/platform.go
+++ b/pkg/skaffold/platform/platform.go
@@ -18,6 +18,7 @@ package platform
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/containerd/containerd/platforms"
@@ -109,9 +110,42 @@ func Parse(ps []string) (Matcher, error) {
 		if err != nil {
 			return Matcher{}, UnknownPlatformCLIFlag(p, err)
 		}
+		if err := isKnownPlatform(platform); err != nil {
+			return Matcher{}, UnknownPlatformCLIFlag(p, err)
+		}
 		sl = append(sl, platform)
 	}
 	return Matcher{Platforms: sl}, nil
+}
+
+func isKnownPlatform(p specs.Platform) error {
+	if err := isKnownOS(p.OS); err != nil {
+		return err
+	}
+	if err := isKnownArch(p.Architecture); err != nil {
+		return err
+	}
+	return nil
+}
+
+// isKnownOS returns an error if we don't know about the operating system.
+// Unexported function copied from "github.com/containerd/containerd/platforms"
+func isKnownOS(os string) error {
+	switch os {
+	case "aix", "android", "darwin", "dragonfly", "freebsd", "hurd", "illumos", "js", "linux", "nacl", "netbsd", "openbsd", "plan9", "solaris", "windows", "zos":
+		return nil
+	}
+	return fmt.Errorf("unknown operating system %q", os)
+}
+
+// isKnownArch returns an error if we don't know about the architecture.
+// Unexported function copied from "github.com/containerd/containerd/platforms"
+func isKnownArch(arch string) error {
+	switch arch {
+	case "386", "amd64", "amd64p32", "arm", "armbe", "arm64", "arm64be", "ppc64", "ppc64le", "mips", "mipsle", "mips64", "mips64le", "mips64p32", "mips64p32le", "ppc", "riscv", "riscv64", "s390", "s390x", "sparc", "sparc64", "wasm":
+		return nil
+	}
+	return fmt.Errorf("unknown architecture %q", arch)
 }
 
 func Format(pl specs.Platform) string { return platforms.Format(pl) }

--- a/pkg/skaffold/platform/platform_test.go
+++ b/pkg/skaffold/platform/platform_test.go
@@ -253,3 +253,33 @@ func TestIntersect(t *testing.T) {
 		})
 	}
 }
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		description string
+		input       []string
+		shouldErr   bool
+	}{
+		{
+			description: "known platforms",
+			input:       []string{"linux/arm64", "darwin/amd64", "freebsd/arm"},
+			shouldErr:   false,
+		},
+		{
+			description: "unknown os",
+			input:       []string{"foo/arm64", "darwin/amd64", "freebsd/arm"},
+			shouldErr:   true,
+		},
+		{
+			description: "unknown arch",
+			input:       []string{"linux/arm64", "darwin/foo", "freebsd/arm"},
+			shouldErr:   true,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			_, err := Parse(test.input)
+			t.CheckError(test.shouldErr, err)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #7813 <!-- tracking issues that this PR will close -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Check the values provided to `--platform` flag and fail fast if unknown.

**Testing instruction**:
- In the `integration/examples/getting-started` project run:
  ```
  skaffold build --platform=foo/arm64
  ```
- You should get the following error:
  ```
  creating runner: getting target platforms: failed to parse platforms: unable to recognise platform "foo/arm64": unknown operating system "foo". Check that the value provided to --platform flag is a valid platform and formatted correctly, like linux/amd64, linux/arm64, linux/arm/v7, etc..
  ```
- Again in the `integration/examples/getting-started` project run:
  ```
  skaffold build --platform=linux/foo
  ```
- You should get the following error:
  ```
  creating runner: getting target platforms: failed to parse platforms: unable to recognise platform "linux/foo": unknown architecture "foo". Check that the value provided to --platform flag is a valid platform and formatted correctly, like linux/amd64, linux/arm64, linux/arm/v7, etc..
  ```
