### PR TITLE
fix: copy dependencies to a new slice to prevent mutation affecting the cache value

### DIFF
--- a/pkg/skaffold/graph/dependencies.go
+++ b/pkg/skaffold/graph/dependencies.go
@@ -98,7 +98,10 @@ func (r *dependencyResolverImpl) SingleArtifactDependencies(ctx context.Context,
 		endTrace(instrumentation.TraceEndError(err))
 		return nil, err
 	}
-	return res.([]string), nil
+
+	deps := make([]string, len(res.([]string)))
+	copy(deps, res.([]string))
+	return deps, nil
 }
 
 func (r *dependencyResolverImpl) Reset() {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->

There is a bad interaction in dependency building which exposes itself only under a specific set of conditions, the result of which is that `skaffold dev` hashes the wrong set of files for an artefact. 

The set of files that make up an artefact are stored in a sync.Map, and when it is loaded the underlying array will be mutated if the following conditions are met:
* The artefact you are building depends on another artefact.
* The files of the child artefact appear before the files of the parent artefact when sorted alphabetically. E.g. parent: `/path/to/project/artefact-foo`, child: `/path/to/project/artefact-bar`.
* The remaining capacity of the slice containing the files for the parents is large enough that [appending the files for the child](https://github.com/GoogleContainerTools/skaffold/blob/1f5af29273e2938c66311fcc22ddf0fcceeeffd7/pkg/skaffold/graph/dependencies.go#L79) does not create a new underlying array.

When the above conditions are met, [this](https://github.com/GoogleContainerTools/skaffold/blob/1f5af29273e2938c66311fcc22ddf0fcceeeffd7/pkg/skaffold/tag/input_digest.go#L57) sort will mutate the underlying array in such a way that future loads from the store for the parent artefact will return a slice with the child artefacts files at the top, and some of the parent artefacts files will be pushed out (depending on the number of files that make up the child artefact).  

This can be trivially reproduced outside of skaffold:
```
package main

import (
	"fmt"
	"reflect"
	"sort"
	"unsafe"
)

func main() {
	foo := make(map[string][]string)
	arr := make([]string, 0, 92)
	arr = append(arr, "c", "d")
	foo["x"] = arr

	var pulled []string
	pulled = foo["x"]
	pulled = append(pulled, []string{"a", "b"}...)

	var pulled2 []string
	pulled2 = foo["x"]

	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&pulled2))
	data := (*[4]string)(unsafe.Pointer(hdr.Data))

	fmt.Printf("foo[\"x\"] before sorting: %v. Underlying array: %v\n", foo["x"], data)

	sort.Strings(pulled)

	fmt.Printf("foo[\"x\"] after sorting: %v. Underlying array: %v\n", foo["x"], data)
}
```

This PR creates a copy of the deps slice before returning it to be mutated. I'm not sure if this is the right fix, but it does do the right thing.