### PR TITLE
fix: remove RenderConfig and fix manifests issues with multi-config

### DIFF
--- a/pkg/skaffold/render/renderer/renderer.go
+++ b/pkg/skaffold/render/renderer/renderer.go
@@ -47,13 +47,13 @@ func New(ctx context.Context, cfg render.Config, renderCfg latest.RenderConfig, 
 		}
 		log.Entry(ctx).Infof("setting up kpt renderer")
 		return GroupRenderer{
-			Renderers:  []Renderer{r},
-			HookRunner: hooks.NewRenderRunner(renderCfg.Generate.LifecycleHooks, &[]string{cfg.GetNamespace()}, hooks.NewRenderEnvOpts(cfg.GetKubeContext(), []string{cfg.GetNamespace()})),
+			Renderers:   []Renderer{r},
+			HookRunners: []hooks.Runner{hooks.NewRenderRunner(renderCfg.Generate.LifecycleHooks, &[]string{cfg.GetNamespace()}, hooks.NewRenderEnvOpts(cfg.GetKubeContext(), []string{cfg.GetNamespace()}))},
 		}, err
 	}
 
 	var rs GroupRenderer
-	rs.HookRunner = hooks.NewRenderRunner(renderCfg.Generate.LifecycleHooks, &[]string{cfg.GetNamespace()}, hooks.NewRenderEnvOpts(cfg.GetKubeContext(), []string{cfg.GetNamespace()}))
+	rs.HookRunners = []hooks.Runner{hooks.NewRenderRunner(renderCfg.Generate.LifecycleHooks, &[]string{cfg.GetNamespace()}, hooks.NewRenderEnvOpts(cfg.GetKubeContext(), []string{cfg.GetNamespace()}))}
 	if renderCfg.RawK8s != nil || renderCfg.Kustomize != nil {
 		r, err := kubectl.New(cfg, renderCfg, labels, configName, cfg.GetNamespace())
 		if err != nil {

--- a/pkg/skaffold/runner/renderer.go
+++ b/pkg/skaffold/runner/renderer.go
@@ -31,15 +31,14 @@ func GetRenderer(ctx context.Context, runCtx *runcontext.RunContext, hydrationDi
 	ps := runCtx.Pipelines.AllByConfigNames()
 
 	var gr renderer.GroupRenderer
-	gr.HookRunner = hooks.NewRenderRunner(runCtx.GetRenderConfig().LifecycleHooks, &[]string{runCtx.GetNamespace()},
-		hooks.NewRenderEnvOpts(runCtx.KubeContext, []string{runCtx.GetNamespace()}))
 	for configName, p := range ps {
 		rs, err := renderer.New(ctx, runCtx, p.Render, hydrationDir, labels, configName)
 		if err != nil {
 			return nil, err
 		}
 		gr.Renderers = append(gr.Renderers, rs.Renderers...)
-		gr.HookRunner = rs.HookRunner
+		gr.HookRunners = append(gr.HookRunners, hooks.NewRenderRunner(p.Render.LifecycleHooks, &[]string{runCtx.GetNamespace()},
+			hooks.NewRenderEnvOpts(runCtx.KubeContext, []string{runCtx.GetNamespace()})))
 	}
 	// In case of legacy helm deployer configured and render command used
 	// force a helm renderer from deploy helm config

--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -288,16 +288,6 @@ func (rc *RunContext) EnableGKEARMNodeTolerationInRenderedManifests() bool {
 	return rc.Opts.EnableGKEARMNodeToleration
 }
 
-// GetRenderConfig returns the top tier RenderConfig.
-// TODO: design how to support multi-module.
-func (rc *RunContext) GetRenderConfig() *latest.RenderConfig {
-	p := rc.GetPipelines()
-	if len(p) > 0 {
-		return &p[0].Render
-	}
-	return &latest.RenderConfig{}
-}
-
 func (rc *RunContext) DigestSource() string {
 	if rc.Opts.DigestSource != "" {
 		return rc.Opts.DigestSource


### PR DESCRIPTION
fixes #7873 

Manually tested via attempting to import hooks from a child skaffold.yaml:
```
aprindle@aprindle-ssd ~/repro-7873 $ skaffold-bin-at-head render
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: kustomize-test
  name: kustomize-test
  namespace: default
spec:
  replicas: 1
  selector:
    matchLabels:
      app: kustomize-test
  template:
    metadata:
      labels:
        app: kustomize-test
    spec:
      containers:
      - command:
        - sleep
        - "3600"
        image: index.docker.io/library/busybox
        name: kustomize-test
      tolerations:
      - effect: NoSchedule
        key: kubernetes.io/arch
        operator: Equal
        value: arm64
 ```
 
 ```
aprindle@aprindle-ssd ~/repro-7873 $ skaffold-bin-at-this-pr render
Starting pre-render hooks...
pre-render host hook running on aprindle-ssd.c.googlers.com!
Completed pre-render hooks
Starting post-render hooks...
post-render host hook running on aprindle-ssd.c.googlers.com!
Completed post-render hooks
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: kustomize-test
  name: kustomize-test
  namespace: default
spec:
  replicas: 1
  selector:
    matchLabels:
      app: kustomize-test
  template:
    metadata:
      labels:
        app: kustomize-test
    spec:
      containers:
      - command:
        - sleep
        - "3600"
        image: index.docker.io/library/busybox
        name: kustomize-test
      tolerations:
      - effect: NoSchedule
        key: kubernetes.io/arch
        operator: Equal
        value: arm64
```