### PR TITLE
fix: preserve configs order when creating renderers and deployers

### DIFF
--- a/integration/deploy_test.go
+++ b/integration/deploy_test.go
@@ -19,6 +19,7 @@ package integration
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -188,6 +189,64 @@ func TestDeployWithoutWorkspaces(t *testing.T) {
 	// Run Deploy using the build output
 	// See https://github.com/GoogleContainerTools/skaffold/issues/2372 on why status-check=false
 	skaffold.Deploy("--build-artifacts", buildOutputFile, "--status-check=false").InDir(tmpDir.Root()).InNs(ns.Name).RunOrFail(t)
+}
+
+func TestDeployDependenciesOrder(t *testing.T) {
+	MarkIntegrationTest(t, CanRunWithoutGcp)
+
+	tests := []struct {
+		description         string
+		dir                 string
+		moduleToDeploy      string
+		expectedDeployOrder []string
+	}{
+		{
+			description: "Deploy order of entire project",
+			dir:         "testdata/multi-config-dependencies-order",
+			expectedDeployOrder: []string{
+				"module4",
+				"module3",
+				"module2",
+				"module1",
+			},
+		},
+		{
+			description:    "Deploy order for just one part of the project",
+			dir:            "testdata/multi-config-dependencies-order",
+			moduleToDeploy: "module2",
+			expectedDeployOrder: []string{
+				"module4",
+				"module3",
+				"module2",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+
+			targetModule := []string{}
+			if test.moduleToDeploy != "" {
+				targetModule = []string{"--module", test.moduleToDeploy}
+			}
+
+			expectedFormatedDeployOrder := []string{}
+			for _, module := range test.expectedDeployOrder {
+				expectedFormatedDeployOrder = append(expectedFormatedDeployOrder, fmt.Sprintf(" - pod/%v created", module))
+			}
+			expectedFormatedDeployOrder = append([]string{"Starting deploy..."}, expectedFormatedDeployOrder...)
+			expectedFormatedDeployOrder = append(expectedFormatedDeployOrder, "Waiting for deployments to stabilize...")
+			expectedOutput := strings.Join(expectedFormatedDeployOrder, "\n")
+
+			ns, _ := SetupNamespace(t)
+			outputBytes := skaffold.Run(targetModule...).InDir(test.dir).InNs(ns.Name).RunOrFailOutput(t)
+			defer skaffold.Delete().InDir(test.dir).InNs(ns.Name).RunOrFail(t)
+
+			output := string(outputBytes)
+			testutil.CheckContains(t, expectedOutput, output)
+		})
+	}
+
 }
 
 // Copies a file or directory tree.  There are 2x3 cases:

--- a/integration/deploy_test.go
+++ b/integration/deploy_test.go
@@ -224,7 +224,6 @@ func TestDeployDependenciesOrder(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-
 			targetModule := []string{}
 			if test.moduleToDeploy != "" {
 				targetModule = []string{"--module", test.moduleToDeploy}
@@ -246,7 +245,6 @@ func TestDeployDependenciesOrder(t *testing.T) {
 			testutil.CheckContains(t, expectedOutput, output)
 		})
 	}
-
 }
 
 // Copies a file or directory tree.  There are 2x3 cases:

--- a/integration/testdata/multi-config-dependencies-order/module1/Dockerfile
+++ b/integration/testdata/multi-config-dependencies-order/module1/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.18 as builder
+WORKDIR /code
+COPY main.go .
+# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
+ARG SKAFFOLD_GO_GCFLAGS
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app main.go
+
+FROM alpine:3
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
+CMD ["./app"]
+COPY --from=builder /app .

--- a/integration/testdata/multi-config-dependencies-order/module1/k8s/k8s-pod.yaml
+++ b/integration/testdata/multi-config-dependencies-order/module1/k8s/k8s-pod.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: module1
+spec:
+  containers:
+  - name: module1
+    image: multi-config-module1

--- a/integration/testdata/multi-config-dependencies-order/module1/main.go
+++ b/integration/testdata/multi-config-dependencies-order/module1/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+	"time"
+)
+
+func main() {
+	for {
+		fmt.Printf("Hello module-1! Running on %s/%s\n", runtime.GOOS, runtime.GOARCH)
+
+		time.Sleep(time.Second * 1)
+	}
+}

--- a/integration/testdata/multi-config-dependencies-order/module1/skaffold.yaml
+++ b/integration/testdata/multi-config-dependencies-order/module1/skaffold.yaml
@@ -1,0 +1,15 @@
+apiVersion: skaffold/v3
+kind: Config
+metadata:
+  name: module1
+build:
+  artifacts:
+  - image: multi-config-module1
+    context: .
+manifests:
+  rawYaml:
+  - k8s/k8s-pod.yaml
+deploy:
+  kubectl: {}
+requires:
+  - path: ../module2

--- a/integration/testdata/multi-config-dependencies-order/module2/Dockerfile
+++ b/integration/testdata/multi-config-dependencies-order/module2/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.18 as builder
+WORKDIR /code
+COPY main.go .
+# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
+ARG SKAFFOLD_GO_GCFLAGS
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app main.go
+
+FROM alpine:3
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
+CMD ["./app"]
+COPY --from=builder /app .

--- a/integration/testdata/multi-config-dependencies-order/module2/k8s/k8s-pod.yaml
+++ b/integration/testdata/multi-config-dependencies-order/module2/k8s/k8s-pod.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: module2
+spec:
+  containers:
+  - name: module2
+    image: multi-config-module2

--- a/integration/testdata/multi-config-dependencies-order/module2/main.go
+++ b/integration/testdata/multi-config-dependencies-order/module2/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+	"time"
+)
+
+func main() {
+	for {
+		fmt.Printf("Hello module-2! Running on %s/%s\n", runtime.GOOS, runtime.GOARCH)
+
+		time.Sleep(time.Second * 1)
+	}
+}

--- a/integration/testdata/multi-config-dependencies-order/module2/skaffold.yaml
+++ b/integration/testdata/multi-config-dependencies-order/module2/skaffold.yaml
@@ -1,0 +1,15 @@
+apiVersion: skaffold/v3
+kind: Config
+metadata:
+  name: module2
+build:
+  artifacts:
+  - image: multi-config-module2
+    context: .
+manifests:
+  rawYaml:
+  - k8s/k8s-pod.yaml
+deploy:
+  kubectl: {}
+requires:
+  - path: ../module3

--- a/integration/testdata/multi-config-dependencies-order/module3/Dockerfile
+++ b/integration/testdata/multi-config-dependencies-order/module3/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.18 as builder
+WORKDIR /code
+COPY main.go .
+# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
+ARG SKAFFOLD_GO_GCFLAGS
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app main.go
+
+FROM alpine:3
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
+CMD ["./app"]
+COPY --from=builder /app .

--- a/integration/testdata/multi-config-dependencies-order/module3/k8s/k8s-pod.yaml
+++ b/integration/testdata/multi-config-dependencies-order/module3/k8s/k8s-pod.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: module3
+spec:
+  containers:
+  - name: module1
+    image: multi-config-module3

--- a/integration/testdata/multi-config-dependencies-order/module3/main.go
+++ b/integration/testdata/multi-config-dependencies-order/module3/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+	"time"
+)
+
+func main() {
+	for {
+		fmt.Printf("Hello module-3! Running on %s/%s\n", runtime.GOOS, runtime.GOARCH)
+
+		time.Sleep(time.Second * 1)
+	}
+}

--- a/integration/testdata/multi-config-dependencies-order/module3/skaffold.yaml
+++ b/integration/testdata/multi-config-dependencies-order/module3/skaffold.yaml
@@ -1,0 +1,15 @@
+apiVersion: skaffold/v3
+kind: Config
+metadata:
+  name: module3
+build:
+  artifacts:
+  - image: multi-config-module3
+    context: .
+manifests:
+  rawYaml:
+  - k8s/k8s-pod.yaml
+deploy:
+  kubectl: {}
+requires:
+  - path: ../module4

--- a/integration/testdata/multi-config-dependencies-order/module4/Dockerfile
+++ b/integration/testdata/multi-config-dependencies-order/module4/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.18 as builder
+WORKDIR /code
+COPY main.go .
+# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
+ARG SKAFFOLD_GO_GCFLAGS
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app main.go
+
+FROM alpine:3
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
+CMD ["./app"]
+COPY --from=builder /app .

--- a/integration/testdata/multi-config-dependencies-order/module4/k8s/k8s-pod.yaml
+++ b/integration/testdata/multi-config-dependencies-order/module4/k8s/k8s-pod.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: module4
+spec:
+  containers:
+  - name: module4
+    image: multi-config-module4

--- a/integration/testdata/multi-config-dependencies-order/module4/main.go
+++ b/integration/testdata/multi-config-dependencies-order/module4/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+	"time"
+)
+
+func main() {
+	for {
+		fmt.Printf("Hello module-4! Running on %s/%s\n", runtime.GOOS, runtime.GOARCH)
+
+		time.Sleep(time.Second * 1)
+	}
+}

--- a/integration/testdata/multi-config-dependencies-order/module4/skaffold.yaml
+++ b/integration/testdata/multi-config-dependencies-order/module4/skaffold.yaml
@@ -1,0 +1,13 @@
+apiVersion: skaffold/v3
+kind: Config
+metadata:
+  name: module4
+build:
+  artifacts:
+  - image: multi-config-module4
+    context: .
+manifests:
+  rawYaml:
+  - k8s/k8s-pod.yaml
+deploy:
+  kubectl: {}

--- a/integration/testdata/multi-config-dependencies-order/skaffold.yaml
+++ b/integration/testdata/multi-config-dependencies-order/skaffold.yaml
@@ -1,0 +1,4 @@
+apiVersion: skaffold/v3
+kind: Config
+requires:
+  - path: ./module1

--- a/pkg/skaffold/deploy/helm/helm_test.go
+++ b/pkg/skaffold/deploy/helm/helm_test.go
@@ -1426,6 +1426,7 @@ func (c *helmConfig) ForceDeploy() bool                                   { retu
 func (c *helmConfig) GetKubeConfig() string                               { return kubectl.TestKubeConfig }
 func (c *helmConfig) GetKubeContext() string                              { return kubectl.TestKubeContext }
 func (c *helmConfig) GetKubeNamespace() string                            { return c.namespace }
+func (c *helmConfig) GetNamespace() string                                { return c.namespace }
 func (c *helmConfig) ConfigurationFile() string                           { return c.configFile }
 func (c *helmConfig) PortForwardResources() []*latest.PortForwardResource { return nil }
 

--- a/pkg/skaffold/deploy/kubectl/kubectl_test.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl_test.go
@@ -231,7 +231,7 @@ func TestKubectlV1RenderDeploy(t *testing.T) {
 						configName: {
 							Render: rc,
 						},
-					}),
+					}, []string{configName}),
 				},
 			}
 
@@ -326,7 +326,7 @@ func TestKubectlCleanup(t *testing.T) {
 						configName: {
 							Render: rc,
 						},
-					}),
+					}, []string{configName}),
 				},
 			}
 
@@ -531,7 +531,7 @@ func TestGCSManifests(t *testing.T) {
 						configName: {
 							Render: latest.RenderConfig{Generate: test.generate},
 						},
-					}),
+					}, []string{configName}),
 				},
 			}
 			r, err := kubectlR.New(mockCfg, rc, map[string]string{}, configName, "")

--- a/pkg/skaffold/runner/deployer.go
+++ b/pkg/skaffold/runner/deployer.go
@@ -120,7 +120,8 @@ func GetDeployer(ctx context.Context, runCtx *runcontext.RunContext, labeller *l
 	var deployers []deploy.Deployer
 	localDeploy := false
 	remoteDeploy := false
-	for configName, pl := range pipelines.AllByConfigNames() {
+	for _, configName := range pipelines.AllOrderedConfigNames() {
+		pl := pipelines.GetForConfigName(configName)
 		d := pl.Deploy
 		r := pl.Render
 		dCtx := &deployerCtx{runCtx, d}

--- a/pkg/skaffold/runner/renderer_test.go
+++ b/pkg/skaffold/runner/renderer_test.go
@@ -32,7 +32,7 @@ func TestGetRenderer(tOuter *testing.T) {
 		Pipelines: runcontext.NewPipelines(
 			map[string]latest.Pipeline{
 				"default": {},
-			})}
+			}, []string{"default"})}
 	labels := map[string]string{}
 	kubectlCfg := latest.RenderConfig{
 		Generate: latest.Generate{
@@ -148,7 +148,7 @@ func TestGetRenderer(tOuter *testing.T) {
 						map[string]latest.Pipeline{
 							"default": test.cfg,
 						},
-					),
+						[]string{"default"}),
 				}, "", map[string]string{}, false)
 
 				t.CheckError(test.shouldErr, err)

--- a/pkg/skaffold/runner/runner_test.go
+++ b/pkg/skaffold/runner/runner_test.go
@@ -314,7 +314,7 @@ func createRunner(t *testutil.T, testBench *TestBench, monitor filemon.Monitor, 
 			map[string]latest.Pipeline{
 				"default": cfg.Pipeline,
 			},
-		),
+			[]string{"default"}),
 		Opts: config.SkaffoldOptions{
 			Trigger:           "polling",
 			WatchPollInterval: 100,
@@ -549,7 +549,7 @@ func TestNewForConfig(t *testing.T) {
 					map[string]latest.Pipeline{
 						"default": tt.pipeline,
 					},
-				),
+					[]string{"default"}),
 				Opts: config.SkaffoldOptions{
 					Trigger: "polling",
 				},
@@ -660,7 +660,7 @@ func TestTriggerCallbackAndIntents(t *testing.T) {
 					map[string]latest.Pipeline{
 						"default": pipeline,
 					},
-				),
+					[]string{"default"}),
 				WorkingDir: tmpDir.Root(),
 			})
 

--- a/pkg/skaffold/schema/validation/validation_test.go
+++ b/pkg/skaffold/schema/validation/validation_test.go
@@ -768,7 +768,7 @@ func TestValidateNetworkModeDockerContainerExists(t *testing.T) {
 							},
 						},
 					},
-				),
+					[]string{"default"}),
 			})
 
 			t.CheckError(test.shouldErr, err)
@@ -1826,7 +1826,7 @@ func TestValidateCloudRunLocation(t *testing.T) {
 							Deploy: test.deploy,
 						},
 					},
-				),
+					[]string{"default"}),
 				Opts: config.SkaffoldOptions{
 					CloudRunProject:  test.cloudRunProject,
 					CloudRunLocation: test.cloudRunLocation,


### PR DESCRIPTION
Fixes: #7993

**Description**
This PR fixes the order in which every deployer and renderer should be created and invoked according to the dependencies created between different modules. So, if `module1` depends on/requires `module2`, skaffold should deploy first `module2` and then `module1`

Also, we now mock the `GetNamespace` from [deploy/helm/helm_test.go](https://github.com/GoogleContainerTools/skaffold/pull/8028/files#diff-00324bab5a92b65d9af9c88f4eb9db3aa71cad52423ca109a0b0b0ac2026ff70) to not depend on kubectl output to get the namespace.

**How to test**
From the code example created in this [commit](https://github.com/duongcongtoaimanabie/skaffold/commit/bfa0e231713ed042c253bb8838561ef8edd83611), run `skaffold dev`and you should be able to see the modules deployed in the proper dependency order all the time:

```
Starting deploy...
deploying for sk4
 - pod/getting-started created
deploying for sk3
 - pod/getting-started unchanged
deploying for sk2
 - pod/getting-started unchanged
deploying for sk1
 - pod/getting-started unchanged
```