### PR TITLE
docs: Add version menu label

### DIFF
--- a/docs-v2/config.toml
+++ b/docs-v2/config.toml
@@ -89,6 +89,10 @@ skaffold_version = "skaffold/v3alpha1"
 # enabling local search https://www.docsy.dev/docs/adding-content/navigation/#configure-local-search-with-lunr
 offlineSearch = true
 
+# Menu title if your navbar has a versions selector to access old versions of your site.
+# This menu appears only if you have at least one [params.versions] set.
+version_menu = "Versions"
+
 # User interface configuration
 [params.ui]
 # Enable to show the side bar menu in its compact state.

--- a/docs-v2/layouts/partials/navbar.html
+++ b/docs-v2/layouts/partials/navbar.html
@@ -22,7 +22,7 @@
 			</li>
 			{{ end }}
 			{{ if  .Site.Params.versions }}
-			<li class="nav-item dropdown d-none d-lg-block">
+			<li class="nav-item mr-4 dropdown d-none d-lg-block">
 				{{ partial "navbar-version-selector.html" . }}
 			</li>
 			{{ end }}

--- a/docs-v2/static/stylesheets/colors.css
+++ b/docs-v2/static/stylesheets/colors.css
@@ -111,3 +111,7 @@ input.td-search-input::placeholder {
 a > code {
     color: #c97300;
 }
+
+.nav-link {
+    color: var(--header-footer-foreground);
+}


### PR DESCRIPTION
**Related**:  https://github.com/GoogleContainerTools/skaffold/issues/7910

**Description**

Adds a version menu label of "Versions" to the versions dropdown on the v2 docs site. (This is the same versions label used by https://kubernetes.io/).

**User facing changes**

Previously, the versions dropdown was an unlabelled chevron and had low discoverability. Now, the versions dropdown is labeled and easily discoverable.

Before:

![55LDLpFYyvhLo6a](https://user-images.githubusercontent.com/15936279/194148112-2a8909b5-5adf-4d28-903b-8ce0b3d4fb6d.png)

After:

![6oKBSqieU6QL5MB](https://user-images.githubusercontent.com/15936279/194148054-4c3cc95f-8a5d-4913-aba8-9c4c45a22798.png)

**Follow-up Work**

Add informational banners to v1 and v2 docs sites. See https://github.com/GoogleContainerTools/skaffold/issues/7910 for details.
