### PR TITLE
chore(examples): update examples to Spring Boot 2.7.4 and SnakeYAML 1.32

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 bin/
 out/
 examples/bazel/bazel-*
+examples/**/.mvn/wrapper/maven-wrapper.jar
 integration/examples/bazel/bazel-*
+integration/**/.mvn/wrapper/maven-wrapper.jar
 integration/testdata/custom/bazel-*
 integration/testdata/plugin/local/bazel/bazel-*
 *.new

--- a/examples/buildpacks-java/pom.xml
+++ b/examples/buildpacks-java/pom.xml
@@ -1,36 +1,47 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.skaffold</groupId>
-    <artifactId>hello-spring-boot</artifactId>
-    <version>0.1.0</version>
-    <description>Spring Boot</description>
+  <groupId>org.skaffold</groupId>
+  <artifactId>hello-spring-boot</artifactId>
+  <version>0.1.0</version>
+  <description>Spring Boot</description>
 
-    <properties>
-        <java.version>1.8</java.version>
-    </properties>
+  <properties>
+    <java.version>1.8</java.version>
+  </properties>
 
-    <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.5.RELEASE</version>
-    </parent>
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.7.4</version>
+  </parent>
 
+  <dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
+      <!-- SnakeYAML 1.32 addresses CVE-2022-25857 and CVE-2022-38752 -->
+      <dependency>
+        <groupId>org.yaml</groupId>
+        <artifactId>snakeyaml</artifactId>
+        <version>1.32</version>
+      </dependency>
     </dependencies>
+  </dependencyManagement>
 
-    <build>
-        <finalName>hello</finalName>
-        <plugins>
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>hello</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/examples/dev-journey-buildpacks/pom.xml
+++ b/examples/dev-journey-buildpacks/pom.xml
@@ -1,36 +1,47 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.skaffold</groupId>
-    <artifactId>hello-spring-boot</artifactId>
-    <version>0.1.0</version>
-    <description>Spring Boot</description>
+  <groupId>org.skaffold</groupId>
+  <artifactId>hello-spring-boot</artifactId>
+  <version>0.1.0</version>
+  <description>Spring Boot</description>
 
-    <properties>
-        <java.version>1.8</java.version>
-    </properties>
+  <properties>
+    <java.version>1.8</java.version>
+  </properties>
 
-    <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.5.RELEASE</version>
-    </parent>
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.7.4</version>
+  </parent>
 
+  <dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
+      <!-- SnakeYAML 1.32 addresses CVE-2022-25857 and CVE-2022-38752 -->
+      <dependency>
+        <groupId>org.yaml</groupId>
+        <artifactId>snakeyaml</artifactId>
+        <version>1.32</version>
+      </dependency>
     </dependencies>
+  </dependencyManagement>
 
-    <build>
-        <finalName>hello</finalName>
-        <plugins>
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>hello</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/examples/jib-multimodule/pom.xml
+++ b/examples/jib-multimodule/pom.xml
@@ -13,13 +13,24 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.0.5.RELEASE</version>
+    <version>2.7.4</version>
   </parent>
 
   <properties>
     <java.version>1.8</java.version>
     <jib.maven-plugin-version>3.3.0</jib.maven-plugin-version>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- SnakeYAML 1.32 addresses CVE-2022-25857 and CVE-2022-38752 -->
+      <dependency>
+        <groupId>org.yaml</groupId>
+        <artifactId>snakeyaml</artifactId>
+        <version>1.32</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>

--- a/examples/jib-sync/pom.xml
+++ b/examples/jib-sync/pom.xml
@@ -15,8 +15,19 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.0.5.RELEASE</version>
+    <version>2.7.4</version>
   </parent>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- SnakeYAML 1.32 addresses CVE-2022-25857 and CVE-2022-38752 -->
+      <dependency>
+        <groupId>org.yaml</groupId>
+        <artifactId>snakeyaml</artifactId>
+        <version>1.32</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>

--- a/examples/jib/pom.xml
+++ b/examples/jib/pom.xml
@@ -1,52 +1,63 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.skaffold</groupId>
-    <artifactId>hello-spring-boot</artifactId>
-    <version>0.1.0</version>
-    <description>Spring Boot with Skaffold and Jib</description>
+  <groupId>org.skaffold</groupId>
+  <artifactId>hello-spring-boot</artifactId>
+  <version>0.1.0</version>
+  <description>Spring Boot with Skaffold and Jib</description>
 
-    <properties>
-        <java.version>1.8</java.version>
-        <jib.maven-plugin-version>3.3.0</jib.maven-plugin-version>
-    </properties>
+  <properties>
+    <java.version>1.8</java.version>
+    <jib.maven-plugin-version>3.3.0</jib.maven-plugin-version>
+  </properties>
 
-    <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.5.RELEASE</version>
-    </parent>
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.7.4</version>
+  </parent>
 
+  <dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
+      <!-- SnakeYAML 1.32 addresses CVE-2022-25857 and CVE-2022-38752 -->
+      <dependency>
+        <groupId>org.yaml</groupId>
+        <artifactId>snakeyaml</artifactId>
+        <version>1.32</version>
+      </dependency>
     </dependencies>
+  </dependencyManagement>
 
-    <build>
-        <finalName>hello</finalName>
-        <plugins>
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>com.google.cloud.tools</groupId>
-                <artifactId>jib-maven-plugin</artifactId>
-                <version>${jib.maven-plugin-version}</version>
-                <configuration>
-                    <from>
-                        <image>openjdk:8</image>
-                    </from>
-                    <container>
-                        <jvmFlags>
-                            <jvmFlag>-Djava.security.egd=file:/dev/./urandom</jvmFlag>
-                        </jvmFlags>
-                    </container>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>hello</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+        <version>${jib.maven-plugin-version}</version>
+        <configuration>
+          <from>
+            <image>openjdk:8</image>
+          </from>
+          <container>
+            <jvmFlags>
+              <jvmFlag>-Djava.security.egd=file:/dev/./urandom</jvmFlag>
+            </jvmFlags>
+          </container>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/integration/examples/buildpacks-java/pom.xml
+++ b/integration/examples/buildpacks-java/pom.xml
@@ -1,36 +1,47 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.skaffold</groupId>
-    <artifactId>hello-spring-boot</artifactId>
-    <version>0.1.0</version>
-    <description>Spring Boot</description>
+  <groupId>org.skaffold</groupId>
+  <artifactId>hello-spring-boot</artifactId>
+  <version>0.1.0</version>
+  <description>Spring Boot</description>
 
-    <properties>
-        <java.version>1.8</java.version>
-    </properties>
+  <properties>
+    <java.version>1.8</java.version>
+  </properties>
 
-    <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.5.RELEASE</version>
-    </parent>
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.7.4</version>
+  </parent>
 
+  <dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
+      <!-- SnakeYAML 1.32 addresses CVE-2022-25857 and CVE-2022-38752 -->
+      <dependency>
+        <groupId>org.yaml</groupId>
+        <artifactId>snakeyaml</artifactId>
+        <version>1.32</version>
+      </dependency>
     </dependencies>
+  </dependencyManagement>
 
-    <build>
-        <finalName>hello</finalName>
-        <plugins>
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>hello</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/integration/examples/dev-journey-buildpacks/pom.xml
+++ b/integration/examples/dev-journey-buildpacks/pom.xml
@@ -1,36 +1,47 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.skaffold</groupId>
-    <artifactId>hello-spring-boot</artifactId>
-    <version>0.1.0</version>
-    <description>Spring Boot</description>
+  <groupId>org.skaffold</groupId>
+  <artifactId>hello-spring-boot</artifactId>
+  <version>0.1.0</version>
+  <description>Spring Boot</description>
 
-    <properties>
-        <java.version>1.8</java.version>
-    </properties>
+  <properties>
+    <java.version>1.8</java.version>
+  </properties>
 
-    <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.5.RELEASE</version>
-    </parent>
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.7.4</version>
+  </parent>
 
+  <dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
+      <!-- SnakeYAML 1.32 addresses CVE-2022-25857 and CVE-2022-38752 -->
+      <dependency>
+        <groupId>org.yaml</groupId>
+        <artifactId>snakeyaml</artifactId>
+        <version>1.32</version>
+      </dependency>
     </dependencies>
+  </dependencyManagement>
 
-    <build>
-        <finalName>hello</finalName>
-        <plugins>
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>hello</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/integration/examples/jib-multimodule/pom.xml
+++ b/integration/examples/jib-multimodule/pom.xml
@@ -13,13 +13,24 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.0.5.RELEASE</version>
+    <version>2.7.4</version>
   </parent>
 
   <properties>
     <java.version>1.8</java.version>
     <jib.maven-plugin-version>3.3.0</jib.maven-plugin-version>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- SnakeYAML 1.32 addresses CVE-2022-25857 and CVE-2022-38752 -->
+      <dependency>
+        <groupId>org.yaml</groupId>
+        <artifactId>snakeyaml</artifactId>
+        <version>1.32</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>

--- a/integration/examples/jib-sync/pom.xml
+++ b/integration/examples/jib-sync/pom.xml
@@ -15,8 +15,19 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.0.5.RELEASE</version>
+    <version>2.7.4</version>
   </parent>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- SnakeYAML 1.32 addresses CVE-2022-25857 and CVE-2022-38752 -->
+      <dependency>
+        <groupId>org.yaml</groupId>
+        <artifactId>snakeyaml</artifactId>
+        <version>1.32</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>

--- a/integration/examples/jib/pom.xml
+++ b/integration/examples/jib/pom.xml
@@ -1,52 +1,63 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.skaffold</groupId>
-    <artifactId>hello-spring-boot</artifactId>
-    <version>0.1.0</version>
-    <description>Spring Boot with Skaffold and Jib</description>
+  <groupId>org.skaffold</groupId>
+  <artifactId>hello-spring-boot</artifactId>
+  <version>0.1.0</version>
+  <description>Spring Boot with Skaffold and Jib</description>
 
-    <properties>
-        <java.version>1.8</java.version>
-        <jib.maven-plugin-version>3.3.0</jib.maven-plugin-version>
-    </properties>
+  <properties>
+    <java.version>1.8</java.version>
+    <jib.maven-plugin-version>3.3.0</jib.maven-plugin-version>
+  </properties>
 
-    <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.5.RELEASE</version>
-    </parent>
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.7.4</version>
+  </parent>
 
+  <dependencyManagement>
     <dependencies>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
+      <!-- SnakeYAML 1.32 addresses CVE-2022-25857 and CVE-2022-38752 -->
+      <dependency>
+        <groupId>org.yaml</groupId>
+        <artifactId>snakeyaml</artifactId>
+        <version>1.32</version>
+      </dependency>
     </dependencies>
+  </dependencyManagement>
 
-    <build>
-        <finalName>hello</finalName>
-        <plugins>
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>com.google.cloud.tools</groupId>
-                <artifactId>jib-maven-plugin</artifactId>
-                <version>${jib.maven-plugin-version}</version>
-                <configuration>
-                    <from>
-                        <image>openjdk:8</image>
-                    </from>
-                    <container>
-                        <jvmFlags>
-                            <jvmFlag>-Djava.security.egd=file:/dev/./urandom</jvmFlag>
-                        </jvmFlags>
-                    </container>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>hello</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+        <version>${jib.maven-plugin-version}</version>
+        <configuration>
+          <from>
+            <image>openjdk:8</image>
+          </from>
+          <container>
+            <jvmFlags>
+              <jvmFlag>-Djava.security.egd=file:/dev/./urandom</jvmFlag>
+            </jvmFlags>
+          </container>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
- Update examples using Spring Boot to use 2.7.4 to fix numerous critical CVEs
- Further pin SnakeYAML to 1.32 to address two recent CVEs
- Reformatted `pom.xml` to use Google-style 2-space indentation for consistency
