### PR TITLE
add: added service account to cloud build config

### DIFF
--- a/docs-v2/content/en/schemas/v3alpha1.json
+++ b/docs-v2/content/en/schemas/v3alpha1.json
@@ -1906,6 +1906,11 @@
           "description": "configures the region to run the build. If WorkerPool is configured, the region will be deduced from the WorkerPool configuration. If neither WorkerPool nor Region is configured, the build will be run in global(non-regional). See [Cloud Build locations](https://cloud.google.com/build/docs/locations).",
           "x-intellij-html-description": "configures the region to run the build. If WorkerPool is configured, the region will be deduced from the WorkerPool configuration. If neither WorkerPool nor Region is configured, the build will be run in global(non-regional). See <a href=\"https://cloud.google.com/build/docs/locations\">Cloud Build locations</a>."
         },
+        "serviceAccount": {
+          "type": "string",
+          "description": "Google Cloud platform service account used by Cloud Build. If unspecified, it defaults to the Cloud Build service account generated when the Cloud Build API is enabled.",
+          "x-intellij-html-description": "Google Cloud platform service account used by Cloud Build. If unspecified, it defaults to the Cloud Build service account generated when the Cloud Build API is enabled."
+        },
         "timeout": {
           "type": "string",
           "description": "amount of time (in seconds) that this build should be allowed to run. See [Cloud Build Reference](https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#resource-build).",
@@ -1933,7 +1938,8 @@
         "concurrency",
         "workerPool",
         "region",
-        "platformEmulatorInstallStep"
+        "platformEmulatorInstallStep",
+        "serviceAccount"
       ],
       "additionalProperties": false,
       "type": "object",

--- a/pkg/skaffold/build/gcb/spec.go
+++ b/pkg/skaffold/build/gcb/spec.go
@@ -54,6 +54,7 @@ func (b *Builder) buildSpec(ctx context.Context, artifact *latest.Artifact, tag 
 	buildSpec.Options.Logging = b.Logging
 	buildSpec.Options.LogStreamingOption = b.LogStreamingOption
 	buildSpec.Timeout = b.Timeout
+	buildSpec.ServiceAccount = b.ServiceAccount
 
 	return buildSpec, nil
 }

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -406,6 +406,11 @@ type GoogleCloudBuild struct {
 	// PlatformEmulatorInstallStep specifies a pre-build step to install the required tooling for QEMU emulation on the GoogleCloudBuild containers. This enables performing cross-platform builds on GoogleCloudBuild.
 	// If unspecified, Skaffold uses the `docker/binfmt` image by default.
 	PlatformEmulatorInstallStep *PlatformEmulatorInstallStep `yaml:"platformEmulatorInstallStep,omitempty"`
+
+	// ServiceAccount is the Google Cloud platform service account used by Cloud Build.
+	// If unspecified, it defaults to the Cloud Build service account generated when
+	// the Cloud Build API is enabled.
+	ServiceAccount string `yaml:"serviceAccount,omitempty"`
 }
 
 // PlatformEmulatorInstallStep specifies a pre-build step to install the required tooling for QEMU emulation on the GoogleCloudBuild containers. This enables performing cross-platform builds on GoogleCloudBuild.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #7787  <!-- tracking issues that this PR will close -->
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
This PR adds a Service Account field to Google Cloud Build configurations. 
It allow users set which service account (different from the default) is used by
cloud build.

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->

**Follow-up Work (remove if N/A)**
<!-- Mention any related follow up work to this PR. -->


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
