### PR TITLE
feat: add skipTests to ignore helm test directory on manifest generation

### DIFF
--- a/docs-v2/content/en/schemas/v4beta1.json
+++ b/docs-v2/content/en/schemas/v4beta1.json
@@ -2164,6 +2164,12 @@
           "x-intellij-html-description": "should build dependencies be skipped. Ignored for <code>remoteChart</code>.",
           "default": "false"
         },
+        "skipTests": {
+          "type": "boolean",
+          "description": "should ignore helm test during manifests generation.",
+          "x-intellij-html-description": "should ignore helm test during manifests generation.",
+          "default": "false"
+        },
         "upgradeOnChange": {
           "type": "boolean",
           "description": "specifies whether to upgrade helm chart on code changes. Default is `true` when helm chart is local (has `chartPath`). Default is `false` when helm chart is remote (has `remoteChart`).",
@@ -2210,6 +2216,7 @@
         "wait",
         "recreatePods",
         "skipBuildDependencies",
+        "skipTests",
         "useHelmSecrets",
         "repo",
         "upgradeOnChange",

--- a/pkg/skaffold/render/renderer/helm/helm.go
+++ b/pkg/skaffold/render/renderer/helm/helm.go
@@ -130,6 +130,10 @@ func (h Helm) generateHelmManifests(ctx context.Context, builds []graph.Artifact
 			return nil, helm.UserErr("construct override args", err)
 		}
 
+		if release.SkipTests {
+			args = append(args, "--skip-tests")
+		}
+
 		namespace, err := helm.ReleaseNamespace(h.namespace, release)
 		if err != nil {
 			return nil, err

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -856,6 +856,10 @@ type HelmRelease struct {
 	// Ignored for `remoteChart`.
 	SkipBuildDependencies bool `yaml:"skipBuildDependencies,omitempty"`
 
+	// SkipTests should ignore helm test during manifests generation.
+	// Defaults to `false`
+	SkipTests bool `yaml:"skipTests,omitempty"`
+
 	// UseHelmSecrets instructs skaffold to use secrets plugin on deployment.
 	UseHelmSecrets bool `yaml:"useHelmSecrets,omitempty"`
 


### PR DESCRIPTION
Fixes: #5132 

**Description**
This PR add new `deploy.helm.releases[*].skipTests` to the configuration file. This is to prevent skaffold from rendering the helm template located on tests directory.

**User facing changes (remove if N/A)**
User can skip helm tests when using helm to deploy the application.

```yaml
apiVersion: skaffold/v3
kind: Config
metadata:
  name: waterfight
profiles:
 - name: helm
    deploy:
      helm:
        releases:
          - name: waterfight-skaffold-k8s
            chartPath: deployment/helm/app
            namespace: default
            skipTests: true
```

Signed-off-by: Imre Nagi <imre.nagi@gojek.com>