### PR TITLE
Add an example for helm chart with multiple images

### DIFF
--- a/docs-v2/content/en/docs/pipeline-stages/deployers/helm.md
+++ b/docs-v2/content/en/docs/pipeline-stages/deployers/helm.md
@@ -23,6 +23,79 @@ Skaffold no longer requires the intricate configuring of `artifactsOverride` and
 {{< /alert >}}
 
 
+## Image Configuration
+The normal Helm convention for defining image references is through the `values.yaml` file. Often, image information is configured through an `image` stanza in the values file, which might look something like this:
+
+```project_root/values.yaml```
+```yaml
+image:
+  repository: gcr.io/my-project/my-image
+  tag: v1.2.0
+  pullPolicy: IfNotPresent
+```
+
+This image would then be referenced in a templated resource file, maybe like this:
+
+```project_root/templates/deployment.yaml:```
+```yaml
+spec:
+  template:
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag}}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+```
+
+**IMPORTANT: To get Skaffold to work with Helm, the `image` key must be configured in the skaffold.yaml.**
+
+Associating the Helm image key allows Skaffold to track the image being built, and then configure Helm to substitute it in the proper resource definitions to be deployed to your cluster. In practice, this looks something like this:
+
+```yaml
+build:
+  artifacts:
+    - image: gcr.io/my-project/my-image # must match in artifactOverrides
+deploy:
+  helm:
+    releases:
+    - name: my-release
+      artifactOverrides:
+        image: gcr.io/my-project/my-image # no tag present!
+      imageStrategy:
+        helm: {}
+```
+
+The `artifactOverrides` binds a Helm value key to a build artifact.  The `imageStrategy` configures the image reference strategy for informing Helm of the image reference to a newly built artifact.
+
+### Multiple image overrides
+
+To override multiple images (ie a Pod with a side car) you can simply add additional variables. For example, the following helm template:
+
+```yaml
+spec:
+  containers:
+    - name: firstContainer
+      image: "{{.Values.firstContainerImage}}"
+      ....
+    - name: secondContainer
+      image: "{{.Values.secondContainerImage}}"
+      ...
+```
+
+can be overriden with:
+
+```
+deploy:
+  helm:
+    releases:
+    - name: my-release
+      artifactOverrides:
+        firstContainerImage: gcr.io/my-project/first-image # no tag present!
+        secondContainerImage: gcr.io/my-project/second-image # no tag present!
+      imageStrategy:
+        helm: {}
+```
+
 ### Helm Build Dependencies
 
 The `skipBuildDependencies` flag toggles whether dependencies of the Helm chart are built with the `helm dep build` command. This command manipulates files inside the `charts` subfolder of the specified Helm chart.

--- a/docs/content/en/docs/pipeline-stages/deployers/helm.md
+++ b/docs/content/en/docs/pipeline-stages/deployers/helm.md
@@ -62,6 +62,35 @@ deploy:
 
 The `artifactOverrides` binds a Helm value key to a build artifact.  The `imageStrategy` configures the image reference strategy for informing Helm of the image reference to a newly built artifact.
 
+### Multiple image overrides
+
+To override multiple images (ie a Pod with a side car) you can simply add additional variables. For example, the following helm template:
+
+```yaml
+spec:
+  containers:
+    - name: firstContainer
+      image: "{{.Values.firstContainerImage}}"
+      ....
+    - name: secondContainer
+      image: "{{.Values.secondContainerImage}}"
+      ...
+```
+
+can be overriden with:
+
+```
+deploy:
+  helm:
+    releases:
+    - name: my-release
+      artifactOverrides:
+        firstContainerImage: gcr.io/my-project/first-image # no tag present!
+        secondContainerImage: gcr.io/my-project/second-image # no tag present!
+      imageStrategy:
+        helm: {}
+```
+
 ### Image reference strategies
 
 Skaffold supports three _image reference strategies_ for Helm:


### PR DESCRIPTION
Shows how to override multiple images in a helm template

<!-- Thank you for your contribution! -->

**Description**
Documentation-only changes: Add a snippet showing how to override multiple images from skaffold-built artifacts. I was testing with this and thought an example in the doc would be useful. Thoughts?
