### PR TITLE
fix: reverse order of deployers during cleanup (#7284)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ integration/testdata/plugin/local/bazel/bazel-*
 *.new
 *.iml
 .idea/
+.tool-versions
 .vscode/
 docs/.firebase
 docs/firebase-debug*

--- a/pkg/skaffold/deploy/deploy_mux.go
+++ b/pkg/skaffold/deploy/deploy_mux.go
@@ -57,6 +57,14 @@ func (m DeployerMux) GetDeployers() []Deployer {
 	return m.deployers
 }
 
+func (m DeployerMux) GetDeployersInverse() []Deployer {
+	inverse := m.deployers
+	for i, j := 0, len(inverse)-1; i < j; i, j = i+1, j-1 {
+		inverse[i], inverse[j] = inverse[j], inverse[i]
+	}
+	return inverse
+}
+
 func (m DeployerMux) GetAccessor() access.Accessor {
 	var accessors access.AccessorMux
 	for _, deployer := range m.deployers {
@@ -161,7 +169,9 @@ func (m DeployerMux) Dependencies() ([]string, error) {
 }
 
 func (m DeployerMux) Cleanup(ctx context.Context, w io.Writer, dryRun bool, manifestsByConfig manifest.ManifestListByConfig) error {
-	for _, deployer := range m.deployers {
+	// Reverse order of deployers for cleanup to ensure resources
+	// are removed before their definitions are removed.
+	for _, deployer := range m.GetDeployersInverse() {
 		ctx, endTrace := instrumentation.StartTrace(ctx, "Cleanup")
 		if dryRun {
 			output.Yellow.Fprintln(w, "Following resources would be deleted:")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #7284 <!-- tracking issues that this PR will close -->
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Add a new deployer slice during cleanup function of the DeployerMux which is reversed in it's order. This change should be covered by the existing unittests since no new function was added.

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->
Before:
Modules are undeployed in the same order as they are deployed. Visible in the console as

```shell
^CCleaning up...
release "postgresql" uninstalled
 - deployment.apps "example-django" deleted
INFO[0016] Cleanup completed in 886.10607ms              subtask=-1 task=DevLoop

```

After:
Modules are undeployed in reverse order.

```shell
^CCleaning up...
 - deployment.apps "example-django" deleted
release "postgresql" uninstalled
INFO[0328] Cleanup completed in 1.038 second             subtask=-1 task=DevLoop
```

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
