### PR TITLE
fix: container image push to local cluster

### DIFF
--- a/pkg/skaffold/deploy/helm/helm.go
+++ b/pkg/skaffold/deploy/helm/helm.go
@@ -237,7 +237,7 @@ func (h *Deployer) Deploy(ctx context.Context, out io.Writer, builds []graph.Art
 	}
 
 	childCtx, endTrace := instrumentation.StartTrace(ctx, "Deploy_LoadImages")
-	if err := h.imageLoader.LoadImages(childCtx, out, h.localImages, nil, builds); err != nil {
+	if err := h.imageLoader.LoadImages(childCtx, out, h.localImages, h.originalImages, builds); err != nil {
 		endTrace(instrumentation.TraceEndError(err))
 		return err
 	}

--- a/pkg/skaffold/deploy/kubectl/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl.go
@@ -84,7 +84,7 @@ type Deployer struct {
 
 // NewDeployer returns a new Deployer for a DeployConfig filled
 // with the needed configuration for `kubectl apply`
-func NewDeployer(cfg Config, labeller *label.DefaultLabeller, d *latest.KubectlDeploy, configName string) (*Deployer, error) {
+func NewDeployer(cfg Config, labeller *label.DefaultLabeller, d *latest.KubectlDeploy, artifacts []*latest.Artifact, configName string) (*Deployer, error) {
 	defaultNamespace := ""
 	b, err := (&util.Commander{}).RunCmdOut(context.Background(), exec.Command("kubectl", "config", "view", "--minify", "-o", "jsonpath='{..namespace}'"))
 	if err != nil {
@@ -114,7 +114,16 @@ func NewDeployer(cfg Config, labeller *label.DefaultLabeller, d *latest.KubectlD
 	if err != nil {
 		return nil, err
 	}
+
+	var ogImages []graph.Artifact
+	for _, artifact := range artifacts {
+		ogImages = append(ogImages, graph.Artifact{
+			ImageName: artifact.ImageName,
+		})
+	}
+
 	return &Deployer{
+		originalImages:     ogImages,
 		configName:         configName,
 		KubectlDeploy:      d,
 		podSelector:        podSelector,
@@ -229,7 +238,7 @@ func (k *Deployer) Deploy(ctx context.Context, out io.Writer, builds []graph.Art
 		return err
 	}
 
-	_, endTrace = instrumentation.StartTrace(ctx, "Deploy_LoadImages")
+	childCtx, endTrace = instrumentation.StartTrace(ctx, "Deploy_LoadImages")
 	if err := k.imageLoader.LoadImages(childCtx, out, k.localImages, k.originalImages, builds); err != nil {
 		endTrace(instrumentation.TraceEndError(err))
 		return err

--- a/pkg/skaffold/deploy/kubectl/kubectl_test.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl_test.go
@@ -220,7 +220,7 @@ func TestKubectlV1RenderDeploy(t *testing.T) {
 				},
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{
 					Namespace: skaffoldNamespaceOption}},
-			}, &label.DefaultLabeller{}, &test.kubectl, configName)
+			}, &label.DefaultLabeller{}, &test.kubectl, nil, configName)
 			t.RequireNoError(err)
 
 			rc := latest.RenderConfig{Generate: test.generate}
@@ -316,7 +316,7 @@ func TestKubectlCleanup(t *testing.T) {
 			k, err := NewDeployer(&kubectlConfig{
 				workingDir: ".",
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{Namespace: TestNamespace}},
-			}, &label.DefaultLabeller{}, &test.kubectl, configName)
+			}, &label.DefaultLabeller{}, &test.kubectl, nil, configName)
 			t.RequireNoError(err)
 			rc := latest.RenderConfig{Generate: test.generate}
 			mockCfg := &kubectlConfig{
@@ -364,7 +364,7 @@ func TestKubectlRedeploy(t *testing.T) {
 				Enabled: true,
 				Delay:   0 * time.Millisecond,
 				Max:     10 * time.Second},
-		}, &label.DefaultLabeller{}, &latest.KubectlDeploy{}, configName)
+		}, &label.DefaultLabeller{}, &latest.KubectlDeploy{}, nil, configName)
 		t.RequireNoError(err)
 
 		// Deploy both manifests
@@ -440,7 +440,7 @@ func TestKubectlWaitForDeletions(t *testing.T) {
 				Delay:   0 * time.Millisecond,
 				Max:     10 * time.Second,
 			},
-		}, &label.DefaultLabeller{}, &latest.KubectlDeploy{}, configName)
+		}, &label.DefaultLabeller{}, &latest.KubectlDeploy{}, nil, configName)
 		t.RequireNoError(err)
 
 		var out bytes.Buffer
@@ -480,7 +480,7 @@ func TestKubectlWaitForDeletionsFails(t *testing.T) {
 				Delay:   10 * time.Second,
 				Max:     100 * time.Millisecond,
 			},
-		}, &label.DefaultLabeller{}, &latest.KubectlDeploy{}, configName)
+		}, &label.DefaultLabeller{}, &latest.KubectlDeploy{}, nil, configName)
 		t.RequireNoError(err)
 
 		m, err := manifest.Load(bytes.NewReader([]byte(DeploymentWebYAMLv1)))
@@ -544,7 +544,7 @@ func TestGCSManifests(t *testing.T) {
 			k, err := NewDeployer(&kubectlConfig{
 				workingDir: ".",
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{Namespace: TestNamespace}},
-			}, &label.DefaultLabeller{}, &latest.KubectlDeploy{}, configName)
+			}, &label.DefaultLabeller{}, &latest.KubectlDeploy{}, nil, configName)
 			t.RequireNoError(err)
 
 			err = k.Deploy(context.Background(), io.Discard, nil, m)
@@ -581,7 +581,7 @@ func TestHasRunnableHooks(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			k, err := NewDeployer(&kubectlConfig{}, &label.DefaultLabeller{}, &test.cfg, "default")
+			k, err := NewDeployer(&kubectlConfig{}, &label.DefaultLabeller{}, &test.cfg, nil, "default")
 			t.RequireNoError(err)
 			actual := k.HasRunnableHooks()
 			t.CheckDeepEqual(test.expected, actual)

--- a/pkg/skaffold/deploy/kubectl/kustomize_test.go
+++ b/pkg/skaffold/deploy/kubectl/kustomize_test.go
@@ -157,7 +157,7 @@ func TestKustomizeRenderDeploy(t *testing.T) {
 				},
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{
 					Namespace: skaffoldNamespaceOption,
-				}}}, &label.DefaultLabeller{}, &test.kDeploy, "default")
+				}}}, &label.DefaultLabeller{}, &test.kDeploy, nil, "default")
 			t.RequireNoError(err)
 
 			err = k.Deploy(context.Background(), io.Discard, test.builds, m)
@@ -234,7 +234,7 @@ func TestKustomizeCleanup(t *testing.T) {
 				k, err := NewDeployer(&kubectlConfig{
 					RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{
 						Namespace: TestNamespace}},
-				}, &label.DefaultLabeller{}, &latest.KubectlDeploy{}, "default")
+				}, &label.DefaultLabeller{}, &latest.KubectlDeploy{}, nil, "default")
 				t.RequireNoError(err)
 				err = k.Cleanup(context.Background(), io.Discard, test.dryRun, m)
 				t.CheckError(test.shouldErr, err)

--- a/pkg/skaffold/runner/deployer.go
+++ b/pkg/skaffold/runner/deployer.go
@@ -157,10 +157,11 @@ func GetDeployer(ctx context.Context, runCtx *runcontext.RunContext, labeller *l
 		}
 
 		if d.KubectlDeploy != nil {
-			deployer, err := kubectl.NewDeployer(dCtx, labeller, d.KubectlDeploy, configName)
+			deployer, err := kubectl.NewDeployer(dCtx, labeller, d.KubectlDeploy, runCtx.Artifacts(), configName)
 			if err != nil {
 				return nil, err
 			}
+
 			deployers = append(deployers, deployer)
 		}
 
@@ -269,7 +270,7 @@ func getDefaultDeployer(runCtx *runcontext.RunContext, labeller *label.DefaultLa
 		DefaultNamespace: defaultNamespace,
 	}
 	dCtx := &deployerCtx{runCtx, latest.DeployConfig{StatusCheck: statusCheck, KubeContext: kubeContext, DeployType: latest.DeployType{KubectlDeploy: k}}}
-	defaultDeployer, err := kubectl.NewDeployer(dCtx, labeller, k, "")
+	defaultDeployer, err := kubectl.NewDeployer(dCtx, labeller, k, runCtx.Artifacts(), "")
 	if err != nil {
 		return nil, fmt.Errorf("instantiating default kubectl deployer: %w", err)
 	}

--- a/pkg/skaffold/runner/deployer_test.go
+++ b/pkg/skaffold/runner/deployer_test.go
@@ -102,7 +102,7 @@ func TestGetDeployer(tOuter *testing.T) {
 						),
 					}, &label.DefaultLabeller{}, &latest.KubectlDeploy{
 						Flags: latest.KubectlFlags{},
-					}, "default")).(deploy.Deployer),
+					}, nil, "default")).(deploy.Deployer),
 				}, false),
 			},
 			{
@@ -146,7 +146,7 @@ func TestGetDeployer(tOuter *testing.T) {
 					),
 				}, &label.DefaultLabeller{}, &latest.KubectlDeploy{
 					Flags: latest.KubectlFlags{},
-				}, "default")).(deploy.Deployer),
+				}, nil, "default")).(deploy.Deployer),
 			},
 			{
 				description: "apply forces creation of kubectl deployer with helm config",
@@ -167,7 +167,7 @@ func TestGetDeployer(tOuter *testing.T) {
 					),
 				}, &label.DefaultLabeller{}, &latest.KubectlDeploy{
 					Flags: latest.KubectlFlags{},
-				}, "default")).(deploy.Deployer),
+				}, nil, "default")).(deploy.Deployer),
 			},
 			{
 				description: "multiple deployers",
@@ -261,7 +261,7 @@ func TestGetDeployer(tOuter *testing.T) {
 					),
 				}, &label.DefaultLabeller{}, &latest.KubectlDeploy{
 					Flags: latest.KubectlFlags{},
-				}, "default")).(deploy.Deployer),
+				}, nil, "default")).(deploy.Deployer),
 			},
 			{
 				description: "apply works with Cloud Run",
@@ -372,7 +372,7 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 					),
 				}, &label.DefaultLabeller{}, &latest.KubectlDeploy{
 					Flags: latest.KubectlFlags{},
-				}, configNameForDefaultDeployer)).(*kubectl.Deployer),
+				}, nil, configNameForDefaultDeployer)).(*kubectl.Deployer),
 			},
 			{
 				name: "one config with kubectl deploy, with flags",
@@ -397,7 +397,7 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 						Apply:  []string{"--foo"},
 						Global: []string{"--bar"},
 					},
-				}, configNameForDefaultDeployer)).(*kubectl.Deployer),
+				}, nil, configNameForDefaultDeployer)).(*kubectl.Deployer),
 			},
 			{
 				name: "two kubectl configs with mismatched flags should fail",
@@ -432,7 +432,7 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 					),
 				}, &label.DefaultLabeller{}, &latest.KubectlDeploy{
 					Flags: latest.KubectlFlags{},
-				}, configNameForDefaultDeployer)).(*kubectl.Deployer),
+				}, nil, configNameForDefaultDeployer)).(*kubectl.Deployer),
 			},
 		}
 


### PR DESCRIPTION
Starting with version 2.x, `skaffold` isn't pushing container images to kind cluster(s), as result - deployment fail due to lack of container image. Issue #7992

Verified changes on 3 [`examples`](/examples):
 * [getting-started](/examples/getting-started)
 * [kustomize](/examples/kustomize)
 * [helm-deployment](/examples/helm-deployment)

Run `skaffold --kube-context=kind-kind dev` in each to validate container images being pushed with this fix.

<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #7992 <!-- tracking issues that this PR will close -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
It appeared that problem with skaffold not loading container images to kind cluster is due to the way how skaffold constructs the list of images that supposed to be pushed to cluster. Function [`imagesToLoad`](https://github.com/GoogleContainerTools/skaffold/blob/aa0bf348b1cb3151356715612ac3db5a63a0d4df/pkg/skaffold/kubernetes/loader/load.go#L63) iterating through different lists, and those lists kind of depend on each other.

Result list check for docker images that being produced, but in case of [`kubectl`](https://github.com/GoogleContainerTools/skaffold/blob/aa0bf348b1cb3151356715612ac3db5a63a0d4df/pkg/skaffold/deploy/kubectl/kubectl.go#L233) and [`helm`](https://github.com/GoogleContainerTools/skaffold/blob/main/pkg/skaffold/deploy/helm/helm.go#L240) deployers list of produced artifact hasn't been passed to this function at all, as result `skaffold` is treating as there were no images to push.


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
