### PR TITLE
fix: no longer pass os env vars through to verify as this can cause unexpected issues with PATH, GOPATH, etc.

### DIFF
--- a/integration/verify_test.go
+++ b/integration/verify_test.go
@@ -29,8 +29,6 @@ import (
 
 func TestVerifyPassingTestsWithEnvVar(t *testing.T) {
 	MarkIntegrationTest(t, CanRunWithoutGcp)
-	os.Setenv("FOO", "foo-var")
-	defer os.Unsetenv("FOO")
 	tmp := t.TempDir()
 	logFile := filepath.Join(tmp, uuid.New().String()+"logs.json")
 
@@ -41,7 +39,6 @@ func TestVerifyPassingTestsWithEnvVar(t *testing.T) {
 
 	testutil.CheckError(t, false, err)
 	testutil.CheckContains(t, "Hello from Docker!", logs)
-	testutil.CheckContains(t, "foo-var", logs)
 	testutil.CheckContains(t, "alpine-1", logs)
 	testutil.CheckContains(t, "alpine-2", logs)
 
@@ -52,15 +49,12 @@ func TestVerifyPassingTestsWithEnvVar(t *testing.T) {
 	}
 	v2EventLogs := string(b)
 	testutil.CheckContains(t, "Hello from Docker!", v2EventLogs)
-	testutil.CheckContains(t, "foo-var", v2EventLogs)
 
 	// TODO(aaron-prindle) verify that SUCCEEDED event is found where expected
 }
 
 func TestVerifyOneTestFailsWithEnvVar(t *testing.T) {
 	MarkIntegrationTest(t, CanRunWithoutGcp)
-	os.Setenv("FOO", "foo-var")
-	defer os.Unsetenv("FOO")
 	tmp := t.TempDir()
 	logFile := filepath.Join(tmp, uuid.New().String()+"logs.json")
 
@@ -71,7 +65,6 @@ func TestVerifyOneTestFailsWithEnvVar(t *testing.T) {
 
 	testutil.CheckError(t, true, err)
 	testutil.CheckContains(t, "Hello from Docker!", logs)
-	testutil.CheckContains(t, "foo-var", logs)
 
 	// verify logs are in the event output as well
 	b, err := os.ReadFile(logFile + ".v2")
@@ -80,8 +73,6 @@ func TestVerifyOneTestFailsWithEnvVar(t *testing.T) {
 	}
 	v2EventLogs := string(b)
 	testutil.CheckContains(t, "Hello from Docker!", v2EventLogs)
-	testutil.CheckContains(t, "foo-var", v2EventLogs)
-
 	// TODO(aaron-prindle) verify that FAILED event is found where expected
 }
 

--- a/pkg/skaffold/verify/docker/verify.go
+++ b/pkg/skaffold/verify/docker/verify.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"os"
 	"path"
 	"strings"
 	"sync"
@@ -216,8 +215,6 @@ func (v *Verifier) createAndRunContainer(ctx context.Context, out io.Writer, art
 	opts.Bindings = bindings
 	// verify waits for run to complete
 	opts.Wait = true
-	// verify passes through os env to container env
-	opts.ContainerConfig.Env = os.Environ()
 
 	eventV2.VerifyInProgress(opts.VerifyTestName)
 	statusCh, errCh, id, err := v.client.Run(ctx, out, opts)


### PR DESCRIPTION
Fixes #7945 