### PR TITLE
feat: Add support for Cloud Run services to stream logs

### DIFF
--- a/pkg/skaffold/deploy/cloudrun/accessor_test.go
+++ b/pkg/skaffold/deploy/cloudrun/accessor_test.go
@@ -39,6 +39,9 @@ func (t *testAccessConfig) PortForwardOptions() config.PortForwardOptions {
 func (t *testAccessConfig) Mode() config.RunMode {
 	return config.RunModes.Run
 }
+func (t *testAccessConfig) Tail() bool {
+	return true
+}
 func (t *testAccessConfig) PortForwardResources() []*latest.PortForwardResource {
 	return t.forwards
 }
@@ -232,6 +235,7 @@ func TestGcloudFoundServicesForwarder(t *testing.T) {
 			var b bytes.Buffer
 			writer := bufio.NewWriter(&b)
 			err := forwarder.Start(ctx, writer)
+			writer.Flush()
 			output := b.Bytes()
 			if test.expectStatus == proto.StatusCode_OK {
 				if err != nil {

--- a/pkg/skaffold/deploy/cloudrun/deploy.go
+++ b/pkg/skaffold/deploy/cloudrun/deploy.go
@@ -48,6 +48,7 @@ type Config interface {
 	PortForwardResources() []*latest.PortForwardResource
 	PortForwardOptions() config.PortForwardOptions
 	Mode() config.RunMode
+	Tail() bool
 }
 
 // Deployer deploys code to Google Cloud Run.
@@ -73,7 +74,7 @@ func NewDeployer(cfg Config, labeller *label.DefaultLabeller, crDeploy *latest.C
 		Project:    crDeploy.ProjectID,
 		Region:     crDeploy.Region,
 		// TODO: implement logger for Cloud Run.
-		logger:        NewLoggerAggregator("test", labeller.GetRunID()),
+		logger:        NewLoggerAggregator(cfg, labeller.GetRunID()),
 		accessor:      NewAccessor(cfg, labeller.GetRunID()),
 		labeller:      labeller,
 		useGcpOptions: true,

--- a/pkg/skaffold/deploy/cloudrun/deploy.go
+++ b/pkg/skaffold/deploy/cloudrun/deploy.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -53,7 +53,7 @@ type Config interface {
 // Deployer deploys code to Google Cloud Run.
 type Deployer struct {
 	configName string
-	logger     log.Logger
+	logger     *LogAggregator
 	accessor   *RunAccessor
 	monitor    *Monitor
 	labeller   *label.DefaultLabeller
@@ -73,7 +73,7 @@ func NewDeployer(cfg Config, labeller *label.DefaultLabeller, crDeploy *latest.C
 		Project:    crDeploy.ProjectID,
 		Region:     crDeploy.Region,
 		// TODO: implement logger for Cloud Run.
-		logger:        &log.NoopLogger{},
+		logger:        NewLoggerAggregator("test", labeller.GetRunID()),
 		accessor:      NewAccessor(cfg, labeller.GetRunID()),
 		labeller:      labeller,
 		useGcpOptions: true,
@@ -201,6 +201,7 @@ func (d *Deployer) deployToCloudRun(ctx context.Context, out io.Writer, manifest
 
 	d.getMonitor().Resources = append(d.getMonitor().Resources, ResourceName{path: sName, name: service.Metadata.Name})
 	d.accessor.AddResource(resName)
+	d.logger.AddResource(resName)
 	getCall := crclient.Projects.Locations.Services.Get(sName)
 	_, err = getCall.Do()
 

--- a/pkg/skaffold/deploy/cloudrun/formatter.go
+++ b/pkg/skaffold/deploy/cloudrun/formatter.go
@@ -1,0 +1,33 @@
+package cloudrun
+
+import (
+	"io"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
+)
+
+type Formatter func(serviceName string) log.Formatter
+
+type cloudRunLogFormatter struct {
+	prefix      string
+	resources   []string
+	outputColor output.Color
+}
+
+func newCloudRunFormatter(serviceName string, outputColor output.Color) *cloudRunLogFormatter {
+	return &cloudRunLogFormatter{
+		prefix:      serviceName,
+		outputColor: outputColor,
+	}
+}
+func (formatter *cloudRunLogFormatter) Name() string {
+	return formatter.prefix
+}
+func (formatter *cloudRunLogFormatter) PrintLine(out io.Writer, line string) {
+	if output.IsColorable(out) {
+		formatter.outputColor.Fprintf(out, "[%s] %s", formatter.prefix, line)
+	} else {
+		output.Default.Fprintln(out, "[%s] %s", formatter.prefix, line)
+	}
+}

--- a/pkg/skaffold/deploy/cloudrun/formatter.go
+++ b/pkg/skaffold/deploy/cloudrun/formatter.go
@@ -1,33 +1,38 @@
+/*
+Copyright 2022 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package cloudrun
 
 import (
 	"io"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
 )
 
-type Formatter func(serviceName string) log.Formatter
-
-type cloudRunLogFormatter struct {
+type LogFormatter struct {
 	prefix      string
-	resources   []string
 	outputColor output.Color
 }
 
-func newCloudRunFormatter(serviceName string, outputColor output.Color) *cloudRunLogFormatter {
-	return &cloudRunLogFormatter{
-		prefix:      serviceName,
-		outputColor: outputColor,
-	}
-}
-func (formatter *cloudRunLogFormatter) Name() string {
+func (formatter *LogFormatter) Name() string {
 	return formatter.prefix
 }
-func (formatter *cloudRunLogFormatter) PrintLine(out io.Writer, line string) {
+func (formatter *LogFormatter) PrintLine(out io.Writer, line string) {
 	if output.IsColorable(out) {
 		formatter.outputColor.Fprintf(out, "[%s] %s", formatter.prefix, line)
 	} else {
-		output.Default.Fprintln(out, "[%s] %s", formatter.prefix, line)
+		output.Default.Fprintf(out, "[%s] %s", formatter.prefix, line)
 	}
 }

--- a/pkg/skaffold/deploy/cloudrun/formatter_test.go
+++ b/pkg/skaffold/deploy/cloudrun/formatter_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2022 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cloudrun
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
+)
+
+func TestLogFormatter_Name(t *testing.T) {
+	serviceName := "test"
+	formatter := LogFormatter{prefix: serviceName, outputColor: output.Red}
+	if formatter.Name() != serviceName {
+		t.Fatalf("expected service name to be %s but got %s", serviceName, formatter.Name())
+	}
+}
+
+func TestLogFormatter_Printline(t *testing.T) {
+	testLog := "Testing log output"
+	serviceName := "test"
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+	formatter := LogFormatter{prefix: serviceName, outputColor: output.Red}
+	formatter.PrintLine(writer, testLog)
+	writer.Flush()
+	result := b.Bytes()
+	expectedLogOutput := fmt.Sprintf("[%s] %s", serviceName, testLog)
+	if string(result) != expectedLogOutput {
+		t.Fatalf("expected log output to be %s but got %s", expectedLogOutput, result)
+	}
+}

--- a/pkg/skaffold/deploy/cloudrun/log.go
+++ b/pkg/skaffold/deploy/cloudrun/log.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2022 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cloudrun
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sync/atomic"
+	"time"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+	"github.com/GoogleContainerTools/skaffold/proto/v1"
+	"golang.org/x/sync/singleflight"
+
+	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
+)
+
+type logTailer interface {
+	Start(ctx context.Context, out io.Writer) error
+	Stop()
+}
+
+type logTailerResource struct {
+	name      RunResourceName
+	cancel    context.CancelFunc
+	isTailing bool
+	cmd       *exec.Cmd
+}
+
+type loggerTracker struct {
+	resources map[RunResourceName]*logTailerResource
+}
+
+type LogAggregator struct {
+	output       io.Writer
+	singleRun    singleflight.Group
+	resourceName string
+	resources    *loggerTracker
+	logTailers   []logTailer
+	muted        int32
+	colorPicker  output.ColorPicker
+	label        string
+	formatter    Formatter
+}
+
+func (r *LogAggregator) Mute() {
+	if r == nil {
+		// Logs are not activated.
+		return
+	}
+
+	atomic.StoreInt32(&r.muted, 1)
+}
+
+func (r *LogAggregator) Unmute() {
+	if r == nil {
+		// Logs are not activated.
+		return
+	}
+
+	atomic.StoreInt32(&r.muted, 0)
+}
+
+func (r *LogAggregator) SetSince(time time.Time) {
+}
+
+func (r *LogAggregator) RegisterArtifacts(artifacts []graph.Artifact) {
+	for _, artifact := range artifacts {
+		r.colorPicker.AddImage(artifact.Tag)
+	}
+}
+
+func NewLoggerAggregator(resourceName string, label string) *LogAggregator {
+	var logTailers []logTailer
+	resources := &loggerTracker{}
+	logTailers = append(logTailers, &runLogTailer{resources: resources})
+	a := &LogAggregator{resourceName: resourceName, logTailers: logTailers, resources: resources, label: label, singleRun: singleflight.Group{}}
+	return a
+}
+
+func (r *LogAggregator) AddResource(resource RunResourceName) {
+	if r.resources.resources == nil {
+		r.resources.resources = make(map[RunResourceName]*logTailerResource)
+	}
+	if _, present := r.resources.resources[resource]; !present {
+		r.resources.resources[resource] = &logTailerResource{name: resource}
+	} else {
+		r.resources.resources[resource].isTailing = true
+	}
+
+}
+
+func (r *LogAggregator) Start(ctx context.Context, out io.Writer) error {
+	if r == nil {
+		return nil
+	}
+	_, err, _ := r.singleRun.Do(r.label, func() (interface{}, error) {
+		return struct{}{}, r.start(ctx, out)
+	})
+	return err
+}
+
+func (r *LogAggregator) start(ctx context.Context, out io.Writer) error {
+	for _, logTail := range r.logTailers {
+		if err := logTail.Start(ctx, out); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *LogAggregator) Stop() {
+	for _, logTailer := range r.logTailers {
+		logTailer.Stop()
+	}
+}
+
+type runLogTailer struct {
+	resources *loggerTracker
+}
+
+func (r *runLogTailer) Start(ctx context.Context, out io.Writer) error {
+	if !gcloudInstalled() {
+		output.Red.Fprintln(out, "gcloud not found on path. Unable to set up Cloud Run port forwarding")
+		return sErrors.NewError(fmt.Errorf("gcloud not found"), &proto.ActionableErr{ErrCode: proto.StatusCode_PORT_FORWARD_RUN_GCLOUD_NOT_FOUND})
+	}
+	if r.resources.resources == nil {
+		return nil
+	}
+	for _, resource := range r.resources.resources {
+		if !resource.isTailing {
+			cctx, cancel := context.WithCancel(ctx)
+			cmd := exec.CommandContext(cctx, "gcloud", getGcloudTailArgs(resource.name)...)
+			cmd.Env = os.Environ()
+			// gcloud uses buffered stream by default
+			cmd.Env = append(cmd.Env, "PYTHONUNBUFFERED=1") // gcloud defaults streaming output as buffered
+			r, w := io.Pipe()
+			cmd.Stderr = w
+			cmd.Stdout = w
+			resource.cancel = cancel
+			if err := cmd.Start(); err != nil {
+				output.Red.Fprintln(out, "failed to start log streaming on service %s", resource.name.Service)
+				return err
+			}
+			buf := make([]byte, 4*1024)
+			for {
+				n, err := r.Read(buf)
+				if err != nil {
+					break
+				}
+				output.Purple.Fprintf(out, "[%s]: %s", resource.name.Service, buf[:n])
+			}
+			resource.isTailing = true
+			resource.cmd = cmd
+		}
+	}
+	return nil
+}
+
+func (r *runLogTailer) Stop() {
+	for _, resource := range r.resources.resources {
+		if resource.cancel != nil {
+			if resource.cmd != nil {
+				if err := resource.cmd.Process.Signal(os.Interrupt); err != nil {
+					// signaling didn't work, force cancel
+					resource.cancel()
+				}
+			} else {
+				resource.cancel()
+			}
+			resource.cancel = nil
+			resource.cmd = nil
+		}
+	}
+}
+
+func getGcloudTailArgs(resource RunResourceName) []string {
+	return []string{"alpha", "run", "services", "logs", "tail", resource.Service, "--project", resource.Project}
+}

--- a/pkg/skaffold/deploy/cloudrun/log.go
+++ b/pkg/skaffold/deploy/cloudrun/log.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,13 +25,12 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
-	"github.com/GoogleContainerTools/skaffold/proto/v1"
 	"golang.org/x/sync/singleflight"
 
 	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
+	"github.com/GoogleContainerTools/skaffold/proto/v1"
 )
 
 type logTailer interface {
@@ -44,7 +43,7 @@ type logTailerResource struct {
 	cancel    context.CancelFunc
 	isTailing bool
 	cmd       *exec.Cmd
-	formatter Formatter
+	formatter LogFormatter
 }
 
 type loggerTracker struct {
@@ -52,7 +51,6 @@ type loggerTracker struct {
 }
 
 type LogAggregator struct {
-	output        io.Writer
 	singleRun     singleflight.Group
 	resources     *loggerTracker
 	logTailers    []logTailer
@@ -101,9 +99,7 @@ func (r *LogAggregator) AddResource(resource RunResourceName) {
 	}
 	if _, present := r.resources.resources[resource]; !present {
 		r.addServiceColor(resource.Service)
-		r.resources.resources[resource] = &logTailerResource{name: resource, formatter: func(serviceName string) log.Formatter {
-			return newCloudRunFormatter(serviceName, r.serviceColors[serviceName])
-		}}
+		r.resources.resources[resource] = &logTailerResource{name: resource, formatter: LogFormatter{resource.Service, r.serviceColors[resource.Service]}}
 	} else {
 		r.resources.resources[resource].isTailing = true
 	}
@@ -147,7 +143,7 @@ type runLogTailer struct {
 func (r *runLogTailer) Start(ctx context.Context, out io.Writer) error {
 	if !gcloudInstalled() {
 		output.Red.Fprintln(out, "gcloud not found on path. Unable to set up Cloud Run port forwarding")
-		return sErrors.NewError(fmt.Errorf("gcloud not found"), &proto.ActionableErr{ErrCode: proto.StatusCode_PORT_FORWARD_RUN_GCLOUD_NOT_FOUND})
+		return sErrors.NewError(fmt.Errorf("gcloud not found"), &proto.ActionableErr{ErrCode: proto.StatusCode_LOG_STREAMING_RUN_GCLOUD_NOT_FOUND})
 	}
 	if r.resources.resources == nil {
 		return nil
@@ -165,14 +161,14 @@ func (r *runLogTailer) Start(ctx context.Context, out io.Writer) error {
 				cmd.Stdout = w
 				resource.cancel = cancel
 				if err := cmd.Start(); err != nil {
-					output.Red.Fprintln(out, "failed to start log streaming on service %s", resource.name.Service)
+					output.Red.Fprintf(out, "failed to start log streaming on service %s\n", resource.name.Service)
 				}
-				if err := streamLog(ctx, out, r, resource.formatter(resource.name.Service)); err != nil {
-					output.Red.Fprintln(out, "log streaming failed: %s", err)
+				if err := streamLog(ctx, out, r, resource.formatter); err != nil {
+					output.Red.Fprintf(out, "log streaming failed: %s\n", err)
 				}
 				go func() {
 					if err := cmd.Wait(); err != nil {
-						output.Red.Fprintln(out, "terminated")
+						output.Red.Fprintf(out, "terminated\n")
 					}
 				}()
 				resource.isTailing = true
@@ -183,7 +179,7 @@ func (r *runLogTailer) Start(ctx context.Context, out io.Writer) error {
 	return nil
 }
 
-func streamLog(ctx context.Context, out io.Writer, rc io.Reader, formatter log.Formatter) error {
+func streamLog(ctx context.Context, out io.Writer, rc io.Reader, formatter LogFormatter) error {
 	reader := bufio.NewReader(rc)
 	for {
 		select {
@@ -196,7 +192,8 @@ func streamLog(ctx context.Context, out io.Writer, rc io.Reader, formatter log.F
 				return nil
 			}
 			if err != nil {
-				output.Red.Fprintf(out, "error reading bytes form log streaming: %w", err)
+				output.Red.Fprintf(out, "error reading bytes form log streaming: %v", err)
+				return err
 			}
 			formatter.PrintLine(out, line)
 		}

--- a/pkg/skaffold/deploy/cloudrun/log_test.go
+++ b/pkg/skaffold/deploy/cloudrun/log_test.go
@@ -1,0 +1,248 @@
+/*
+Copyright 2022 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cloudrun
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/proto/v1"
+)
+
+type testConfig struct {
+	tail bool
+}
+
+func (t *testConfig) Tail() bool {
+	return t.tail
+}
+
+func (t *testConfig) Mode() config.RunMode {
+	return config.RunModes.Run
+}
+
+func (t *testConfig) PortForwardOptions() config.PortForwardOptions {
+	return config.PortForwardOptions{}
+}
+
+func (t *testConfig) PortForwardResources() []*latest.PortForwardResource {
+	return nil
+}
+func newLogTestConfig(tail bool) *testConfig {
+	return &testConfig{tail: tail}
+}
+func TestNewLoggerAggregator(t *testing.T) {
+	tests := []struct {
+		name       string
+		tail       bool
+		numTailers int
+	}{
+		{
+			name:       "tailing is turned on",
+			tail:       true,
+			numTailers: 1,
+		},
+		{
+			name:       "tailing is turned off",
+			tail:       false,
+			numTailers: 0,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := newLogTestConfig(test.tail)
+			logAggregator := NewLoggerAggregator(cfg, "test")
+			if len(logAggregator.logTailers) != test.numTailers {
+				t.Fatalf("expected %d forwarders, but got %v", test.numTailers, logAggregator.logTailers)
+			}
+		})
+	}
+}
+
+func TestResourcesAddedLogTailers(t *testing.T) {
+	tests := []struct {
+		name      string
+		resources []RunResourceName
+		outputs   []logTailerResource
+	}{
+		{
+			name: "one service with one color",
+			resources: []RunResourceName{
+				{
+					Project: "test-proj",
+					Region:  "test-region",
+					Service: "test-service",
+				},
+			},
+			outputs: []logTailerResource{
+				{
+					name: RunResourceName{
+						Project: "test-proj",
+						Region:  "test-region",
+						Service: "test-service",
+					},
+					formatter: LogFormatter{
+						prefix:      "test-service",
+						outputColor: output.DefaultColorCodes[0],
+					},
+					isTailing: false,
+				},
+			},
+		},
+		{
+			name: "two services with same name",
+			resources: []RunResourceName{
+				{
+					Project: "test-proj",
+					Region:  "test-region",
+					Service: "test-service",
+				},
+				{
+					Project: "test-proj",
+					Region:  "test-region",
+					Service: "test-service",
+				},
+			},
+			outputs: []logTailerResource{
+				{
+					name: RunResourceName{
+						Project: "test-proj",
+						Region:  "test-region",
+						Service: "test-service",
+					},
+					formatter: LogFormatter{
+						prefix:      "test-service",
+						outputColor: output.DefaultColorCodes[0],
+					},
+					isTailing: true,
+				},
+			},
+		},
+		{
+			name: "two services with different names",
+			resources: []RunResourceName{
+				{
+					Project: "test-proj",
+					Region:  "test-region",
+					Service: "test-service",
+				},
+				{
+					Project: "test-proj",
+					Region:  "test-region",
+					Service: "test-service2",
+				},
+			},
+			outputs: []logTailerResource{
+				{
+					name: RunResourceName{
+						Project: "test-proj",
+						Region:  "test-region",
+						Service: "test-service",
+					},
+					formatter: LogFormatter{
+						prefix:      "test-service",
+						outputColor: output.DefaultColorCodes[0],
+					},
+					isTailing: false,
+				},
+				{
+					name: RunResourceName{
+						Project: "test-proj",
+						Region:  "test-region",
+						Service: "test-service2",
+					},
+					formatter: LogFormatter{
+						prefix:      "test-service2",
+						outputColor: output.DefaultColorCodes[1],
+					},
+					isTailing: false,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := newLogTestConfig(true)
+			logAggregator := NewLoggerAggregator(cfg, "")
+			for _, resource := range test.resources {
+				logAggregator.AddResource(resource)
+			}
+			if len(test.outputs) != len(logAggregator.resources.resources) {
+				t.Fatalf("Mismatch in expected outputs. Expected %v, got %v", test.outputs, logAggregator.resources.resources)
+			}
+			for _, result := range test.outputs {
+				got, found := logAggregator.resources.resources[result.name]
+				if !found {
+					t.Fatalf("expected to find log resource %v but got nothing", result.name)
+				}
+				if result.name != got.name || result.formatter != got.formatter {
+					t.Fatalf("did not get expected result. Expected %v, got %v", result, got)
+				}
+			}
+		})
+	}
+}
+
+func TestGcloudFoundLogTailing(t *testing.T) {
+	tests := []struct {
+		name         string
+		gcloudFound  bool
+		expectStatus proto.StatusCode
+	}{
+		{
+			name:        "gcloud found",
+			gcloudFound: true,
+		},
+		{
+			name:         "gcloud not found",
+			gcloudFound:  false,
+			expectStatus: proto.StatusCode_LOG_STREAMING_RUN_GCLOUD_NOT_FOUND,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logTailers := runLogTailer{resources: &loggerTracker{}}
+			gcloudInstalled = func() bool { return test.gcloudFound }
+			ctx := context.Background()
+			var b bytes.Buffer
+			writer := bufio.NewWriter(&b)
+			err := logTailers.Start(ctx, writer)
+			writer.Flush()
+			result := b.Bytes()
+			if test.expectStatus == proto.StatusCode_OK {
+				if err != nil {
+					t.Fatalf("expected success, got error: %v with output %s", err, string(result))
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("expected failure with code %v, got success with output: %s", test.expectStatus, string(result))
+				}
+				sErr := err.(*sErrors.ErrDef)
+				if sErr.StatusCode() != test.expectStatus {
+					t.Fatalf("expected failure with code %v, got code %v with output: %s", test.expectStatus, sErr.StatusCode(), string(result))
+				}
+			}
+		})
+	}
+}

--- a/proto/enums/enums.pb.go
+++ b/proto/enums/enums.pb.go
@@ -886,6 +886,7 @@ const (
 	StatusCode_INSPECT_PROFILE_NOT_FOUND_ERR      StatusCode = 1304
 	StatusCode_PORT_FORWARD_RUN_GCLOUD_NOT_FOUND  StatusCode = 1601
 	StatusCode_PORT_FORWARD_RUN_PROXY_START_ERROR StatusCode = 1602
+	StatusCode_LOG_STREAM_RUN_GCLOUD_NOT_FOUND    StatusCode = 1603
 )
 
 // Enum value maps for StatusCode.

--- a/proto/v1/skaffold.pb.go
+++ b/proto/v1/skaffold.pb.go
@@ -307,6 +307,7 @@ const StatusCode_INSPECT_BUILD_ENV_INCORRECT_TYPE_ERR = enums.StatusCode_INSPECT
 const StatusCode_INSPECT_PROFILE_NOT_FOUND_ERR = enums.StatusCode_INSPECT_PROFILE_NOT_FOUND_ERR
 const StatusCode_PORT_FORWARD_RUN_GCLOUD_NOT_FOUND = enums.StatusCode_PORT_FORWARD_RUN_GCLOUD_NOT_FOUND
 const StatusCode_PORT_FORWARD_RUN_PROXY_START_ERROR = enums.StatusCode_PORT_FORWARD_RUN_PROXY_START_ERROR
+const StatusCode_LOG_STREAMING_RUN_GCLOUD_NOT_FOUND = enums.StatusCode_LOG_STREAM_RUN_GCLOUD_NOT_FOUND
 
 var StatusCode_name = enums.StatusCode_name
 var StatusCode_value = enums.StatusCode_value


### PR DESCRIPTION
**Description**
Add log streaming support for cloud run services

**User facing changes (remove if N/A)**
log streaming will automatically be triggered on skaffold if it is running in dev, debug, run --tail modes

**Follow-up Work**
Migrate gcloud command from alpha to beta once log streaming command is published to gcloud beta.

