### PR TITLE
feat: new dockerfiles and cloudbuild config for slim image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,6 +172,15 @@ release-lts: $(BUILD_DIR)/VERSION
 		-t gcr.io/$(GCP_PROJECT)/skaffold:$(VERSION)-lts \
 		.
 
+.PHONY: release-slim
+release-slim: $(BUILD_DIR)/VERSION
+	docker build \
+		-f deploy/skaffold/Dockerfile.slim \
+		--target release \
+		-t gcr.io/$(GCP_PROJECT)/skaffold:slim \
+		-t gcr.io/$(GCP_PROJECT)/skaffold:$(COMMIT)-slim \
+		.
+
 .PHONY: release-lts-build
 release-lts-build:
 	docker build \

--- a/deploy/cloudbuild-slim.yaml
+++ b/deploy/cloudbuild-slim.yaml
@@ -1,0 +1,54 @@
+# using default substitutions, provided by Google Cloud Build
+# see: https://cloud.google.com/container-builder/docs/configuring-builds/substitute-variable-values#using_default_substitutions
+steps:
+
+# Build and tag skaffold-deps image using docker with cache-from
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+    - 'build'
+    - '-t'
+    - 'gcr.io/$PROJECT_ID/build_deps:slim'
+    - '--cache-from'
+    - 'gcr.io/k8s-skaffold/build_deps:slim'
+    - '-f'
+    - 'deploy/skaffold/Dockerfile.deps.slim'
+    - '.'
+
+# Grab secret credentials from gcp bucket
+  - name: gcr.io/cloud-builders/gcloud
+    entrypoint: 'bash'
+    args: ['deploy/setup-secret.sh','-p', $PROJECT_ID]
+
+# Build and tag skaffold builder
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+    - 'build'
+    - '-t'
+    - 'gcr.io/$PROJECT_ID/skaffold-builder:slim'
+    - '-f'
+    - 'deploy/skaffold/Dockerfile.slim'
+    - '.'
+
+# Do the go build & push the results to GCS
+  - name: 'gcr.io/$PROJECT_ID/skaffold-builder:slim'
+    args:
+    - 'make'
+    - 'release-slim'
+    - 'RELEASE_BUCKET=$_RELEASE_BUCKET'
+    - 'GCP_PROJECT=$PROJECT_ID'
+
+# Check that skaffold is in the image
+  - name: 'gcr.io/$PROJECT_ID/skaffold:slim'
+    args:
+    - 'skaffold'
+    - 'version'
+
+images:
+- 'gcr.io/$PROJECT_ID/build_deps:slim'
+- 'gcr.io/$PROJECT_ID/skaffold:slim'
+- 'gcr.io/$PROJECT_ID/skaffold:$COMMIT_SHA-slim'
+
+options:
+  machineType: 'N1_HIGHCPU_8'
+
+timeout: 1500s

--- a/deploy/cloudbuild-slim.yaml
+++ b/deploy/cloudbuild-slim.yaml
@@ -26,7 +26,7 @@ steps:
     - '-t'
     - 'gcr.io/$PROJECT_ID/skaffold-builder:slim'
     - '-f'
-    - 'deploy/skaffold/Dockerfile.slim'
+    - 'deploy/skaffold/Dockerfile'
     - '.'
 
 # Do the go build & push the results to GCS

--- a/deploy/skaffold/Dockerfile.deps.slim
+++ b/deploy/skaffold/Dockerfile.deps.slim
@@ -1,0 +1,104 @@
+# Copyright 2019 The Skaffold Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG ARCH=amd64
+
+# Download kubectl
+FROM alpine:3.10 as download-kubectl
+ARG ARCH
+# Track default version installed by Google Cloud SDK: 406.0.0 moved to 1.22(.14)
+# https://cloud.google.com/sdk/docs/release-notes
+ENV KUBECTL_VERSION v1.22.14
+ENV KUBECTL_URL https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl
+# SHAs at gs://kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/
+COPY deploy/skaffold/digests/kubectl.${ARCH}.sha512 .
+RUN wget -O kubectl "${KUBECTL_URL}" && sha512sum -c kubectl.${ARCH}.sha512
+RUN chmod +x kubectl
+
+# Download helm (see https://github.com/helm/helm/releases/latest)
+FROM alpine:3.10 as download-helm
+ARG ARCH
+RUN echo arch=$ARCH
+ENV HELM_VERSION v3.10.1
+ENV HELM_URL https://storage.googleapis.com/skaffold/deps/helm/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz
+COPY deploy/skaffold/digests/helm.${ARCH}.sha256 .
+RUN wget -O helm.tar.gz "${HELM_URL}" && sha256sum -c helm.${ARCH}.sha256
+RUN tar -xvf helm.tar.gz --strip-components 1
+
+# Download kustomize
+FROM alpine:3.10 as download-kustomize
+ARG ARCH
+ENV KUSTOMIZE_VERSION 4.4.0
+ENV KUSTOMIZE_URL https://storage.googleapis.com/skaffold/deps/kustomize/v${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_${ARCH}.tar.gz
+COPY deploy/skaffold/digests/kustomize.${ARCH}.sha256 .
+RUN wget -O kustomize.tar.gz "${KUSTOMIZE_URL}" && sha256sum -c kustomize.${ARCH}.sha256
+RUN tar -xvf kustomize.tar.gz
+
+# Download kpt
+FROM alpine:3.10 as download-kpt
+ARG ARCH
+ENV KPT_VERSION 0.39.3
+ENV KPT_URL https://storage.googleapis.com/skaffold/deps/kpt/v${KPT_VERSION}/kpt_linux_amd64
+COPY deploy/skaffold/digests/kpt.${ARCH}.sha256 .
+RUN wget -O kpt "${KPT_URL}" && sha256sum -c kpt.${ARCH}.sha256
+RUN chmod +x kpt
+
+# Download gcloud
+FROM alpine:3.10 as download-gcloud
+ARG ARCH
+ENV GCLOUD_VERSION 406.0.0
+ENV GCLOUD_URL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GCLOUD_VERSION}-linux-GCLOUDARCH.tar.gz
+# SHAs listed at https://cloud.google.com/sdk/docs/downloads-versioned-archives
+COPY deploy/skaffold/digests/gcloud.${ARCH}.sha256 .
+RUN \
+    GCLOUDARCH=$(case "${ARCH}" in amd64) echo x86_64;; *) echo ${ARCH};; esac); \
+    wget -O gcloud.tar.gz $(echo "${GCLOUD_URL}" | sed "s/GCLOUDARCH/${GCLOUDARCH}/g") && \
+    sha256sum -c gcloud.${ARCH}.sha256
+RUN tar -zxf gcloud.tar.gz
+
+
+FROM gcr.io/gcp-runtimes/ubuntu_20_0_4 as runtime_deps
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends --no-install-suggests -y \
+    git python unzip && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=download-kubectl kubectl /usr/local/bin/
+COPY --from=download-helm helm /usr/local/bin/
+COPY --from=download-kustomize kustomize /usr/local/bin/
+COPY --from=download-kpt kpt /usr/local/bin/
+COPY --from=download-gcloud google-cloud-sdk/ /google-cloud-sdk/
+
+# Finish installation of gcloud
+RUN /google-cloud-sdk/install.sh \
+    --usage-reporting=false \
+    --bash-completion=false \
+    --disable-installation-options
+ENV PATH=$PATH:/google-cloud-sdk/bin
+RUN gcloud auth configure-docker && \
+    gcloud components install gke-gcloud-auth-plugin
+
+FROM runtime_deps
+RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \
+    build-essential \
+    python-setuptools \
+    lsb-release \
+    openjdk-11-jdk \
+    software-properties-common \
+    jq \
+    apt-transport-https && \
+    rm -rf /var/lib/apt/lists/*
+COPY --from=golang:1.19.1 /usr/local/go /usr/local/go
+ENV PATH /usr/local/go/bin:/root/go/bin:$PATH

--- a/deploy/skaffold/Dockerfile.slim
+++ b/deploy/skaffold/Dockerfile.slim
@@ -1,0 +1,26 @@
+# Copyright 2019 The Skaffold Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This base image is built using docker from cache every single time as build step.
+FROM gcr.io/k8s-skaffold/build_deps:slim as build
+WORKDIR /skaffold
+
+FROM build as builder
+ARG VERSION
+COPY . .
+RUN make clean out/skaffold VERSION=$VERSION && mv out/skaffold /usr/bin/skaffold && rm -rf secrets $SECRET
+
+FROM build as release
+COPY --from=builder /usr/bin/skaffold /usr/bin/skaffold
+RUN skaffold credits -d /THIRD_PARTY_NOTICES


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #6637

**Description**
This PR adds new Dockerfiles and a `cloudbuild-slim.yaml` configuration to trigger the creation of a skaffold slim image with every push to main branch.

The slim image is a copy of the `lts` version which has less dependencies that the `edge` version.
