### PR TITLE
chore: remove unnecessary rerender from devloop,

### DIFF
--- a/cmd/skaffold/app/cmd/dev.go
+++ b/cmd/skaffold/app/cmd/dev.go
@@ -19,12 +19,10 @@ package cmd
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 
 	"github.com/spf13/cobra"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -71,14 +69,11 @@ func runDev(ctx context.Context, out io.Writer) error {
 					artifacts = append(artifacts, cfg.(*latest.SkaffoldConfig).Build.Artifacts...)
 				}
 				err := r.Dev(ctx, out, artifacts)
+				manifestListByConfig := r.DeployManifests()
 
-				if r.DeployManifests().String() != "" {
+				if manifestListByConfig.String() != "" {
 					cleanup = func() {
-						manifestsByConfig, err := r.Render(ctx, io.Discard, []graph.Artifact{}, false)
-						if err != nil {
-							log.Entry(ctx).Warn(fmt.Errorf("failed to render manifests: %w", err))
-						}
-						if err := r.Cleanup(context.Background(), out, false, manifestsByConfig); err != nil {
+						if err := r.Cleanup(context.Background(), out, false, manifestListByConfig); err != nil {
 							log.Entry(ctx).Warn("deployer cleanup:", err)
 						}
 					}

--- a/cmd/skaffold/app/cmd/dev_test.go
+++ b/cmd/skaffold/app/cmd/dev_test.go
@@ -80,7 +80,7 @@ func TestDoDev(t *testing.T) {
 			description:       "cleanup and then prune",
 			hasBuilt:          true,
 			deployedManifests: manifest.ManifestList{[]byte("dummy")},
-			expectedCalls:     []string{"Dev", "DeployManifests", "HasBuilt", "Render", "Cleanup", "Prune"},
+			expectedCalls:     []string{"Dev", "DeployManifests", "HasBuilt", "Cleanup", "Prune"},
 		},
 		{
 			description:       "hasn't deployed",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #7805
**Related**:  #7657 
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
 - remove unnecessary rerender from devloop and use pre-rendered result from r.DeployedManifests for cleanup work.

