### PR TITLE
fix: adjust set namespace logic

### DIFF
--- a/pkg/skaffold/kubernetes/manifest/errors.go
+++ b/pkg/skaffold/kubernetes/manifest/errors.go
@@ -73,18 +73,3 @@ func nsSettingErr(err error) error {
 			ErrCode: proto.StatusCode_RENDER_SET_NAMESPACE_ERR,
 		})
 }
-
-func nsAlreadySetErr() error {
-	err := fmt.Errorf("namespace field already set in the manifests")
-	return sErrors.NewError(err,
-		&proto.ActionableErr{
-			Message: err.Error(),
-			ErrCode: proto.StatusCode_RENDER_NAMESPACE_ALREADY_SET_ERR,
-			Suggestions: []*proto.Suggestion{
-				{
-					SuggestionCode: proto.SuggestionCode_REMOVE_NAMESPACE_FROM_MANIFESTS,
-					Action:         "remove/unset 'namespace' field in manifests and try again",
-				},
-			},
-		})
-}

--- a/pkg/skaffold/kubernetes/manifest/namespace_test.go
+++ b/pkg/skaffold/kubernetes/manifest/namespace_test.go
@@ -409,7 +409,32 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: getting-started
-`)}},
+`)}}, {
+			description: "manifests with namespace set and empty value in CLI",
+			namespace:   "",
+			manifests: ManifestList{[]byte(`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: getting-started
+  namespace: my-namespace
+spec:
+  containers:
+    - image: gcr.io/k8s-skaffold/example
+      name: example
+`)},
+			expected: ManifestList{[]byte(`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: getting-started
+  namespace: my-namespace
+spec:
+  containers:
+  - image: gcr.io/k8s-skaffold/example
+    name: example
+`)},
+		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {

--- a/pkg/skaffold/kubernetes/manifest/namespaces.go
+++ b/pkg/skaffold/kubernetes/manifest/namespaces.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output/log"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yaml"
 )
 
@@ -135,7 +136,8 @@ func addOrUpdateNamespace(manifest map[string]interface{}, ns string) error {
 		return nil
 	}
 
-	return nsAlreadySetErr()
+	warnings.Printf("a manifest already has namespace set \"%s\" which conflicts with namespace on the CLI \"%s\"", nsValue, ns)
+	return nil
 }
 
 func isEmptyOrEqual(v interface{}, s string) bool {

--- a/pkg/skaffold/kubernetes/manifest/namespaces.go
+++ b/pkg/skaffold/kubernetes/manifest/namespaces.go
@@ -30,6 +30,8 @@ import (
 
 const namespaceField = "namespace"
 
+const defaultNamespace = "default"
+
 // CollectNamespaces returns all the namespaces in the manifests.
 func (l *ManifestList) CollectNamespaces() ([]string, error) {
 	replacer := newNamespaceCollector()
@@ -85,7 +87,7 @@ func (r *namespaceCollector) Visit(gk schema.GroupKind, navpath string, o map[st
 // Returns error if any manifest in the list has namespace set.
 func (l *ManifestList) SetNamespace(namespace string, rs ResourceSelector) (ManifestList, error) {
 	if namespace == "" {
-		namespace = "default"
+		namespace = defaultNamespace
 	}
 	var updated ManifestList
 	for _, item := range *l {
@@ -128,6 +130,11 @@ func addOrUpdateNamespace(manifest map[string]interface{}, ns string) error {
 		metadata[namespaceField] = ns
 		return nil
 	}
+
+	if present && isEmptyOrEqual(ns, defaultNamespace) {
+		return nil
+	}
+
 	return nsAlreadySetErr()
 }
 


### PR DESCRIPTION
Fixes: #7834

**Description**
Adjust set namespace logic in render phase to accept the case when there are k8s manifest with a namespace already set, and the skaffold `--namespace` flag is empty. Change from error to warning message when there is a problem setting the namespace.
