### PR TITLE
fix: stderr of "helm template" not printed

### DIFF
--- a/pkg/skaffold/render/renderer/helm/helm.go
+++ b/pkg/skaffold/render/renderer/helm/helm.go
@@ -149,7 +149,7 @@ func (h Helm) generateHelmManifests(ctx context.Context, builds []graph.Artifact
 		outBuffer := new(bytes.Buffer)
 		errBuffer := new(bytes.Buffer)
 		if err := helm.ExecWithStdoutAndStderr(ctx, h, outBuffer, errBuffer, false, helmEnv, args...); err != nil {
-			return nil, helm.UserErr("std out err", fmt.Errorf(outBuffer.String()))
+			return nil, helm.UserErr("std out err", fmt.Errorf(outBuffer.String(), fmt.Errorf(errBuffer.String())))
 		}
 		log.Entry(ctx).Errorf(errBuffer.String())
 		renderedManifests.Append(outBuffer.Bytes())


### PR DESCRIPTION
Without stderr is hard to tell why template rendering fails