### PR TITLE
fix: log duplication when using dependencies

### DIFF
--- a/integration/util.go
+++ b/integration/util.go
@@ -430,6 +430,7 @@ func WaitForLogs(t *testing.T, out io.Reader, firstMessage string, moreMessages 
 		case <-timer.C:
 			t.Fatal("timeout")
 		case line := <-lines:
+			t.Logf("Expecting %s, received %s \n", message, line)
 			if strings.Contains(line, message) {
 				if current >= len(moreMessages) {
 					return

--- a/pkg/skaffold/deploy/cloudrun/deploy.go
+++ b/pkg/skaffold/deploy/cloudrun/deploy.go
@@ -127,7 +127,7 @@ func (d *Deployer) GetSyncer() sync.Syncer {
 }
 
 // TrackBuildArtifacts is not supported by this deployer.
-func (d *Deployer) TrackBuildArtifacts([]graph.Artifact) {
+func (d *Deployer) TrackBuildArtifacts(_, _ []graph.Artifact) {
 
 }
 

--- a/pkg/skaffold/deploy/deploy.go
+++ b/pkg/skaffold/deploy/deploy.go
@@ -56,7 +56,7 @@ type Deployer interface {
 	GetSyncer() sync.Syncer
 
 	// TrackBuildArtifacts registers build artifacts to be tracked by a Deployer
-	TrackBuildArtifacts([]graph.Artifact)
+	TrackBuildArtifacts(builds, deployedImages []graph.Artifact)
 
 	// RegisterLocalImages tracks all local images to be loaded by the Deployer
 	RegisterLocalImages([]graph.Artifact)

--- a/pkg/skaffold/deploy/deploy_mux.go
+++ b/pkg/skaffold/deploy/deploy_mux.go
@@ -185,4 +185,4 @@ func (m DeployerMux) Cleanup(ctx context.Context, w io.Writer, dryRun bool, mani
 }
 
 // TrackBuildArtifacts should *only* be called on individual deployers. This is a noop.
-func (m DeployerMux) TrackBuildArtifacts(_ []graph.Artifact) {}
+func (m DeployerMux) TrackBuildArtifacts(_, _ []graph.Artifact) {}

--- a/pkg/skaffold/deploy/deploy_mux_test.go
+++ b/pkg/skaffold/deploy/deploy_mux_test.go
@@ -83,7 +83,7 @@ func (m *MockDeployer) GetSyncer() sync.Syncer {
 
 func (m *MockDeployer) RegisterLocalImages(_ []graph.Artifact) {}
 
-func (m *MockDeployer) TrackBuildArtifacts(_ []graph.Artifact) {}
+func (m *MockDeployer) TrackBuildArtifacts(_, _ []graph.Artifact) {}
 
 func (m *MockDeployer) Dependencies() ([]string, error) {
 	return m.dependencies, m.dependenciesErr

--- a/pkg/skaffold/deploy/docker/deploy.go
+++ b/pkg/skaffold/deploy/docker/deploy.go
@@ -106,8 +106,8 @@ func NewDeployer(ctx context.Context, cfg dockerutil.Config, labeller *label.Def
 	}, nil
 }
 
-func (d *Deployer) TrackBuildArtifacts(artifacts []graph.Artifact) {
-	d.logger.RegisterArtifacts(artifacts)
+func (d *Deployer) TrackBuildArtifacts(builds, _ []graph.Artifact) {
+	d.logger.RegisterArtifacts(builds)
 }
 
 // TrackContainerFromBuild adds an artifact and its newly-associated container
@@ -133,7 +133,7 @@ func (d *Deployer) Deploy(ctx context.Context, out io.Writer, builds []graph.Art
 			return err
 		}
 	}
-	d.TrackBuildArtifacts(builds)
+	d.TrackBuildArtifacts(builds, nil)
 
 	return nil
 }

--- a/pkg/skaffold/deploy/helm/helm.go
+++ b/pkg/skaffold/deploy/helm/helm.go
@@ -218,9 +218,9 @@ func (h *Deployer) RegisterLocalImages(images []graph.Artifact) {
 	h.localImages = images
 }
 
-func (h *Deployer) TrackBuildArtifacts(artifacts []graph.Artifact) {
-	deployutil.AddTagsToPodSelector(artifacts, h.podSelector)
-	h.logger.RegisterArtifacts(artifacts)
+func (h *Deployer) TrackBuildArtifacts(builds, deployedImages []graph.Artifact) {
+	deployutil.AddTagsToPodSelector(builds, deployedImages, h.podSelector)
+	h.logger.RegisterArtifacts(builds)
 }
 
 // Deploy deploys the build results to the Kubernetes cluster
@@ -290,8 +290,9 @@ func (h *Deployer) Deploy(ctx context.Context, out io.Writer, builds []graph.Art
 	for ns := range nsMap {
 		namespaces = append(namespaces, ns)
 	}
+	deployedImages, _ := manifests.GetImages(manifest.NewResourceSelectorImages(manifest.TransformAllowlist, manifest.TransformDenylist))
 
-	h.TrackBuildArtifacts(builds)
+	h.TrackBuildArtifacts(builds, deployedImages)
 	h.trackNamespaces(namespaces)
 	return nil
 }

--- a/pkg/skaffold/deploy/kpt/kpt.go
+++ b/pkg/skaffold/deploy/kpt/kpt.go
@@ -165,9 +165,9 @@ func (k *Deployer) GetSyncer() sync.Syncer {
 }
 
 // TrackBuildArtifacts registers build artifacts to be tracked by a Deployer
-func (k *Deployer) TrackBuildArtifacts(artifacts []graph.Artifact) {
-	deployutil.AddTagsToPodSelector(artifacts, k.podSelector)
-	k.logger.RegisterArtifacts(artifacts)
+func (k *Deployer) TrackBuildArtifacts(builds, deployedImages []graph.Artifact) {
+	deployutil.AddTagsToPodSelector(builds, deployedImages, k.podSelector)
+	k.logger.RegisterArtifacts(builds)
 }
 
 func (k *Deployer) RegisterLocalImages(images []graph.Artifact) {
@@ -350,7 +350,7 @@ func (k *Deployer) Deploy(ctx context.Context, out io.Writer, builds []graph.Art
 		endTrace(instrumentation.TraceEndError(err))
 		return liveApplyErr(err, k.applyDir)
 	}
-	k.TrackBuildArtifacts(builds)
+	k.TrackBuildArtifacts(builds, builds)
 	k.trackNamespaces(namespaces)
 	endTrace()
 	return nil

--- a/pkg/skaffold/deploy/util/util.go
+++ b/pkg/skaffold/deploy/util/util.go
@@ -66,10 +66,28 @@ func ApplyDefaultRepo(globalConfig string, defaultRepo *string, tag string) (str
 	return newTag, nil
 }
 
-// Update which images are logged.
-func AddTagsToPodSelector(artifacts []graph.Artifact, podSelector *kubernetes.ImageList) {
-	for _, artifact := range artifacts {
-		podSelector.Add(artifact.Tag)
+// Update which images are logged, if the image is present in the provided deployer's artifacts.
+func AddTagsToPodSelector(runnerBuilds []graph.Artifact, deployerArtifacts []graph.Artifact, podSelector *kubernetes.ImageList) {
+	// This implementation is mostly picked from v1 for fixing log duplication issue when multiple deployers are used.
+	// According to the original author "Each Deployer will be directly responsible for adding its deployed artifacts to the PodSelector
+	// by cross-referencing them against the list of images parsed out of the set of manifests they each deploy". Each deploy should only
+	// add its own deployed artifacts to the PodSelector to avoid duplicate logging when multi-deployers are used.
+	// This implementation only streams logs for the intersection of runnerBuilds and deployerArtifacts images, not all images from a deployer
+	// probably because at that time the team didn't want to stream logs from images not built by Skaffold, e.g. images from docker hub, but this
+	// may change. The initial implementation was using imageName as map key for getting shared elements, this was ok as deployerArtifacts were
+	// parsed out from skaffold config files in v1 and tag was not available if not specified. Now deployers don't own render responsibilities
+	// anymore, instead callers pass rendered manifests to deployers, we can only parse artifacts from these rendered manifests. The imageName
+	// from deployerArtifacts here has the default-repo value as prefix while the one from runnerBuilds doesn't. This discrepancy causes artifact.Tag
+	// fail to add into podSelector, which leads to podWatchers fail to get events from pods. As tags are available in deployerArtifacts now, so using
+	// tag as map key to get the shared elements.
+	m := map[string]bool{}
+	for _, a := range deployerArtifacts {
+		m[a.Tag] = true
+	}
+	for _, artifact := range runnerBuilds {
+		if _, ok := m[artifact.Tag]; ok {
+			podSelector.Add(artifact.Tag)
+		}
 	}
 }
 

--- a/pkg/skaffold/deploy/util/util_test.go
+++ b/pkg/skaffold/deploy/util/util_test.go
@@ -153,6 +153,7 @@ func TestAddTagsToPodSelector(t *testing.T) {
 			deployerArtifacts: []graph.Artifact{
 				{
 					ImageName: "not-my-image",
+					Tag:       "not-my-image:tag",
 				},
 			},
 		},
@@ -175,9 +176,11 @@ func TestAddTagsToPodSelector(t *testing.T) {
 			deployerArtifacts: []graph.Artifact{
 				{
 					ImageName: "my-image1",
+					Tag:       "registry.example.com/repo/my-image1:tag1",
 				},
 				{
 					ImageName: "my-image2",
+					Tag:       "registry.example.com/repo/my-image2:tag2",
 				},
 			},
 			expectedImages: []string{
@@ -186,28 +189,28 @@ func TestAddTagsToPodSelector(t *testing.T) {
 			},
 		},
 		{
-			description: "images from manifest files with ko:// scheme prefix are sanitized before matching",
+			description: "images from deployerManifests with default-repo",
 			artifacts: []graph.Artifact{
 				{
-					ImageName: "ko://git.example.com/Foo/bar",
-					Tag:       "registry.example.com/repo/git.example.com/foo/bar:tag",
+					ImageName: "bar",
+					Tag:       "registry.example.com/bar:tag",
 				},
 			},
 			deployerArtifacts: []graph.Artifact{
 				{
-					ImageName: "git.example.com/foo/bar",
-					Tag:       "ko://git.example.com/Foo/bar",
+					ImageName: "registry.example.com/bar",
+					Tag:       "registry.example.com/bar:tag",
 				},
 			},
 			expectedImages: []string{
-				"registry.example.com/repo/git.example.com/foo/bar:tag",
+				"registry.example.com/bar:tag",
 			},
 		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			podSelector := kubernetes.NewImageList()
-			AddTagsToPodSelector(test.artifacts, podSelector)
+			AddTagsToPodSelector(test.artifacts, test.deployerArtifacts, podSelector)
 			for _, expectedImage := range test.expectedImages {
 				if exists := podSelector.Select(&v1.Pod{
 					Spec: v1.PodSpec{

--- a/pkg/skaffold/runner/runner_test.go
+++ b/pkg/skaffold/runner/runner_test.go
@@ -134,8 +134,8 @@ func (t *TestBench) GetSyncer() sync.Syncer {
 	return t
 }
 
-func (t *TestBench) RegisterLocalImages(_ []graph.Artifact) {}
-func (t *TestBench) TrackBuildArtifacts(_ []graph.Artifact) {}
+func (t *TestBench) RegisterLocalImages(_ []graph.Artifact)    {}
+func (t *TestBench) TrackBuildArtifacts(_, _ []graph.Artifact) {}
 
 func (t *TestBench) TestDependencies(context.Context, *latest.Artifact) ([]string, error) {
 	return nil, nil


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #8023  <!-- tracking issues that this PR will close -->
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
 - The cause was that each deployer was adding all builds to podSelectors, the logger of a deployer will stream log from all pods deployed with runner built artifacts.
 - Ideally, each deployer should only stream from pods that it deploys artifacts to. 
 - The workable implementation in v1 only added shared artifacts between deployerArtifacts set and runner builds artifacts set to podSelector for streaming logs, port-forwarding, etc. With artifact image name as identifier for an artifact to filter common elements, but due to the difference between v1 and v2 we cannot use imageName as the key for the map to filter those, the reason was added in the comment, let me know if you have any concern for using artifact.tag as key to filter. Alternatively, we can just track deployed artifacts regardless they're built from runner or not. This should fix log duplication issue, but it will also stream logs for remote artifacts. 

**Manual Testing** 
 - use this project [ examples/multi-config-microservices](https://github.com/GoogleContainerTools/skaffold/tree/main/examples/multi-config-microservices)
 - run skaffold dev 
 - expect to one log from each pod
![Screen Shot 2022-11-07 at 10 16 01 AM](https://user-images.githubusercontent.com/102683393/200345957-3f5ce020-f0c0-4b06-8bc6-ddf16a26ad45.png)
 - without this pr, the log would be like below.

![Screen Shot 2022-11-07 at 10 17 16 AM](https://user-images.githubusercontent.com/102683393/200346237-c905d76a-af3e-40f7-9acd-7de343023bb0.png)




**Follow-up Work (remove if N/A)**
<!-- Mention any related follow up work to this PR. -->


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
