### PR TITLE
fix: remove Cloud Run location validation for non-remote commands

### DIFF
--- a/pkg/skaffold/schema/validation/validation.go
+++ b/pkg/skaffold/schema/validation/validation.go
@@ -834,6 +834,10 @@ func validateKubectlManifests(configs parser.SkaffoldConfigSet) (errs []ErrorWit
 }
 
 func validateLocationSetForCloudRun(rCtx *runcontext.RunContext) []error {
+	if !requiresCloudRun(rCtx) {
+		// if the current command doesn't require connecting to Cloud Run, a location isn't needed.
+		return nil
+	}
 	runDeployer := false
 	hasLocation := false
 	if rCtx.Opts.CloudRunLocation != "" {
@@ -867,4 +871,18 @@ func validateLocationSetForCloudRun(rCtx *runcontext.RunContext) []error {
 		}
 	}
 	return nil
+}
+
+// requiresCloudRun returns true if the current command needs to connect to a Cloud Run regional endpoint.
+func requiresCloudRun(rCtx *runcontext.RunContext) bool {
+	runCommands := map[string]bool{
+		"run":    true,
+		"deploy": true,
+		"debug":  true,
+		"dev":    true,
+		"delete": true,
+		"apply":  true,
+	}
+	_, ok := runCommands[rCtx.Opts.Command]
+	return ok
 }

--- a/pkg/skaffold/schema/validation/validation_test.go
+++ b/pkg/skaffold/schema/validation/validation_test.go
@@ -1757,6 +1757,7 @@ func TestValidateCloudRunLocation(t *testing.T) {
 		deploy           latest.DeployConfig
 		cloudRunLocation string
 		cloudRunProject  string
+		command          string
 		shouldErr        bool
 	}{
 		{
@@ -1779,6 +1780,16 @@ func TestValidateCloudRunLocation(t *testing.T) {
 				},
 			},
 			shouldErr: true,
+		},
+		{
+			description: "location not specified, command doesn't deploy",
+			deploy: latest.DeployConfig{
+				DeployType: latest.DeployType{
+					CloudRunDeploy: &latest.CloudRunDeploy{},
+				},
+			},
+			command:   "diagnose",
+			shouldErr: false,
 		},
 		{
 			description: "location specified via flag",
@@ -1804,6 +1815,10 @@ func TestValidateCloudRunLocation(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
+			command := test.command
+			if command == "" {
+				command = "run"
+			}
 			err := ProcessWithRunContext(context.Background(), &runcontext.RunContext{
 				Pipelines: runcontext.NewPipelines(
 					map[string]latest.Pipeline{
@@ -1815,6 +1830,7 @@ func TestValidateCloudRunLocation(t *testing.T) {
 				Opts: config.SkaffoldOptions{
 					CloudRunProject:  test.cloudRunProject,
 					CloudRunLocation: test.cloudRunLocation,
+					Command:          command,
 				},
 			})
 


### PR DESCRIPTION
For commands like render and diagnose that do not connect to a Cloud Run instance, don't require a Cloud Run location to be set even when the deployer is specified. It can be provided via flag when a rendered manifest is deployed. 