### PR TITLE
docs: Fix helm command

### DIFF
--- a/docs-v2/content/en/docs/pipeline-stages/renderers/helm.md
+++ b/docs-v2/content/en/docs/pipeline-stages/renderers/helm.md
@@ -15,7 +15,7 @@ To use `helm` with Skaffold, the `helm` binary must be installed on your machine
 
 # Rendering with helm
 [`helm template`](https://helm.sh/docs/helm/helm_template/) allows Kubernetes
-developers to locally render templates. Skaffold relies on `helm temple --post-render` functionality to substitute the images
+developers to locally render templates. Skaffold relies on `helm template --post-renderer` functionality to substitute the images
 in the rendered charts with Skaffold built images.
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Fixes the reference to the `helm template --post-renderer` command.  

