### PR TITLE
chore: update skaffold Dockerfiles to pull from approved GCS buckets vs open internet

### DIFF
--- a/deploy/skaffold/Dockerfile.deps
+++ b/deploy/skaffold/Dockerfile.deps
@@ -31,7 +31,7 @@ FROM alpine:3.10 as download-helm
 ARG ARCH
 RUN echo arch=$ARCH
 ENV HELM_VERSION v3.9.2
-ENV HELM_URL https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz
+ENV HELM_URL https://storage.googleapis.com/skaffold/deps/helm/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz
 COPY deploy/skaffold/digests/helm.${ARCH}.sha256 .
 RUN wget -O helm.tar.gz "${HELM_URL}" && sha256sum -c helm.${ARCH}.sha256
 RUN tar -xvf helm.tar.gz --strip-components 1
@@ -40,7 +40,7 @@ RUN tar -xvf helm.tar.gz --strip-components 1
 FROM alpine:3.10 as download-kustomize
 ARG ARCH
 ENV KUSTOMIZE_VERSION 4.4.0
-ENV KUSTOMIZE_URL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_${ARCH}.tar.gz
+ENV KUSTOMIZE_URL https://storage.googleapis.com/skaffold/deps/kustomize/v${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_${ARCH}.tar.gz
 COPY deploy/skaffold/digests/kustomize.${ARCH}.sha256 .
 RUN wget -O kustomize.tar.gz "${KUSTOMIZE_URL}" && sha256sum -c kustomize.${ARCH}.sha256
 RUN tar -xvf kustomize.tar.gz
@@ -49,7 +49,7 @@ RUN tar -xvf kustomize.tar.gz
 FROM alpine:3.10 as download-kpt
 ARG ARCH
 ENV KPT_VERSION 0.39.3
-ENV KPT_URL https://github.com/GoogleContainerTools/kpt/releases/download/v${KPT_VERSION}/kpt_linux_amd64
+ENV KPT_URL https://storage.googleapis.com/skaffold/deps/kpt/v${KPT_VERSION}/kpt_linux_amd64
 COPY deploy/skaffold/digests/kpt.${ARCH}.sha256 .
 RUN wget -O kpt "${KPT_URL}" && sha256sum -c kpt.${ARCH}.sha256
 RUN chmod +x kpt
@@ -58,7 +58,7 @@ RUN chmod +x kpt
 FROM alpine:3.10 as download-kompose
 ARG ARCH
 ENV KOMPOSE_VERSION v1.26.0
-ENV KOMPOSE_URL https://github.com/kubernetes/kompose/releases/download/${KOMPOSE_VERSION}/kompose-linux-amd64
+ENV KOMPOSE_URL https://storage.googleapis.com/skaffold/deps/kompose/${KOMPOSE_VERSION}/kompose-linux-amd64
 COPY deploy/skaffold/digests/kompose.${ARCH}.sha256 .
 RUN wget -O kompose "${KOMPOSE_URL}" && sha256sum -c kompose.${ARCH}.sha256
 RUN chmod +x kompose
@@ -76,7 +76,7 @@ RUN chmod +x container-structure-test
 FROM alpine:3.10 as download-kind
 ARG ARCH
 ENV KIND_VERSION v0.11.1
-ENV KIND_URL https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-${ARCH}
+ENV KIND_URL https://storage.googleapis.com/skaffold/deps/kind/${KIND_VERSION}/kind-linux-${ARCH}
 COPY deploy/skaffold/digests/kind.${ARCH}.sha512 .
 RUN wget -O kind "${KIND_URL}" && sha512sum -c kind.${ARCH}.sha512
 RUN chmod +x kind
@@ -85,7 +85,7 @@ RUN chmod +x kind
 FROM alpine:3.10 as download-k3d
 ARG ARCH
 ENV K3D_VERSION v5.0.3
-ENV K3D_URL https://github.com/rancher/k3d/releases/download/${K3D_VERSION}/k3d-linux-amd64
+ENV K3D_URL https://storage.googleapis.com/skaffold/deps/k3d/${K3D_VERSION}/k3d-linux-amd64
 COPY deploy/skaffold/digests/k3d.${ARCH}.sha256 .
 RUN wget -O k3d "${K3D_URL}" && sha256sum -c k3d.${ARCH}.sha256
 RUN chmod +x k3d
@@ -107,7 +107,7 @@ RUN tar -zxf gcloud.tar.gz
 FROM alpine:3.10 as download-bazel
 ARG ARCH
 ENV BAZEL_VERSION 4.2.1
-ENV BAZEL_URL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-BAZELARCH
+ENV BAZEL_URL https://storage.googleapis.com/skaffold/deps/bazel/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-BAZELARCH
 COPY deploy/skaffold/digests/bazel.${ARCH}.sha256 .
 RUN \
     BAZELARCH=$(case "${ARCH}" in amd64) echo x86_64;; *) echo ${ARCH};; esac); \

--- a/deploy/skaffold/Dockerfile.deps.lts
+++ b/deploy/skaffold/Dockerfile.deps.lts
@@ -31,7 +31,7 @@ FROM alpine:3.10 as download-helm
 ARG ARCH
 RUN echo arch=$ARCH
 ENV HELM_VERSION v3.9.2
-ENV HELM_URL https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz
+ENV HELM_URL https://storage.googleapis.com/skaffold/deps/helm/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz
 COPY deploy/skaffold/digests/helm.${ARCH}.sha256 .
 RUN wget -O helm.tar.gz "${HELM_URL}" && sha256sum -c helm.${ARCH}.sha256
 RUN tar -xvf helm.tar.gz --strip-components 1
@@ -40,7 +40,7 @@ RUN tar -xvf helm.tar.gz --strip-components 1
 FROM alpine:3.10 as download-kustomize
 ARG ARCH
 ENV KUSTOMIZE_VERSION 4.4.0
-ENV KUSTOMIZE_URL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_${ARCH}.tar.gz
+ENV KUSTOMIZE_URL https://storage.googleapis.com/skaffold/deps/kustomize/v${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_${ARCH}.tar.gz
 COPY deploy/skaffold/digests/kustomize.${ARCH}.sha256 .
 RUN wget -O kustomize.tar.gz "${KUSTOMIZE_URL}" && sha256sum -c kustomize.${ARCH}.sha256
 RUN tar -xvf kustomize.tar.gz
@@ -49,7 +49,7 @@ RUN tar -xvf kustomize.tar.gz
 FROM alpine:3.10 as download-kpt
 ARG ARCH
 ENV KPT_VERSION 0.39.3
-ENV KPT_URL https://github.com/GoogleContainerTools/kpt/releases/download/v${KPT_VERSION}/kpt_linux_amd64
+ENV KPT_URL https://storage.googleapis.com/skaffold/deps/kpt/v${KPT_VERSION}/kpt_linux_amd64
 COPY deploy/skaffold/digests/kpt.${ARCH}.sha256 .
 RUN wget -O kpt "${KPT_URL}" && sha256sum -c kpt.${ARCH}.sha256
 RUN chmod +x kpt


### PR DESCRIPTION
Fixes #7716 

Future PR will add a script to mirror the binaries necessary to remove Skaffold team toil of mirroring binaries - #7922 

NOTE: the kubectl and gcloud binaries are not mirrored to a skaffold GCS bucket as they are already released via Google infra