### PR TITLE
fix: correct issues with current upgrade logic for artifactOverrides with helm imageStrategy

### DIFF
--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -279,7 +279,7 @@ func TestRunTailTolerateFailuresUntilDeadline(t *testing.T) {
 
 			args := append(test.args, "--tail")
 			out := skaffold.Run(args...).InDir(test.dir).InNs(ns.Name).WithEnv(test.env).RunLive(t)
-			defer skaffold.Delete().InDir(test.dir).WithEnv(test.env).RunOrFail(t)
+			defer skaffold.Delete().InDir(test.dir).InNs(ns.Name).WithEnv(test.env).Run(t)
 			WaitForLogs(t, out, test.targetLogOne)
 			WaitForLogs(t, out, test.targetLogTwo)
 		})

--- a/integration/testdata/helm-multi-config/Makefile
+++ b/integration/testdata/helm-multi-config/Makefile
@@ -1,0 +1,22 @@
+build:
+	cd skaffold; \
+	DOCKER_HOST="unix:///Users/$$(whoami)/.docker/run/docker.sock" \
+	skaffold build \
+		--verbosity info \
+		--default-repo docker.io/bringes
+
+dev:
+	cd skaffold; \
+	DOCKER_HOST="unix:///Users/$$(whoami)/.docker/run/docker.sock" \
+	skaffold dev \
+		--verbosity info \
+		--default-repo docker.io/bringes \
+		--kubeconfig ../kubeconfig.yml
+
+render:
+	cd skaffold; \
+	DOCKER_HOST="unix:///Users/$$(whoami)/.docker/run/docker.sock" \
+	skaffold render \
+		--verbosity info \
+		--default-repo docker.io/bringes \
+        -vdebug

--- a/integration/testdata/helm-multi-config/app1/Dockerfile
+++ b/integration/testdata/helm-multi-config/app1/Dockerfile
@@ -1,0 +1,2 @@
+FROM alpine
+ENTRYPOINT echo "app1" && tail -f /dev/null

--- a/integration/testdata/helm-multi-config/app2/Dockerfile
+++ b/integration/testdata/helm-multi-config/app2/Dockerfile
@@ -1,0 +1,2 @@
+FROM alpine
+ENTRYPOINT echo "app2" && tail -f /dev/null

--- a/integration/testdata/helm-multi-config/charts/app/.helmignore
+++ b/integration/testdata/helm-multi-config/charts/app/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/integration/testdata/helm-multi-config/charts/app/Chart.yaml
+++ b/integration/testdata/helm-multi-config/charts/app/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: app
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/integration/testdata/helm-multi-config/charts/app/templates/NOTES.txt
+++ b/integration/testdata/helm-multi-config/charts/app/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "app.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "app.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "app.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "app.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/integration/testdata/helm-multi-config/charts/app/templates/_helpers.tpl
+++ b/integration/testdata/helm-multi-config/charts/app/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "app.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "app.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "app.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "app.labels" -}}
+helm.sh/chart: {{ include "app.chart" . }}
+{{ include "app.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "app.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "app.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "app.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/integration/testdata/helm-multi-config/charts/app/templates/deployment.yaml
+++ b/integration/testdata/helm-multi-config/charts/app/templates/deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "app.fullname" . }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "app.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "app.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/integration/testdata/helm-multi-config/charts/app/values.yaml
+++ b/integration/testdata/helm-multi-config/charts/app/values.yaml
@@ -1,0 +1,82 @@
+# Default values for app.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: dev-registry.internal.io/app
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/integration/testdata/helm-multi-config/skaffold/app1/skaffold.yml
+++ b/integration/testdata/helm-multi-config/skaffold/app1/skaffold.yml
@@ -1,0 +1,19 @@
+apiVersion: skaffold/v3
+kind: Config
+build:
+  artifacts:
+    - context: ../../app1/
+      image: app1
+  tagPolicy:
+    inputDigest: {}
+deploy:
+  helm: {}
+manifests:
+  helm:
+    releases:
+      - chartPath: ../../charts/app
+        createNamespace: true
+        name: app1
+        setValues:
+          image.repository: app1
+          image.tag: app1

--- a/integration/testdata/helm-multi-config/skaffold/app2/skaffold.yml
+++ b/integration/testdata/helm-multi-config/skaffold/app2/skaffold.yml
@@ -1,0 +1,19 @@
+apiVersion: skaffold/v3
+kind: Config
+build:
+  artifacts:
+    - context: ../../app2/
+      image: app2
+  tagPolicy:
+    inputDigest: {}
+deploy:
+  helm: {}
+manifests:
+  helm:
+    releases:
+      - chartPath: ../../charts/app
+        createNamespace: true
+        name: app2
+        setValues:
+          image.repository: app2
+          image.tag: app2

--- a/integration/testdata/helm-multi-config/skaffold/skaffold.yml
+++ b/integration/testdata/helm-multi-config/skaffold/skaffold.yml
@@ -1,0 +1,5 @@
+apiVersion: skaffold/v3
+kind: Config
+requires:
+  - path: ./app1/skaffold.yml
+  - path: ./app2/skaffold.yml

--- a/pkg/skaffold/kubernetes/manifest/images.go
+++ b/pkg/skaffold/kubernetes/manifest/images.go
@@ -19,6 +19,7 @@ package manifest
 import (
 	"context"
 	"strconv"
+	"strings"
 
 	apimachinery "k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -197,9 +198,39 @@ func (r *imageReplacer) Visit(gk apimachinery.GroupKind, navpath string, o map[s
 
 	parsed, err := docker.ParseReference(image)
 	if err != nil {
-		log.Entry(context.TODO()).Debugf("Couldn't parse image [%s]: %s", image, err.Error())
-		return false
+		// this is a hack to properly support `imageStrategy=helm` & `imageStrategy=helm+explicitRegistry` from Skaffold v1.X.X
+		// which have the form:
+		// helm - image: "{{.Values.image.repository}}:{{.Values.image.tag}}"
+		// helm+explicitRegistry - image: "{{.Values.image.registry}}/{{.Values.image.repository}}:{{.Values.image.tag}}"
+		// when the artifact name has a fully qualified path - gcr.io/example-repo/skaffold-helm-image
+		// works by looking for intermediate helm replacement of the form image:
+		// helm - image: <artifactName>/<artifactName>:<artifactName>
+		// helm+explicitRegistry - image: <artifactName>:<artifactName>
+		// and treating that as just <artifact> by modifying the parsed representation.
+		tagSplit := strings.Split(image, ":")
+		if len(tagSplit) == 2 && strings.HasPrefix(image, tagSplit[1]) {
+			if _, present := r.tagsByImageName[tagSplit[1]]; present {
+				parsed = &docker.ImageReference{
+					BaseName: tagSplit[1],
+				}
+			}
+		} else {
+			log.Entry(context.TODO()).Debugf("Couldn't parse image [%s]: %s", image, err.Error())
+			return false
+		}
 	}
+	// this is a hack to properly support `imageStrategy=helm+explicitRegistry` from Skaffold v1.X.X which has the form:
+	// image: "{{.Values.image.registry}}/{{.Values.image.repository}}:{{.Values.image.tag}}"
+	// when the artifact name is not fully qualified - skaffold-helm-image
+	// works by looking for intermediate helm replacement of the form image:
+	// image: <artifactName>/<artifactName>:<artifactName>
+	// and treating that as just <artifact> by modifying the parsed representation.
+	if parsed.Domain != "" && parsed.Domain == parsed.Repo {
+		if _, present := r.tagsByImageName[parsed.Repo]; present {
+			parsed.BaseName = parsed.Repo
+		}
+	}
+
 	if imageName, tag, selected := r.selector(r.tagsByImageName, parsed); selected {
 		r.found[imageName] = true
 		o[k] = tag

--- a/pkg/skaffold/schema/v2beta29/upgrade.go
+++ b/pkg/skaffold/schema/v2beta29/upgrade.go
@@ -118,20 +118,11 @@ func upgradeOnePipeline(oldPipeline, newPipeline interface{}) error {
 			if oldPL.Deploy.HelmDeploy.Releases[i].ImageStrategy.HelmConventionConfig != nil {
 				// is 'helm' imageStrategy
 				for k, v := range aos {
-					if k == "image" {
-						if svts == nil {
-							svts = map[string]string{}
-						}
-						svts["image.tag"] = "{{.IMAGE_TAG}}@{{.IMAGE_DIGEST}}"
-						svts["image.repository"] = "{{.IMAGE_REPO}}"
-						if oldPL.Deploy.HelmDeploy.Releases[i].ImageStrategy.HelmConventionConfig.ExplicitRegistry {
-							// is 'helm' imageStrategy + explicitRegistry
-							svts["image.registry"] = "{{.IMAGE_DOMAIN}}"
-							svts["image.repository"] = "{{.IMAGE_REPO_NO_DOMAIN}}"
-						}
-						continue
+					svs[k+".repository"] = v
+					svs[k+".tag"] = v
+					if oldPL.Deploy.HelmDeploy.Releases[i].ImageStrategy.HelmConventionConfig.ExplicitRegistry {
+						svs[k+".registry"] = v
 					}
-					svs[k] = v
 				}
 			} else {
 				// is 'fqn' imageStrategy


### PR DESCRIPTION
Initially artifactsOverrides and imageStrategy were removed in skaffold v2 as we now use skaffold as a helm --post-renderer.  In our upgrade.go for v2beta29 we had some logic added that would migrate people that used those fields to setValues and setValueTemplates.  The upgrade.go logic here though did not work properly for multi-config projects as setValueTemplates has unfriendly behaviour when used with multi-config images as noted in https://github.com/GoogleContainerTools/skaffold/issues/5317.  As such this new PR changes upgrade.go to use all setValueTemplates replacements and adds a helm multi-config example as an integration test.  This docs PR below might help to explain this a bit as well:
https://github.com/GoogleContainerTools/skaffold/pull/8093
