### PR TITLE
[skaffold v2] fix: Cloud Code log viewer shows render stage correctly

### DIFF
--- a/pkg/skaffold/runner/render.go
+++ b/pkg/skaffold/runner/render.go
@@ -40,7 +40,7 @@ func (r *SkaffoldRunner) Render(ctx context.Context, out io.Writer, builds []gra
 	}
 	defer postRenderFn()
 
-	eventV2.TaskInProgress(constants.Render, "")
+	eventV2.TaskInProgress(constants.Render, "Render Manifests")
 	if r.runCtx.RenderOnly() {
 		// Fetch the digest and append it to the tag with the format of "tag@digest"
 		if r.runCtx.DigestSource() == constants.RemoteDigestSource {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #7930 <!-- tracking issues that this PR will close -->
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
For Cloud Code VSCode, I've submitted the fix in the plugin repo directly. Shows correct output in their Nightly build:
<img width="1054" alt="image" src="https://user-images.githubusercontent.com/39389231/195224831-21e62e58-02c3-474c-880a-37cc0f0f3d0d.png">

For Cloud Code IntelliJ, this PR fixes the event description that shows up directly in the log view:
<img width="1403" alt="image" src="https://user-images.githubusercontent.com/39389231/195225105-83050f75-89ac-410b-abd5-ffe3384b0cca.png">


