### PR TITLE
docs: Add banner to v1 and v2 docs indicating that v1 is archived

### DIFF
--- a/docs-v2/content/en/docs/_index.md
+++ b/docs-v2/content/en/docs/_index.md
@@ -8,6 +8,13 @@ menu:
 no_list: true
 ---
 
+<div class="pageinfo pageinfo-primary">
+    <p class="banner-title">Skaffold v2 has been released!</p>
+    <p>You are viewing the Skaffold v2 documentation. View the archived v1 documentation
+      <a href="https://skaffold.dev/docs/" target="_blank">here.</a>
+    </p>
+</div>
+
 Skaffold is a command line tool that facilitates continuous development for
 Kubernetes-native applications. Skaffold handles the workflow for building,
 pushing, and deploying your application, and provides building blocks for

--- a/docs-v2/static/stylesheets/font.css
+++ b/docs-v2/static/stylesheets/font.css
@@ -30,3 +30,7 @@
     font-family: FontAwesome, "Open Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
         Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !important;
 }
+
+.banner-title {
+    font-size: 1.3rem;
+}

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -75,6 +75,10 @@ languageName ="English"
 # Weight used for sorting.
 weight = 1
 
+# Configuration for displaying a banner on archived doc sites
+archived_version = true
+version = "v1.39"
+url_latest_version = "https://skaffold-v2-latest.firebaseapp.com/docs"
 
 # Everything below this are Site Params
 


### PR DESCRIPTION
Fixes: https://github.com/GoogleContainerTools/skaffold/issues/7910
Related: https://github.com/GoogleContainerTools/skaffold/pull/7917

**Description**
* Add a banner to all v1 documentation pages indicating that v1 is archived, using [Docsy's built-in functionality of displaying banners on archived docs sites](https://www.docsy.dev/docs/adding-content/versioning/#displaying-a-banner-on-archived-doc-sites). (Note: this is similar to [archived Kubernetes documentation](https://v1-21.docs.kubernetes.io/docs/tutorials/configuration/)).
* Add a banner to the main v2 documentation page indicating that v2 has been released, and providing a link back to the archived v1 documentation.

**User facing changes**

V1 screenshot:

![mh4NS2E4BkpSKTV](https://user-images.githubusercontent.com/15936279/194368315-a03dcd06-da57-4934-b323-8eaf2945dc78.png)

V2 screenshot:

![8JZzHFfgRr79bKX](https://user-images.githubusercontent.com/15936279/194368366-4f0a5555-2d60-4070-90f4-61b74fc2b8e8.png)

