### PR TITLE
docs: Add new inputDigest tagger alias to customTemplate tagger

### DIFF
--- a/docs/content/en/docs/pipeline-stages/taggers.md
+++ b/docs/content/en/docs/pipeline-stages/taggers.md
@@ -167,7 +167,7 @@ it will evaluate `FOO` and `BAR` and use their values to tag the image.
 {{< alert >}}
 <b>Note</b><br>
 
-`GIT`, `DATE`, and `SHA` are special built-in component references that will evaluate to the default gitCommit, dateTime, and sha256 taggers, respectively.
+`GIT`, `DATE`, `SHA`, and `INPUT_DIGEST` are special built-in component references that will evaluate to the default gitCommit, dateTime, sha256, and inputDigest taggers, respectively.
 Users can overwrite these values by defining a component with one of these names.
 {{< /alert >}}
 


### PR DESCRIPTION
Fixes: #7933

**Description**
It updates docs by including that the INPUT_DIGEST field is also part of the template values now.
