### PR TITLE
docs: Add a copy of the buildpacks node tutorial without a skaffold.yaml

### DIFF
--- a/examples/buildpacks-node-tutorial/.gitignore
+++ b/examples/buildpacks-node-tutorial/.gitignore
@@ -1,0 +1,1 @@
+package-lock.json

--- a/examples/buildpacks-node-tutorial/README.md
+++ b/examples/buildpacks-node-tutorial/README.md
@@ -1,0 +1,9 @@
+### Example: buildpacks (NodeJS)
+
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/buildpacks-node)
+
+This is an example demonstrating:
+
+* **building** a simple NodeJS app built with [Cloud Native Buildpacks](https://buildpacks.io/)
+* **tagging** using the default tagPolicy (`gitCommit`)
+* **deploying** a single container pod using `kubectl`

--- a/examples/buildpacks-node-tutorial/k8s/web.yaml
+++ b/examples/buildpacks-node-tutorial/k8s/web.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+spec:
+  ports:
+  - port: 3000
+    name: http
+  type: LoadBalancer
+  selector:
+    app: web
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+      - name: web
+        image: skaffold-buildpacks-node
+        ports:
+          - containerPort: 3000

--- a/examples/buildpacks-node-tutorial/package.json
+++ b/examples/buildpacks-node-tutorial/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "node src/index.js"
+  },
+  "dependencies": {
+    "express": "^4.16.4"
+  }
+}

--- a/examples/buildpacks-node-tutorial/project.toml
+++ b/examples/buildpacks-node-tutorial/project.toml
@@ -1,0 +1,3 @@
+[[build.env]]
+name = "GOOGLE_RUNTIME_VERSION"
+value = "14.3.0"

--- a/examples/buildpacks-node-tutorial/public/index.html
+++ b/examples/buildpacks-node-tutorial/public/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Demo</title>
+</head>
+
+<body>
+  <h1>Hello World</h1>
+</body>
+</html>

--- a/examples/buildpacks-node-tutorial/src/index.js
+++ b/examples/buildpacks-node-tutorial/src/index.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const express = require('express')
+const app = express()
+
+app.use(express.static('public'));
+app.get('/hello', (req, res) => res.send('Hello World'))
+
+const port = 3000
+app.listen(port, () => console.log(`Example app listening on port ${port}!`))

--- a/integration/examples/buildpacks-node-tutorial/.gitignore
+++ b/integration/examples/buildpacks-node-tutorial/.gitignore
@@ -1,0 +1,1 @@
+package-lock.json

--- a/integration/examples/buildpacks-node-tutorial/README.md
+++ b/integration/examples/buildpacks-node-tutorial/README.md
@@ -1,0 +1,9 @@
+### Example: buildpacks (NodeJS)
+
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/buildpacks-node)
+
+This is an example demonstrating:
+
+* **building** a simple NodeJS app built with [Cloud Native Buildpacks](https://buildpacks.io/)
+* **tagging** using the default tagPolicy (`gitCommit`)
+* **deploying** a single container pod using `kubectl`

--- a/integration/examples/buildpacks-node-tutorial/k8s/web.yaml
+++ b/integration/examples/buildpacks-node-tutorial/k8s/web.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+spec:
+  ports:
+  - port: 3000
+    name: http
+  type: LoadBalancer
+  selector:
+    app: web
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+      - name: web
+        image: skaffold-buildpacks-node
+        ports:
+          - containerPort: 3000

--- a/integration/examples/buildpacks-node-tutorial/package.json
+++ b/integration/examples/buildpacks-node-tutorial/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "node src/index.js"
+  },
+  "dependencies": {
+    "express": "^4.16.4"
+  }
+}

--- a/integration/examples/buildpacks-node-tutorial/project.toml
+++ b/integration/examples/buildpacks-node-tutorial/project.toml
@@ -1,0 +1,3 @@
+[[build.env]]
+name = "GOOGLE_RUNTIME_VERSION"
+value = "14.3.0"

--- a/integration/examples/buildpacks-node-tutorial/public/index.html
+++ b/integration/examples/buildpacks-node-tutorial/public/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Demo</title>
+</head>
+
+<body>
+  <h1>Hello World</h1>
+</body>
+</html>

--- a/integration/examples/buildpacks-node-tutorial/src/index.js
+++ b/integration/examples/buildpacks-node-tutorial/src/index.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const express = require('express')
+const app = express()
+
+app.use(express.static('public'));
+app.get('/hello', (req, res) => res.send('Hello World'))
+
+const port = 3000
+app.listen(port, () => console.log(`Example app listening on port ${port}!`))


### PR DESCRIPTION
**Description**

Creates a copy of the buildpacks node tutorial without a `skaffold.yaml`, so that it can be used in a tutorial that has users run `skaffold init` to generate the `skaffold.yaml`.

@aaron-prindle LMK what you think!
