### PR TITLE
fix: cleanup not called when using helm deployer alone

### DIFF
--- a/cmd/skaffold/app/cmd/dev.go
+++ b/cmd/skaffold/app/cmd/dev.go
@@ -71,11 +71,9 @@ func runDev(ctx context.Context, out io.Writer) error {
 				err := r.Dev(ctx, out, artifacts)
 				manifestListByConfig := r.DeployManifests()
 
-				if manifestListByConfig.String() != "" {
-					cleanup = func() {
-						if err := r.Cleanup(context.Background(), out, false, manifestListByConfig); err != nil {
-							log.Entry(ctx).Warn("deployer cleanup:", err)
-						}
+				cleanup = func() {
+					if err := r.Cleanup(context.Background(), out, false, manifestListByConfig); err != nil {
+						log.Entry(ctx).Warn("deployer cleanup:", err)
 					}
 				}
 

--- a/cmd/skaffold/app/cmd/dev_test.go
+++ b/cmd/skaffold/app/cmd/dev_test.go
@@ -83,16 +83,16 @@ func TestDoDev(t *testing.T) {
 			expectedCalls:     []string{"Dev", "DeployManifests", "HasBuilt", "Cleanup", "Prune"},
 		},
 		{
-			description:       "hasn't deployed",
+			description:       "cleanup always gets called even without deployments",
 			hasBuilt:          true,
 			deployedManifests: manifest.ManifestList{},
-			expectedCalls:     []string{"Dev", "DeployManifests", "HasBuilt", "Prune"},
+			expectedCalls:     []string{"Dev", "DeployManifests", "HasBuilt", "Cleanup", "Prune"},
 		},
 		{
 			description:       "hasn't built",
 			hasBuilt:          false,
 			deployedManifests: manifest.ManifestList{},
-			expectedCalls:     []string{"Dev", "DeployManifests", "HasBuilt"},
+			expectedCalls:     []string{"Dev", "DeployManifests", "HasBuilt", "Cleanup"},
 		},
 	}
 

--- a/examples/helm-render/Dockerfile
+++ b/examples/helm-render/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.18 as builder
+WORKDIR /code
+COPY main.go .
+COPY go.mod .
+# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
+ARG SKAFFOLD_GO_GCFLAGS
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app main.go
+
+FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
+CMD ["./app"]
+COPY --from=builder /app .

--- a/examples/helm-render/README.md
+++ b/examples/helm-render/README.md
@@ -1,0 +1,39 @@
+### Example: deploy multiple releases with Helm
+
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/helm-deployment)
+
+You can deploy multiple releases with skaffold, each will need a chartPath, a values file, and namespace.
+Skaffold can inject intermediate build tags in the the values map in the skaffold.yaml.
+
+Let's walk through the skaffold yaml:
+
+We'll be building an image called `skaffold-helm`, and it's a dockerfile, so we'll add it to the artifacts.
+
+```yaml
+build:
+  artifacts:
+  - image: skaffold-helm
+```
+
+Now, we want to deploy this image with helm.
+We add a new release in the helm part of the deploy stanza.
+
+```yaml
+deploy:
+  helm:
+    releases:
+    - name: skaffold-helm
+      chartPath: charts
+      # namespace: skaffold
+      setValues:
+        image: skaffold-helm
+      valuesFiles:
+      - values.yaml
+```
+
+This part tells Skaffold to set the `image` parameter of the values file to the built `skaffold-helm` image and tag.
+
+```yaml
+      setValues:
+        image: skaffold-helm
+```

--- a/examples/helm-render/charts/Chart.yaml
+++ b/examples/helm-render/charts/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: Skaffold example with Helm
+name: skaffold-helm
+version: 0.1.0

--- a/examples/helm-render/charts/templates/deployment.yaml
+++ b/examples/helm-render/charts/templates/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    app: {{ .Chart.Name }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Chart.Name }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: {{ .Values.image }}

--- a/examples/helm-render/charts/values.yaml
+++ b/examples/helm-render/charts/values.yaml
@@ -1,0 +1,5 @@
+# Default values for skaffold-helm.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 2
+image: skaffold-helm:latest

--- a/examples/helm-render/go.mod
+++ b/examples/helm-render/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/examples/helm-deployment
+
+go 1.18

--- a/examples/helm-render/main.go
+++ b/examples/helm-render/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+	for counter := 0; ; counter++ {
+		fmt.Println("Hello world!", counter)
+
+		time.Sleep(time.Second * 1)
+	}
+}

--- a/examples/helm-render/skaffold.yaml
+++ b/examples/helm-render/skaffold.yaml
@@ -1,9 +1,9 @@
-apiVersion: skaffold/v3
+apiVersion: skaffold/v4beta1
 kind: Config
 build:
   artifacts:
   - image: skaffold-helm
-deploy:
+manifests:
   helm:
     releases:
     - name: skaffold-helm

--- a/examples/helm-render/skaffold.yaml
+++ b/examples/helm-render/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta1
+apiVersion: skaffold/v3
 kind: Config
 build:
   artifacts:

--- a/integration/examples/helm-deployment/skaffold.yaml
+++ b/integration/examples/helm-deployment/skaffold.yaml
@@ -3,7 +3,7 @@ kind: Config
 build:
   artifacts:
   - image: skaffold-helm
-manifests:
+deploy:
   helm:
     releases:
     - name: skaffold-helm

--- a/integration/examples/helm-render/Dockerfile
+++ b/integration/examples/helm-render/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.18 as builder
+WORKDIR /code
+COPY main.go .
+COPY go.mod .
+# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
+ARG SKAFFOLD_GO_GCFLAGS
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app main.go
+
+FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
+CMD ["./app"]
+COPY --from=builder /app .

--- a/integration/examples/helm-render/README.md
+++ b/integration/examples/helm-render/README.md
@@ -1,0 +1,39 @@
+### Example: deploy multiple releases with Helm
+
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/helm-deployment)
+
+You can deploy multiple releases with skaffold, each will need a chartPath, a values file, and namespace.
+Skaffold can inject intermediate build tags in the the values map in the skaffold.yaml.
+
+Let's walk through the skaffold yaml:
+
+We'll be building an image called `skaffold-helm`, and it's a dockerfile, so we'll add it to the artifacts.
+
+```yaml
+build:
+  artifacts:
+  - image: skaffold-helm
+```
+
+Now, we want to deploy this image with helm.
+We add a new release in the helm part of the deploy stanza.
+
+```yaml
+deploy:
+  helm:
+    releases:
+    - name: skaffold-helm
+      chartPath: charts
+      # namespace: skaffold
+      setValues:
+        image: skaffold-helm
+      valuesFiles:
+      - values.yaml
+```
+
+This part tells Skaffold to set the `image` parameter of the values file to the built `skaffold-helm` image and tag.
+
+```yaml
+      setValues:
+        image: skaffold-helm
+```

--- a/integration/examples/helm-render/charts/Chart.yaml
+++ b/integration/examples/helm-render/charts/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: Skaffold example with Helm
+name: skaffold-helm
+version: 0.1.0

--- a/integration/examples/helm-render/charts/templates/deployment.yaml
+++ b/integration/examples/helm-render/charts/templates/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    app: {{ .Chart.Name }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Chart.Name }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: {{ .Values.image }}

--- a/integration/examples/helm-render/charts/values.yaml
+++ b/integration/examples/helm-render/charts/values.yaml
@@ -1,0 +1,5 @@
+# Default values for skaffold-helm.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 2
+image: skaffold-helm:latest

--- a/integration/examples/helm-render/go.mod
+++ b/integration/examples/helm-render/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/examples/helm-deployment
+
+go 1.18

--- a/integration/examples/helm-render/main.go
+++ b/integration/examples/helm-render/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+	for counter := 0; ; counter++ {
+		fmt.Println("Hello world!", counter)
+
+		time.Sleep(time.Second * 1)
+	}
+}

--- a/integration/examples/helm-render/skaffold.yaml
+++ b/integration/examples/helm-render/skaffold.yaml
@@ -1,9 +1,9 @@
-apiVersion: skaffold/v3
+apiVersion: skaffold/v4beta1
 kind: Config
 build:
   artifacts:
   - image: skaffold-helm
-deploy:
+manifests:
   helm:
     releases:
     - name: skaffold-helm


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #8033  <!-- tracking issues that this PR will close -->
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
 -  deployment can happen without user specifies manifest then `deployedManifests` will be empty, so in this pr,  change dev command to always call cleanup.


