### PR TITLE
fix: add description to StatusCheck TaskEvent

### DIFF
--- a/pkg/skaffold/kubernetes/status/status_check.go
+++ b/pkg/skaffold/kubernetes/status/status_check.go
@@ -139,7 +139,7 @@ func (s *monitor) Check(ctx context.Context, out io.Writer) error {
 
 func (s *monitor) check(ctx context.Context, out io.Writer) error {
 	event.StatusCheckEventStarted()
-	eventV2.TaskInProgress(constants.StatusCheck, "")
+	eventV2.TaskInProgress(constants.StatusCheck, "Status Checking Deployed Artifacts")
 	ctx, endTrace := instrumentation.StartTrace(ctx, "performStatusCheck_WaitForDeploymentToStabilize")
 	defer endTrace()
 


### PR DESCRIPTION
fixes #8016

Similar to the fix for https://github.com/GoogleContainerTools/skaffold/pull/7937 (same issue just with StatusCheck TaskEvent)