### PR TITLE
chore: add new marker for integration tests need mixed nodes cluster

### DIFF
--- a/integration/util.go
+++ b/integration/util.go
@@ -49,10 +49,16 @@ type TestType int
 const (
 	CanRunWithoutGcp TestType = iota
 	NeedsGcp
+	NeedsHybridCluster
 )
 
 func MarkIntegrationTest(t *testing.T, testType TestType) {
 	t.Helper()
+	runOnHybridCluster := os.Getenv("HYBRID_ONLY") == "true"
+	if runOnHybridCluster != (NeedsHybridCluster == testType) {
+		t.Skipf("Skipping test due to testType doesn't match environment setup : runOnHybrid: %t, NeedsHybridCluster: %t", runOnHybridCluster, NeedsHybridCluster == testType)
+	}
+
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}


### PR DESCRIPTION

**Description**
 - add a new testType -  NeedsHybridCluster for integration tests that need a mixed nodes cluster
 - Related build config will also be set on kokoro. 



