### PR TITLE
fix: add inputDigest tagger alias to customTemplate tagger

### DIFF
--- a/pkg/skaffold/tag/git_commit_test.go
+++ b/pkg/skaffold/tag/git_commit_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -530,6 +532,9 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 }
 
 func TestGitCommit_CustomTemplate(t *testing.T) {
+	ctx := context.Background()
+	runCtx, _ := runcontext.GetRunContext(ctx, config.SkaffoldOptions{}, nil)
+
 	gitCommitExample, _ := NewGitCommit("", "CommitSha", false)
 	tests := []struct {
 		description   string
@@ -573,11 +578,11 @@ func TestGitCommit_CustomTemplate(t *testing.T) {
 				Workspace: tmpDir.Path(test.subDir),
 			}
 
-			c, err := NewCustomTemplateTagger(test.template, test.customMap)
+			c, err := NewCustomTemplateTagger(runCtx, test.template, test.customMap)
 
 			t.CheckNoError(err)
 
-			tag, err := c.GenerateTag(context.Background(), image)
+			tag, err := c.GenerateTag(ctx, image)
 
 			t.CheckNoError(err)
 			t.CheckDeepEqual(test.expected, tag)

--- a/pkg/skaffold/tag/input_digest.go
+++ b/pkg/skaffold/tag/input_digest.go
@@ -40,9 +40,13 @@ type inputDigestTagger struct {
 }
 
 func NewInputDigestTagger(cfg docker.Config, ag graph.ArtifactGraph) (Tagger, error) {
+	return NewInputDigestTaggerWithSourceCache(cfg, graph.NewSourceDependenciesCache(cfg, nil, ag))
+}
+
+func NewInputDigestTaggerWithSourceCache(cfg docker.Config, cache graph.SourceDependenciesCache) (Tagger, error) {
 	return &inputDigestTagger{
 		cfg:   cfg,
-		cache: graph.NewSourceDependenciesCache(cfg, nil, ag),
+		cache: cache,
 	}, nil
 }
 

--- a/pkg/skaffold/tag/tag_test.go
+++ b/pkg/skaffold/tag/tag_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"
@@ -42,7 +44,11 @@ func TestTagger_GenerateFullyQualifiedImageName(t *testing.T) {
 	}
 	dateTimeExpected := "2015-03-07"
 
-	customTemplateExample, _ := NewCustomTemplateTagger("{{.DATE}}_{{.SHA}}", map[string]Tagger{"DATE": dateTimeExample})
+	ctx := context.Background()
+	runCtx, _ := runcontext.GetRunContext(ctx, config.SkaffoldOptions{}, nil)
+	customTemplateExample, _ := NewCustomTemplateTagger(runCtx, "{{.DATE}}_{{.SHA}}", map[string]Tagger{
+		"DATE": dateTimeExample,
+	})
 
 	tests := []struct {
 		description      string
@@ -121,7 +127,7 @@ func TestTagger_GenerateFullyQualifiedImageName(t *testing.T) {
 				ImageName: test.imageName,
 			}
 
-			tag, err := GenerateFullyQualifiedImageName(context.Background(), test.tagger, image)
+			tag, err := GenerateFullyQualifiedImageName(ctx, test.tagger, image)
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, tag)
 			t.CheckDeepEqual(test.expectedWarnings, fakeWarner.Warnings)
 		})

--- a/pkg/skaffold/tag/tagger_mux.go
+++ b/pkg/skaffold/tag/tagger_mux.go
@@ -85,7 +85,7 @@ func getTagger(runCtx *runcontext.RunContext, t *latest.TagPolicy) (Tagger, erro
 			return nil, fmt.Errorf("creating components: %w", err)
 		}
 
-		return NewCustomTemplateTagger(t.CustomTemplateTagger.Template, components)
+		return NewCustomTemplateTagger(runCtx, t.CustomTemplateTagger.Template, components)
 
 	default:
 		return nil, fmt.Errorf("unknown tagger for strategy %+v", t)

--- a/pkg/skaffold/tag/template_utils.go
+++ b/pkg/skaffold/tag/template_utils.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tag
+
+import (
+	"reflect"
+	"text/template"
+	"text/template/parse"
+)
+
+// GetTemplateFields returns a list of template variables.
+func GetTemplateFields(t *template.Template) []string {
+	fields := getNodeFields(t.Root.Nodes...)
+	u := make([]string, 0, len(fields))
+	m := make(map[string]bool)
+
+	for _, f := range fields {
+		if _, ok := m[f]; !ok {
+			m[f] = true
+			u = append(u, f)
+		}
+	}
+	return u
+}
+
+// getNodeFields returns a list of template node list fields.
+func getNodeFields(nodes ...parse.Node) []string {
+	var fields []string
+	for _, node := range nodes {
+		fields = append(fields, getFields(node)...)
+	}
+	return fields
+}
+
+// getFields returns a list of template node fields.
+func getFields(node parse.Node) []string {
+	var fields []string
+	if reflect.ValueOf(node).IsNil() {
+		return fields
+	}
+	switch n := node.(type) {
+	case *parse.FieldNode:
+		return n.Ident
+	case *parse.ActionNode:
+		return getFields(n.Pipe)
+	case *parse.TemplateNode:
+		return getFields(n.Pipe)
+	case *parse.CommandNode:
+		return getNodeFields(n.Args...)
+	case *parse.ListNode:
+		return getNodeFields(n.Nodes...)
+	case *parse.IfNode:
+		return getNodeFields(n.Pipe, n.List, n.ElseList)
+	case *parse.RangeNode:
+		return getNodeFields(n.Pipe, n.List, n.ElseList)
+	case *parse.WithNode:
+		return getNodeFields(n.Pipe, n.List, n.ElseList)
+	case *parse.PipeNode:
+		for _, cmd := range n.Cmds {
+			fields = append(fields, getFields(cmd)...)
+		}
+	}
+	return fields
+}

--- a/pkg/skaffold/tag/template_utils_test.go
+++ b/pkg/skaffold/tag/template_utils_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tag
+
+import (
+	"testing"
+	"text/template"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestTemplateUtils_GetTemplateVariables(t *testing.T) {
+	tests := []struct {
+		description string
+		template    string
+		expected    []string
+	}{
+		{
+			description: "variables",
+			template:    "{{.V1}}  {{.V1}}    {{.V2}}",
+			expected:    []string{"V1", "V2"},
+		},
+		{
+			description: "condition",
+			template:    "{{.V1}}{{if ne .V1 .V2}}{{.V3}}{{else if .V4}}{{else}}{{.V5}}{{end}}",
+			expected:    []string{"V1", "V2", "V3", "V4", "V5"},
+		},
+		{
+			description: "range",
+			template:    "{{range .V1}}{{.V2}}{{end}}",
+			expected:    []string{"V1", "V2"},
+		},
+		{
+			description: "block-template",
+			template:    `{{block "b1" .V1}}block content{{end}}{{template "t1" .V2}}`,
+			expected:    []string{"V1", "V2"},
+		},
+		{
+			description: "with",
+			template:    "{{with .V1}} {{.V2}} {{else}} {{.V3}} {{end}}",
+			expected:    []string{"V1", "V2", "V3"},
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			parsedTemplate, _ := template.New(test.description).Parse(test.template)
+			variables := GetTemplateFields(parsedTemplate)
+
+			t.CheckDeepEqual(test.expected, variables)
+		})
+	}
+}


### PR DESCRIPTION
Fixes: #7865

**Description**
It modifies `customTemplate` tagger to support `inputDigest` by default:
- Given template is parsed to understand which variables to expect. This way it's not required to initialize all possible taggers in advance. And it seriously simplifies testing.
- Taggers are created one by one giving higher priority to the ones defined in `components`.
