### PR TITLE
chore(doc): note that filesync works for debug

### DIFF
--- a/docs-v2/data/maturity.json
+++ b/docs-v2/data/maturity.json
@@ -355,6 +355,7 @@
   },
   "sync.infer": {
     "dev": "x",
+    "debug": "x",
     "area": "Filesync",
     "feature": "sync.infer",
     "maturity": "GA",
@@ -362,6 +363,7 @@
   },
   "sync": {
     "dev": "x",
+    "debug": "x",
     "area": "Filesync",
     "maturity": "GA",
     "description": "Instead of rebuilding, copy the changed files in the running container",

--- a/docs/data/maturity.json
+++ b/docs/data/maturity.json
@@ -431,6 +431,7 @@
   },
   "sync.infer": {
     "dev": "x",
+    "debug": "x",
     "area": "Filesync",
     "feature": "sync.infer",
     "maturity": "beta",
@@ -438,6 +439,7 @@
   },
   "sync": {
     "dev": "x",
+    "debug": "x",
     "area": "Filesync",
     "maturity": "GA",
     "description": "Instead of rebuilding, copy the changed files in the running container",


### PR DESCRIPTION
**Description**
File sync does work with `debug`, but is disabled by default.

We should document some of the limitations of `sync` since some users assume that it magically rebuilds their applications.  Some context in https://chat.google.com/room/AAAAuTCR_1s/srcFk70Ok_A