### PR TITLE
chore: skip buildpacks integration test if being run on arm cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ ifeq ($(GCP_ONLY),true)
 		--zone $(GKE_ZONE) \
 		--project $(GCP_PROJECT)
 endif
-	@ GCP_ONLY=$(GCP_ONLY) ./hack/gotest.sh -v $(REPOPATH)/integration/binpack $(REPOPATH)/integration -timeout 50m $(INTEGRATION_TEST_ARGS)
+	@ GCP_ONLY=$(GCP_ONLY) GKE_CLUSTER_NAME=$(GKE_CLUSTER_NAME) ./hack/gotest.sh -v $(REPOPATH)/integration/binpack $(REPOPATH)/integration -timeout 50m $(INTEGRATION_TEST_ARGS)
 
 .PHONY: integration
 integration: install integration-tests

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -350,6 +350,9 @@ func TestRunGCPOnly(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
+		if (os.Getenv("GKE_CLUSTER_NAME") == "integration-tests-arm" || os.Getenv("GKE_CLUSTER_NAME") == "integration-tests-hybrid") && strings.Contains(test.description, "buildpacks") {
+			continue // buildpacks doesn't support arm64 builds, so skip run on these clusters
+		}
 		t.Run(test.description, func(t *testing.T) {
 			ns, client := SetupNamespace(t)
 


### PR DESCRIPTION
This PR marks a buildpacks integration test to skip for the cross platform and hybrid clusters.