### PR TITLE
fix: ensure project descriptor in Pack Build

### DIFF
--- a/pkg/skaffold/build/buildpacks/lifecycle.go
+++ b/pkg/skaffold/build/buildpacks/lifecycle.go
@@ -67,11 +67,12 @@ func (b *Builder) build(ctx context.Context, out io.Writer, a *latest.Artifact, 
 	}
 	latest := parsed.BaseName + ":latest"
 
-	// Evaluate Env Vars.
+	// Evaluate Env Vars replacing those in project.toml.
 	env, err := env(a, b.mode, projectDescriptor)
 	if err != nil {
 		return "", fmt.Errorf("unable to evaluate env variables: %w", err)
 	}
+	projectDescriptor.Build.Env = nil
 
 	cc, err := containerConfig(artifact)
 	if err != nil {
@@ -94,22 +95,22 @@ func (b *Builder) build(ctx context.Context, out io.Writer, a *latest.Artifact, 
 			}
 		}
 	}
+	projectDescriptor.Build.Buildpacks = nil
 
 	builderImage, runImage, pullPolicy := resolveDependencyImages(artifact, b.artifacts, a.Dependencies, b.pushImages)
 
 	if err := runPackBuildFunc(ctx, out, b.localDocker, pack.BuildOptions{
-		AppPath:         workspace,
-		Builder:         builderImage,
-		RunImage:        runImage,
-		Buildpacks:      buildpacks,
-		Env:             env,
-		Image:           latest,
-		PullPolicy:      pullPolicy,
-		TrustBuilder:    func(_ string) bool { return artifact.TrustBuilder },
-		ClearCache:      clearCache,
-		ContainerConfig: cc,
-		// TODO(dgageot): Support project.toml include/exclude.
-		// FileFilter: func(string) bool { return true },
+		AppPath:           workspace,
+		Builder:           builderImage,
+		RunImage:          runImage,
+		Buildpacks:        buildpacks,
+		Env:               env,
+		Image:             latest,
+		PullPolicy:        pullPolicy,
+		TrustBuilder:      func(_ string) bool { return artifact.TrustBuilder },
+		ClearCache:        clearCache,
+		ContainerConfig:   cc,
+		ProjectDescriptor: projectDescriptor,
 	}); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
**Description**
Currently Skaffold BuildPack implementation does not correctly support most of the properties in BuildPacks project descriptor, as a user defined project descriptor is an optional value - but is not correctly passed into the build options during pack build.

A side affect of this is that build.include or build.exclude as documented here: https://buildpacks.io/docs/app-developer-guide/using-project-descriptor/ does not correctly ignore (or exclusively include) files.

This means that for projects with larges files ie. node_modules in a nodejs project will be incorrectly copied into the `/workspace` mount destination.

ie. Equivalent of Pack CLI commands:

```
...
[build]
exclude = [
   "ignore_me"
]
...
```

Using Pack CLI will correctly exclude matching files from the build container
```bash
pack build mycontainer:latest -B myBuilder:base --run-image myRunImage:base-cnb --trustbuilder -d project.toml
```

However Skaffolds implementation is Equivalent to
```bash
pack build mycontainer:latest -B myBuilder:base --run-image myRunImage:base-cnb --trustbuilder
```

As project.toml is used to extract certain fields, but other fields - such as exclude/include are essentially ignored.
