### PR TITLE
chore: set v3 schema as the first schema shown on v2 doc site

### DIFF
--- a/docs-v2/config.toml
+++ b/docs-v2/config.toml
@@ -82,7 +82,7 @@ weight = 1
 copyright = "Skaffold Authors"
 privacy_policy = "https://policies.google.com/privacy"
 github_repo = "https://github.com/GoogleContainerTools/skaffold"
-skaffold_version = "skaffold/v3alpha1"
+skaffold_version = "skaffold/v3"
 
 # Google Custom Search Engine ID. Remove or comment out to disable search.
 # gcs_engine_id = "013756393218025596041:3nojel67sum"

--- a/docs-v2/static/javascripts/schemas.js
+++ b/docs-v2/static/javascripts/schemas.js
@@ -22,7 +22,17 @@ for (let s of schema_list) {
 }
 
 Object.keys(majors)
-    .sort().reverse()
+    .sort((a, b) => {
+        // v3 was released after v3alpha and doc site should show schema in reverse chronological order
+        // so we put v3 first.
+        if (a === "v3" && b === "v3alpha") {
+            return -1
+        }
+        if (a === "v3alpha" && b === "v3") {
+            return 1
+        }
+        return a > b ? -1 : 1
+    })
     .forEach(function(major) {
         majors[major].sort((a,b) => b-a);
         for (const minor of majors[major]) {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #7980  <!-- tracking issues that this PR will close -->
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
 - change the schema drop list order to put v3 schema before v3alpha, so the default one becomes v3 schema 
 - update skaffold doc site param skaffold_version to skaffold/v3

**Test Plan**
 - run ``make preview-docs-v2``  with this branch 
 - open http://localhost:1313/docs/references/yaml/ in an incognito window to avoid any previous doc site build cache 
 - should see default schema is v3 

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
