### PR TITLE
fix: reverse order of deployers during cleanup (#7284) (backport v1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ integration/testdata/plugin/local/bazel/bazel-*
 *.new
 *.iml
 .idea/
+.tool-versions
 .vscode/
 docs/.firebase
 docs/firebase-debug*

--- a/pkg/skaffold/deploy/deploy_mux.go
+++ b/pkg/skaffold/deploy/deploy_mux.go
@@ -59,6 +59,14 @@ func (m DeployerMux) GetDeployers() []Deployer {
 	return m.deployers
 }
 
+func (m DeployerMux) GetDeployersInverse() []Deployer {
+	inverse := m.deployers
+	for i, j := 0, len(inverse)-1; i < j; i, j = i+1, j-1 {
+		inverse[i], inverse[j] = inverse[j], inverse[i]
+	}
+	return inverse
+}
+
 func (m DeployerMux) GetAccessor() access.Accessor {
 	var accessors access.AccessorMux
 	for _, deployer := range m.deployers {
@@ -159,7 +167,9 @@ func (m DeployerMux) Dependencies() ([]string, error) {
 }
 
 func (m DeployerMux) Cleanup(ctx context.Context, w io.Writer, dryRun bool) error {
-	for _, deployer := range m.deployers {
+	// Reverse order of deployers for cleanup to ensure resources
+	// are removed before their definitions are removed.
+	for _, deployer := range m.GetDeployersInverse() {
 		ctx, endTrace := instrumentation.StartTrace(ctx, "Cleanup")
 		if dryRun {
 			output.Yellow.Fprintln(w, "Following resources would be deleted:")

--- a/pkg/skaffold/deploy/deploy_mux_test.go
+++ b/pkg/skaffold/deploy/deploy_mux_test.go
@@ -25,6 +25,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/access"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
@@ -294,4 +296,46 @@ func TestDeployerMux_Render(t *testing.T) {
 		content, _ := ioutil.ReadAll(file)
 		testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, test.expectedRender, string(content))
 	})
+}
+
+func TestDeployerMux_GetDeployersInverse(t *testing.T) {
+	d1 := NewMockDeployer()
+	d2 := NewMockDeployer()
+	d3 := NewMockDeployer()
+	d4 := NewMockDeployer()
+	d5 := NewMockDeployer()
+
+	tests := []struct {
+		name     string
+		args     []Deployer
+		expected []Deployer
+	}{
+		{
+			name:     "uneven slice",
+			args:     []Deployer{d1, d2, d3, d4, d5},
+			expected: []Deployer{d5, d4, d3, d2, d1},
+		},
+		{
+			name:     "even slice",
+			args:     []Deployer{d1, d2, d3, d4},
+			expected: []Deployer{d4, d3, d2, d1},
+		},
+		{
+			name:     "slice of one",
+			args:     []Deployer{d1},
+			expected: []Deployer{d1},
+		},
+		{
+			name:     "slice of zero",
+			args:     []Deployer{},
+			expected: []Deployer{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			deployerMux := DeployerMux{deployers: test.args, iterativeStatusCheck: false}
+			testutil.CheckDeepEqual(t, test.expected, deployerMux.GetDeployersInverse(), cmp.AllowUnexported(MockDeployer{}))
+		})
+	}
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #7284 <!-- tracking issues that this PR will close -->
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Add a new deployer slice during cleanup function of the DeployerMux which is reversed in it's order. This change should be covered by the existing unittests since no new function was added.

This is a backport for v1.

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->
Before:
Modules are undeployed in the same order as they are deployed. Visible in the console as

```shell
^CCleaning up...
release "postgresql" uninstalled
 - deployment.apps "example-django" deleted
INFO[0016] Cleanup completed in 886.10607ms              subtask=-1 task=DevLoop

```

After:
Modules are undeployed in reverse order.

```shell
^CCleaning up...
 - deployment.apps "example-django" deleted
release "postgresql" uninstalled
INFO[0328] Cleanup completed in 1.038 second             subtask=-1 task=DevLoop
```

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
