### PR TITLE
use relref shortcode to fix links

### DIFF
--- a/docs-v2/content/en/docs/pipeline-stages/renderers/helm.md
+++ b/docs-v2/content/en/docs/pipeline-stages/renderers/helm.md
@@ -15,12 +15,12 @@ To use `helm` with Skaffold, the `helm` binary must be installed on your machine
 
 # Rendering with helm
 [`helm template`](https://helm.sh/docs/helm/helm_template/) allows Kubernetes
-developers to locally render templates. Skaffold relies on `helm temple --post-render`functionality to substitute the images
+developers to locally render templates. Skaffold relies on `helm temple --post-render` functionality to substitute the images
 in the rendered charts with Skaffold built images.
 
 
 {{< alert title="Note" >}}
-If you wish to deploy using helm, please see [Configuring Helm Deployer Section](../deployers/helm.md)
+If you wish to deploy using helm, please see [Configuring Helm Deployer Section]({{< relref "/docs/pipeline-stages/deployers/helm.md" >}})
 {{< /alert >}}
 
 ### Configuration

--- a/docs-v2/content/en/docs/workflows/debug.md
+++ b/docs-v2/content/en/docs/workflows/debug.md
@@ -551,13 +551,14 @@ debug.cloud.google.com/config={
 ### API: Events
 
 Each debuggable container being started or stopped raises a _debug-container-event_ through
-Skaffold's event mechanism ([gRPC](../references/api/grpc/#debuggingcontainerevent),
-[REST](../references/api/swagger/#/SkaffoldService/Events)).
+Skaffold's event mechanism ([gRPC]({{< ref "/docs/references/api/grpc#debuggingcontainerevent" >}}),
+[REST]({{< ref "/docs/references/api/swagger#/SkaffoldService/Events" >}})).
 
 <details>
 <summary>`/v1/events` stream of `skaffold debug` within `examples/jib`</summary>
 
-In this example, we do a `skaffold debug`, and then kill the deployed pod.  The deployment starts a new pod.  We get a terminated event for the container for the killed pod.
+In this example, we do a `skaffold debug`, and then kill the deployed pod.  The deployment starts a new pod.
+We get a terminated event for the container for the killed pod.
 
 ```json
 {
@@ -587,7 +588,8 @@ In this example, we do a `skaffold debug`, and then kill the deployed pod.  The 
 
 ### API: State
 
-The API's _state_ ([gRPC](../references/api/grpc/#skaffoldservice), [REST](../references/api/swagger/#/SkaffoldService/GetState)) also includes a list of debuggable containers.
+The API's _state_ ([gRPC]({{< relref "/docs/references/api/grpc#skaffoldservice" >}}),
+[REST]({{< relref "/docs/references/api/swagger#/SkaffoldService/GetState" >}})) also includes a list of debuggable containers.
 
 <details>
 <summary>The `/v1/state` listing debugging containers</summary>


### PR DESCRIPTION
**Description**
Noticed broken links in the v2 documentation. Fixed it in the `docs-v2` folder, but kept the grpc/swagger links pointing to `api` and not `api-v2`, asuming the v2 version is just temporary until the release?
<!-- Describe your changes here. The more detail, the easier the review! -->
