### PR TITLE
chore: change `jib.from.image` to multi-arch image

### DIFF
--- a/examples/jib-gradle/build.gradle
+++ b/examples/jib-gradle/build.gradle
@@ -39,4 +39,4 @@ compileJava.options.compilerArgs += '-parameters'
 compileTestJava.options.compilerArgs += '-parameters'
 mainClassName = 'example.micronaut.Application'
 
-jib.from.image = 'gcr.io/google-appengine/openjdk:8'
+jib.from.image = 'openjdk:8'

--- a/examples/jib-multimodule/pom.xml
+++ b/examples/jib-multimodule/pom.xml
@@ -42,7 +42,7 @@
           <version>${jib.maven-plugin-version}</version>
           <configuration>
             <from>
-              <image>gcr.io/google-appengine/openjdk:8</image>
+              <image>openjdk:8</image>
             </from>
           </configuration>
         </plugin>

--- a/examples/jib-sync/build.gradle
+++ b/examples/jib-sync/build.gradle
@@ -22,4 +22,4 @@ dependencies {
   testImplementation "org.springframework.boot:spring-boot-starter-test"
 }
 
-jib.from.image = 'gcr.io/google-appengine/openjdk:8'
+jib.from.image = 'openjdk:8'

--- a/examples/jib-sync/pom.xml
+++ b/examples/jib-sync/pom.xml
@@ -38,7 +38,7 @@
         <version>${jib.maven-plugin-version}</version>
         <configuration>
           <from>
-            <image>gcr.io/google-appengine/openjdk:8</image>
+            <image>openjdk:8</image>
           </from>
           <container>
             <jvmFlags>

--- a/examples/jib/pom.xml
+++ b/examples/jib/pom.xml
@@ -38,7 +38,7 @@
                 <version>${jib.maven-plugin-version}</version>
                 <configuration>
                     <from>
-                        <image>gcr.io/google-appengine/openjdk:8</image>
+                        <image>openjdk:8</image>
                     </from>
                     <container>
                         <jvmFlags>

--- a/integration/examples/jib-gradle/build.gradle
+++ b/integration/examples/jib-gradle/build.gradle
@@ -39,4 +39,4 @@ compileJava.options.compilerArgs += '-parameters'
 compileTestJava.options.compilerArgs += '-parameters'
 mainClassName = 'example.micronaut.Application'
 
-jib.from.image = 'gcr.io/google-appengine/openjdk:8'
+jib.from.image = 'openjdk:8'

--- a/integration/examples/jib-multimodule/pom.xml
+++ b/integration/examples/jib-multimodule/pom.xml
@@ -42,7 +42,7 @@
           <version>${jib.maven-plugin-version}</version>
           <configuration>
             <from>
-              <image>gcr.io/google-appengine/openjdk:8</image>
+              <image>openjdk:8</image>
             </from>
           </configuration>
         </plugin>

--- a/integration/examples/jib-sync/build.gradle
+++ b/integration/examples/jib-sync/build.gradle
@@ -22,4 +22,4 @@ dependencies {
   testImplementation "org.springframework.boot:spring-boot-starter-test"
 }
 
-jib.from.image = 'gcr.io/google-appengine/openjdk:8'
+jib.from.image = 'openjdk:8'

--- a/integration/examples/jib-sync/pom.xml
+++ b/integration/examples/jib-sync/pom.xml
@@ -38,7 +38,7 @@
         <version>${jib.maven-plugin-version}</version>
         <configuration>
           <from>
-            <image>gcr.io/google-appengine/openjdk:8</image>
+            <image>openjdk:8</image>
           </from>
           <container>
             <jvmFlags>

--- a/integration/examples/jib/pom.xml
+++ b/integration/examples/jib/pom.xml
@@ -38,7 +38,7 @@
                 <version>${jib.maven-plugin-version}</version>
                 <configuration>
                     <from>
-                        <image>gcr.io/google-appengine/openjdk:8</image>
+                        <image>openjdk:8</image>
                     </from>
                     <container>
                         <jvmFlags>

--- a/integration/testdata/debug/java/pom.xml
+++ b/integration/testdata/debug/java/pom.xml
@@ -22,7 +22,7 @@
         <version>${jib.maven-plugin-version}</version>
         <configuration>
           <from>
-            <image>gcr.io/google-appengine/openjdk:8</image> <!-- has jdb -->
+            <image>openjdk:8</image> <!-- has jdb -->
           </from>
           <container>
             <jvmFlags>

--- a/integration/testdata/jib/pom.xml
+++ b/integration/testdata/jib/pom.xml
@@ -22,7 +22,7 @@
                 <version>${jib.maven-plugin-version}</version>
                 <configuration>
                     <from>
-                        <image>gcr.io/google-appengine/openjdk:8</image>
+                        <image>openjdk:8</image>
                     </from>
                     <container>
                         <jvmFlags>


### PR DESCRIPTION

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Update `jib` examples to use `index.docker.io/openjdk:8` image. The `gcr.io/google-engine/openjdk:8` is a single-platform image for `linux/amd64` which doesn't work for building cross-platform and multi-platform images.