### PR TITLE
docs: update v1 and v2 docs to properly reflect recent tagger changes

### DIFF
--- a/docs-v2/content/en/docs/pipeline-stages/taggers.md
+++ b/docs-v2/content/en/docs/pipeline-stages/taggers.md
@@ -167,7 +167,7 @@ it will evaluate `FOO` and `BAR` and use their values to tag the image.
 {{< alert >}}
 <b>Note</b><br>
 
-`GIT`, `DATE`, and `SHA` are special built-in component references that will evaluate to the default gitCommit, dateTime, and sha256 taggers, respectively.
+`GIT`, `DATE`, `SHA`, and `INPUT_DIGEST` are special built-in component references that will evaluate to the default gitCommit, dateTime, sha256, and inputDigest taggers, respectively.
 Users can overwrite these values by defining a component with one of these names.
 {{< /alert >}}
 

--- a/docs/content/en/docs/pipeline-stages/taggers.md
+++ b/docs/content/en/docs/pipeline-stages/taggers.md
@@ -167,7 +167,7 @@ it will evaluate `FOO` and `BAR` and use their values to tag the image.
 {{< alert >}}
 <b>Note</b><br>
 
-`GIT`, `DATE`, `SHA`, and `INPUT_DIGEST` are special built-in component references that will evaluate to the default gitCommit, dateTime, sha256, and inputDigest taggers, respectively.
+`GIT`, `DATE`, and `SHA` are special built-in component references that will evaluate to the default gitCommit, dateTime, and sha256 taggers, respectively.
 Users can overwrite these values by defining a component with one of these names.
 {{< /alert >}}
 


### PR DESCRIPTION
#7939 was merged but placed the additional tagger functionality in the `v1` docs when this is only present in the `v2` code.  This fixes the docs to reflect the proper functionality