### PR TITLE
chore: update skaffold v2 docs to point reference v2.0.0 and not v2.0.0-beta*

### DIFF
--- a/docs-v2/content/en/docs/install/_index.md
+++ b/docs-v2/content/en/docs/install/_index.md
@@ -1,6 +1,6 @@
 ---
-title: "Installing Skaffold v2.0.0-beta3 [NEW]"
-linkTitle: "Installing Skaffold v2.0.0-beta3 [NEW]"
+title: "Installing Skaffold v2.0.0 [NEW]"
+linkTitle: "Installing Skaffold v2.0.0 [NEW]"
 weight: 10
 aliases: [/docs/getting-started]
 ---
@@ -10,37 +10,37 @@ aliases: [/docs/getting-started]
 
 {{% tab "LINUX" %}}
 The latest **stable** v2.0.0 beta binaries can be found here:
-- Linux x86_64 (amd64): https://storage.googleapis.com/skaffold/releases/v2.0.0-beta3/skaffold-linux-amd64
-- Linux ARMv8 (arm64): https://storage.googleapis.com/skaffold/releases/v2.0.0-beta3/skaffold-linux-arm64
+- Linux x86_64 (amd64): https://storage.googleapis.com/skaffold/releases/v2.0.0/skaffold-linux-amd64
+- Linux ARMv8 (arm64): https://storage.googleapis.com/skaffold/releases/v2.0.0/skaffold-linux-arm64
 
 Simply download the appropriate binary and add it to your `PATH`. Or, copy+paste one of the following commands in your terminal:
 
 ```bash
 # For Linux x86_64 (amd64)
-curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v2.0.0-beta3/skaffold-linux-amd64 && \
+curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v2.0.0/skaffold-linux-amd64 && \
 sudo install skaffold /usr/local/bin/
 ```
 
 ```bash
 # For Linux ARMv8 (arm64)
-curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v2.0.0-beta3/skaffold-linux-arm64 && \
+curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v2.0.0/skaffold-linux-arm64 && \
 sudo install skaffold /usr/local/bin/
 ```
 
 We also release a v2.0.0 **bleeding edge** latest build, built from the latest commit:
 
-- Linux x86_64 (amd64): https://storage.googleapis.com/skaffold/builds/latest/v2/skaffold-linux-amd64
-- Linux ARMv8 (arm64): https://storage.googleapis.com/skaffold/builds/latest/v2/skaffold-linux-arm64
+- Linux x86_64 (amd64): https://storage.googleapis.com/skaffold/builds/latest/skaffold-linux-amd64
+- Linux ARMv8 (arm64): https://storage.googleapis.com/skaffold/builds/latest/skaffold-linux-arm64
 
 ```bash
 # For Linux on x86_64 (amd64)
-curl -Lo skaffold https://storage.googleapis.com/skaffold/builds/v2.0.0-beta3/skaffold-linux-amd64 && \
+curl -Lo skaffold https://storage.googleapis.com/skaffold/builds/v2.0.0/skaffold-linux-amd64 && \
 sudo install skaffold /usr/local/bin/
 ```
 
 ```bash
 # For Linux on ARMv8 (arm64)
-curl -Lo skaffold https://storage.googleapis.com/skaffold/builds/v2.0.0-beta3/skaffold-linux-arm64 && \
+curl -Lo skaffold https://storage.googleapis.com/skaffold/builds/v2.0.0/skaffold-linux-arm64 && \
 sudo install skaffold /usr/local/bin/
 ```
 
@@ -50,37 +50,37 @@ sudo install skaffold /usr/local/bin/
 
 The latest **stable** binaries can be found here:
 
-- Darwin x86_64 (amd64): https://storage.googleapis.com/skaffold/releases/v2.0.0-beta3/skaffold-darwin-amd64
-- Darwin ARMv8 (arm64): https://storage.googleapis.com/skaffold/releases/v2.0.0-beta3/skaffold-darwin-arm64
+- Darwin x86_64 (amd64): https://storage.googleapis.com/skaffold/releases/v2.0.0/skaffold-darwin-amd64
+- Darwin ARMv8 (arm64): https://storage.googleapis.com/skaffold/releases/v2.0.0/skaffold-darwin-arm64
 
 Simply download the appropriate binary and add it to your `PATH`. Or, copy+paste one of the following commands in your terminal:
 
 ```bash
 # For macOS on x86_64 (amd64)
-curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v2.0.0-beta3/skaffold-darwin-amd64 && \
+curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v2.0.0/skaffold-darwin-amd64 && \
 sudo install skaffold /usr/local/bin/
 ```
 
 ```bash
 # For macOS on ARMv8 (arm64)
-curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v2.0.0-beta3/skaffold-darwin-arm64 && \
+curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v2.0.0/skaffold-darwin-arm64 && \
 sudo install skaffold /usr/local/bin/
 ```
 
 We also release a v2.0.0 **bleeding edge** build, built from the latest commit:
 
-- Darwin x86_64 (amd64): https://storage.googleapis.com/skaffold/builds/latest/v2/skaffold-darwin-amd64
-- Darwin ARMv8 (arm64): https://storage.googleapis.com/skaffold/builds/latest/v2/skaffold-darwin-arm64
+- Darwin x86_64 (amd64): https://storage.googleapis.com/skaffold/builds/latest/skaffold-darwin-amd64
+- Darwin ARMv8 (arm64): https://storage.googleapis.com/skaffold/builds/latest/skaffold-darwin-arm64
 
 ```bash
 # For macOS on x86_64 (amd64)
-curl -Lo skaffold https://storage.googleapis.com/skaffold/builds/latest/v2/skaffold-darwin-amd64 && \
+curl -Lo skaffold https://storage.googleapis.com/skaffold/builds/latest/skaffold-darwin-amd64 && \
 sudo install skaffold /usr/local/bin/
 ```
 
 ```bash
 # For macOS on ARMv8 (arm64)
-curl -Lo skaffold https://storage.googleapis.com/skaffold/builds/latest/v2/skaffold-darwin-arm64 && \
+curl -Lo skaffold https://storage.googleapis.com/skaffold/builds/latest/skaffold-darwin-arm64 && \
 sudo install skaffold /usr/local/bin/
 ```
 {{% /tab %}}
@@ -90,13 +90,13 @@ sudo install skaffold /usr/local/bin/
 
 The latest **stable** release binary can be found here:
 
-https://storage.googleapis.com/skaffold/releases/v2.0.0-beta3/skaffold-windows-amd64.exe
+https://storage.googleapis.com/skaffold/releases/v2.0.0/skaffold-windows-amd64.exe
 
 Simply download it and place it in your `PATH` as `skaffold.exe`.
 
 We also release a **bleeding edge** build, built from the latest commit:
 
-https://storage.googleapis.com/skaffold/builds/latest/v2/skaffold-windows-amd64.exe
+https://storage.googleapis.com/skaffold/builds/latest/skaffold-windows-amd64.exe
 {{% /tab %}}
 
 {{% tab "DOCKER" %}}


### PR DESCRIPTION
Related to #7891 