### PR TITLE
chore: update Ingress manifests

### DIFF
--- a/examples/helm-deployment-dependencies/skaffold-helm/charts/subchart/templates/ingress.yaml
+++ b/examples/helm-deployment-dependencies/skaffold-helm/charts/subchart/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "subchart.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "subchart.fullname" . }}
@@ -21,9 +21,12 @@ spec:
       http:
         paths:
           - path: /
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
     {{- end -}}
   {{- if .Values.ingress.tls }}
   tls:

--- a/examples/helm-deployment-dependencies/skaffold-helm/templates/ingress.yaml
+++ b/examples/helm-deployment-dependencies/skaffold-helm/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "skaffold-helm.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "skaffold-helm.fullname" . }}
@@ -21,9 +21,12 @@ spec:
       http:
         paths:
           - path: /
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
     {{- end -}}
   {{- if .Values.ingress.tls }}
   tls:

--- a/integration/examples/helm-deployment-dependencies/skaffold-helm/charts/subchart/templates/ingress.yaml
+++ b/integration/examples/helm-deployment-dependencies/skaffold-helm/charts/subchart/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "subchart.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "subchart.fullname" . }}
@@ -21,9 +21,12 @@ spec:
       http:
         paths:
           - path: /
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
     {{- end -}}
   {{- if .Values.ingress.tls }}
   tls:

--- a/integration/examples/helm-deployment-dependencies/skaffold-helm/templates/ingress.yaml
+++ b/integration/examples/helm-deployment-dependencies/skaffold-helm/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "skaffold-helm.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "skaffold-helm.fullname" . }}
@@ -21,9 +21,12 @@ spec:
       http:
         paths:
           - path: /
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
     {{- end -}}
   {{- if .Values.ingress.tls }}
   tls:

--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -342,7 +342,7 @@ spec:
         - containerPort: 80
         resources: {}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations: null
@@ -357,9 +357,12 @@ spec:
   - http:
       paths:
       - backend:
-          serviceName: skaffold-helm-skaffold-helm
-          servicePort: 80
+          service:
+            name: skaffold-helm-skaffold-helm
+            port:
+              number: 80
         path: /
+        pathType: ImplementationSpecific
 `,
 		},
 	}

--- a/integration/testdata/helm-render/skaffold-helm/templates/ingress.yaml
+++ b/integration/testdata/helm-render/skaffold-helm/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "skaffold-helm.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "skaffold-helm.fullname" . }}
@@ -22,17 +22,23 @@ spec:
       http:
         paths:
           - path: /
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
     {{- end -}}
     {{- else }}
     - http:
         paths:
           - path: /
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
     {{- end -}}
   {{- if .Values.ingress.tls }}
   tls:

--- a/integration/testdata/helm/skaffold-helm/templates/ingress.yaml
+++ b/integration/testdata/helm/skaffold-helm/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "skaffold-helm.fullname" . -}}
 {{- $servicePort := .Values.service.externalPort -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "skaffold-helm.fullname" . }}
@@ -22,17 +22,23 @@ spec:
       http:
         paths:
           - path: /
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
     {{- end -}}
     {{- else }}
     - http:
         paths:
           - path: /
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
     {{- end -}}
   {{- if .Values.ingress.tls }}
   tls:

--- a/pkg/skaffold/deploy/helm/parse_test.go
+++ b/pkg/skaffold/deploy/helm/parse_test.go
@@ -108,7 +108,7 @@ spec:
    release: skaffold-helm
 ---
 # Source: skaffold-helm/templates/ingress.yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
  name: skaffold-helm-skaffold-helm
@@ -124,9 +124,12 @@ spec:
    - http:
        paths:
          - path: /
+           pathType: ImplementationSpecific
            backend:
-             serviceName: skaffold-helm-skaffold-helm
-             servicePort: 80`),
+           service:
+             name: skaffold-helm-skaffold-helm
+             port:
+               number: 80`),
 			expected: []types.Artifact{{Namespace: "testNamespace"}, {Namespace: "test"}},
 		},
 		{

--- a/pkg/skaffold/deploy/testdata/foo/templates/ingress.yaml
+++ b/pkg/skaffold/deploy/testdata/foo/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "foo.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -32,8 +32,11 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Update all `Ingress` manifests to use `apiVersion: networking.k8s.io/v1` instead of the deprecated `extensions/v1beta1`. Without this, the auto-update of `k8s-skaffold/integration-tests` Kubernetes cluster was blocked.
<img width="1004" alt="image" src="https://user-images.githubusercontent.com/39389231/190037294-454f9727-178a-4974-ae1f-162ca5a787ff.png">
