### PR TITLE
docs: Fix incorrect default set for project for jib

### DIFF
--- a/docs-v2/content/en/docs/pipeline-stages/builders/jib.md
+++ b/docs-v2/content/en/docs/pipeline-stages/builders/jib.md
@@ -86,7 +86,7 @@ a container image.  Then for each such sub-project:
 
   - Create a Skaffold `artifact` in the `skaffold.yaml`.
   - Set the `artifact`'s `context` field to the root project location.
-  - Add a `jib` element and set its `project` field to the sub-project's name (the directory, by default).
+  - Add a `jib` element and set its `project` field to the sub-project's name.
 
 
 ## Remotely with Google Cloud Build


### PR DESCRIPTION
Fixes #7454 

I verified for  jib project key there was no default set in pkg/skaffold/schema/defaults folder and also nothing checked here. 
https://github.com/GoogleContainerTools/skaffold/blob/e5a846c1efc57f7073b30b6ab010a0d9fe84a115/pkg/skaffold/build/jib/jib.go#L94
