### PR TITLE
docs: Fix v1 and v2 docs links

### DIFF
--- a/docs-v2/content/en/docs/_index.md
+++ b/docs-v2/content/en/docs/_index.md
@@ -11,7 +11,7 @@ no_list: true
 <div class="pageinfo pageinfo-primary">
     <p class="banner-title">Skaffold v2 has been released!</p>
     <p>You are viewing the Skaffold v2 documentation. View the archived v1 documentation
-      <a href="https://skaffold.dev/docs/" target="_blank">here.</a>
+      <a href="https://skaffold-v1.web.app/docs/" target="_blank">here.</a>
     </p>
 </div>
 

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -78,7 +78,7 @@ weight = 1
 # Configuration for displaying a banner on archived doc sites
 archived_version = true
 version = "v1.39"
-url_latest_version = "https://skaffold-v2-latest.firebaseapp.com/docs"
+url_latest_version = "https://skaffold-v2.web.app/docs/"
 
 # Everything below this are Site Params
 


### PR DESCRIPTION
Related: https://github.com/GoogleContainerTools/skaffold/issues/7910

**Description**

Fix v1 and v2 docs links. In preparation for skaffold.dev to point to the v2 site, set v1 URL to `https://skaffold-v1.web.app/docs/` and the v2 URL to `https://skaffold-v2.web.app/docs/`.