### PR TITLE
fix: not print error message if it is empty

### DIFF
--- a/pkg/skaffold/render/renderer/helm/helm.go
+++ b/pkg/skaffold/render/renderer/helm/helm.go
@@ -148,10 +148,18 @@ func (h Helm) generateHelmManifests(ctx context.Context, builds []graph.Artifact
 
 		outBuffer := new(bytes.Buffer)
 		errBuffer := new(bytes.Buffer)
-		if err := helm.ExecWithStdoutAndStderr(ctx, h, outBuffer, errBuffer, false, helmEnv, args...); err != nil {
-			return nil, helm.UserErr("std out err", fmt.Errorf(outBuffer.String(), fmt.Errorf(errBuffer.String())))
+
+		err = helm.ExecWithStdoutAndStderr(ctx, h, outBuffer, errBuffer, false, helmEnv, args...)
+		errorMsg := errBuffer.String()
+
+		if len(errorMsg) > 0 {
+			log.Entry(ctx).Errorf(errorMsg)
 		}
-		log.Entry(ctx).Errorf(errBuffer.String())
+
+		if err != nil {
+			return nil, helm.UserErr("std out err", fmt.Errorf(outBuffer.String(), fmt.Errorf(errorMsg)))
+		}
+
 		renderedManifests.Append(outBuffer.Bytes())
 	}
 


### PR DESCRIPTION
Fixes: #7979

**Description**
With this PR we check first if an error message has a value before printing it so we don't get empty errors

**Follow-up Work**
Check other places where this could be happening