### PR TITLE
chore: reduce gcp integration test time

### DIFF
--- a/integration/apply_test.go
+++ b/integration/apply_test.go
@@ -35,7 +35,7 @@ func TestDiagnoseRenderApply(t *testing.T) {
 		MarkIntegrationTest(t.T, NeedsGcp)
 		ns, client := SetupNamespace(t.T)
 
-		out := skaffold.Diagnose("--yaml-only").InDir("examples/multi-config-microservices").RunOrFailOutput(t.T)
+		out := skaffold.Diagnose("--yaml-only").InDir("testdata/multi-config-pods").RunOrFailOutput(t.T)
 
 		tmpDir := testutil.NewTempDir(t.T)
 		tmpDir.Chdir()
@@ -47,11 +47,10 @@ func TestDiagnoseRenderApply(t *testing.T) {
 
 		skaffold.Apply("render.yaml", "-f", "skaffold-diagnose.yaml").InNs(ns.Name).RunOrFail(t.T)
 
-		depApp := client.GetDeployment("leeroy-app")
-		t.CheckNotNil(depApp)
-
-		depWeb := client.GetDeployment("leeroy-web")
-		t.CheckNotNil(depWeb)
+		pod1 := client.GetPod("module1")
+		t.CheckNotNil(pod1)
+		pod2 := client.GetPod("module2")
+		t.CheckNotNil(pod2)
 	})
 }
 
@@ -91,10 +90,13 @@ func TestApplyStatusCheckFailure(t *testing.T) {
 			description: "status check for statefulset resources",
 			profile:     "statefulset",
 		},
-		{
-			description: "status check for config connector resources",
-			profile:     "configconnector",
-		},
+		//{
+		// config connector resource status doesn't distinguish between resource that is making progress towards reconciling from one that is doomed.
+		// This is tracked in b/187759279 internally. The test currently passes due to status check timeout, it's not what we want to test, hence
+		// commenting this out at the moment.
+		// description: "status check for config connector resources",
+		// profile:     "configconnector",
+		// },
 		{
 			description: "status check for standalone pods",
 			profile:     "pod",

--- a/integration/build_test.go
+++ b/integration/build_test.go
@@ -153,8 +153,6 @@ func TestBuildWithWithPlatform(t *testing.T) {
 }
 
 func TestBuildWithMultiPlatforms(t *testing.T) {
-	MarkIntegrationTest(t, NeedsGcp)
-
 	tests := []struct {
 		description       string
 		dir               string
@@ -172,6 +170,7 @@ func TestBuildWithMultiPlatforms(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
+			MarkIntegrationTest(t, NeedsGcp)
 			tmpfile := testutil.TempFile(t, "", []byte{})
 			args := append(test.args, "--file-output", tmpfile)
 			skaffold.Build(args...).InDir(test.dir).RunOrFail(t)
@@ -186,7 +185,6 @@ func TestBuildWithMultiPlatforms(t *testing.T) {
 
 // TestExpectedBuildFailures verifies that `skaffold build` fails in expected ways
 func TestExpectedBuildFailures(t *testing.T) {
-	MarkIntegrationTest(t, NeedsGcp)
 	if !jib.JVMFound(context.Background()) {
 		t.Fatal("test requires Java VM")
 	}
@@ -207,6 +205,7 @@ func TestExpectedBuildFailures(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
+			MarkIntegrationTest(t, NeedsGcp)
 			if out, err := skaffold.Build(test.args...).InDir(test.dir).RunWithCombinedOutput(t); err == nil {
 				t.Fatal("expected build to fail")
 			} else if !strings.Contains(string(out), test.expected) {

--- a/integration/deploy_cloudrun_test.go
+++ b/integration/deploy_cloudrun_test.go
@@ -29,7 +29,6 @@ import (
 
 func TestDeployCloudRun(t *testing.T) {
 	MarkIntegrationTest(t, NeedsGcp)
-
 	// Other integration tests run with the --default-repo option.
 	// This one explicitly specifies the full image name.
 	skaffold.Deploy().InDir("testdata/deploy-cloudrun").RunOrFail(t)

--- a/integration/multiplatform_test.go
+++ b/integration/multiplatform_test.go
@@ -38,7 +38,6 @@ const (
 )
 
 func TestMultiPlatformWithRun(t *testing.T) {
-	MarkIntegrationTest(t, NeedsGcp)
 	isRunningInHybridCluster := os.Getenv("GKE_CLUSTER_NAME") == hybridClusterName
 	type image struct {
 		name string
@@ -73,6 +72,7 @@ func TestMultiPlatformWithRun(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
+			MarkIntegrationTest(t, NeedsGcp)
 			platforms := platformsCliValue(test.expectedPlatforms)
 			ns, client := SetupNamespace(t)
 			tag := fmt.Sprintf("%s-%s", test.tag, uuid.New().String())
@@ -95,7 +95,6 @@ func TestMultiPlatformWithRun(t *testing.T) {
 }
 
 func TestMultiplatformWithDevAndDebug(t *testing.T) {
-	MarkIntegrationTest(t, NeedsGcp)
 	const platformsExpectedInNodeAffinity = 1
 	const platformsExpectedInCreatedImage = 1
 	isRunningInHybridCluster := os.Getenv("GKE_CLUSTER_NAME") == hybridClusterName
@@ -155,6 +154,7 @@ func TestMultiplatformWithDevAndDebug(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
+			MarkIntegrationTest(t, NeedsGcp)
 			platforms := platformsCliValue(test.expectedPlatforms)
 			tag := fmt.Sprintf("%s-%s", test.tag, uuid.New().String())
 			ns, client := SetupNamespace(t)
@@ -193,7 +193,6 @@ func TestMultiplatformWithDevAndDebug(t *testing.T) {
 }
 
 func TestMultiplatformWithDeploy(t *testing.T) {
-	MarkIntegrationTest(t, NeedsGcp)
 	isRunningInHybridCluster := os.Getenv("GKE_CLUSTER_NAME") == hybridClusterName
 	type image struct {
 		name string
@@ -228,6 +227,7 @@ func TestMultiplatformWithDeploy(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
+			MarkIntegrationTest(t, NeedsGcp)
 			tmpfile := testutil.TempFile(t, "", []byte{})
 			tag := fmt.Sprintf("%s-%s", test.tag, uuid.New().String())
 			platforms := platformsCliValue(test.expectedPlatforms)

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -316,8 +316,6 @@ func TestRunRenderOnly(t *testing.T) {
 }
 
 func TestRunGCPOnly(t *testing.T) {
-	MarkIntegrationTest(t, NeedsGcp)
-
 	tests := []struct {
 		description string
 		dir         string
@@ -342,9 +340,9 @@ func TestRunGCPOnly(t *testing.T) {
 		},
 		{
 			description: "Google Cloud Build with source artifact dependencies",
-			dir:         "examples/microservices",
+			dir:         "testdata/multi-config-pods",
 			args:        []string{"-p", "gcb"},
-			deployments: []string{"leeroy-app", "leeroy-web"},
+			pods:        []string{"module1", "module2"},
 		},
 		// {
 		//	description: "Google Cloud Build with Kaniko",
@@ -395,6 +393,7 @@ func TestRunGCPOnly(t *testing.T) {
 			continue // buildpacks doesn't support arm64 builds, so skip run on these clusters
 		}
 		t.Run(test.description, func(t *testing.T) {
+			MarkIntegrationTest(t, NeedsGcp)
 			ns, client := SetupNamespace(t)
 
 			test.args = append(test.args, "--tag", uuid.New().String())

--- a/integration/testdata/multi-config-pods/skaffold.yaml
+++ b/integration/testdata/multi-config-pods/skaffold.yaml
@@ -3,3 +3,7 @@ kind: Config
 requires:
   - path: ./module1
   - path: ./module2
+profiles:
+  - name: gcb
+    build:
+      googleCloudBuild: {}

--- a/integration/util.go
+++ b/integration/util.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"os"
 	"os/exec"
@@ -35,7 +36,6 @@ import (
 	typedappsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
-	"github.com/GoogleContainerTools/skaffold/integration/binpack"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	kubernetesclient "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
@@ -67,11 +67,11 @@ func MarkIntegrationTest(t *testing.T, testType TestType) {
 		t.Skip("skipping non-GCP integration test")
 	}
 
-	if partition() && testType == CanRunWithoutGcp && !matchesPartition(t, t.Name(), binpack.Timings, binpack.MaxBinTime) {
+	if partition() && testType == CanRunWithoutGcp && !matchesPartition(t) {
 		t.Skipf("skipping non-GCP integration test that doesn't match partition %s", getPartition())
 	}
 
-	if partition() && testType == NeedsGcp && !matchesPartition(t, t.Name(), binpack.GCPTimings, binpack.MaxGCPBinTime) {
+	if partition() && testType == NeedsGcp && !matchesPartition(t) {
 		t.Skipf("Skipping GCP integration test that doesn't match partition %s", getPartition())
 	}
 }
@@ -84,16 +84,17 @@ func getPartition() string {
 	return os.Getenv("IT_PARTITION")
 }
 
-func matchesPartition(t *testing.T, testName string, timings []binpack.Timing, maxBinTime float64) bool {
-	var partition int
-	m, lastPartition := binpack.Partitions(timings, maxBinTime)
-	if p, ok := m[testName]; ok {
-		partition = p
-	} else {
-		partition = lastPartition
-	}
-	t.Logf("Test partition: %d", partition)
-	return strconv.Itoa(partition) == getPartition()
+func matchesPartition(t *testing.T) bool {
+	partition := hash(t.Name()) % 4
+	t.Logf("Assinged test %s to partition: %d", t.Name(), partition)
+
+	return strconv.FormatUint(partition, 10) == getPartition()
+}
+
+func hash(s string) uint64 {
+	h := fnv.New64a()
+	h.Write([]byte(s))
+	return h.Sum64()
 }
 
 func Run(t *testing.T, dir, command string, args ...string) {

--- a/integration/util.go
+++ b/integration/util.go
@@ -50,6 +50,7 @@ const (
 	CanRunWithoutGcp TestType = iota
 	NeedsGcp
 )
+const numberOfPartition = 4
 
 func MarkIntegrationTest(t *testing.T, testType TestType) {
 	t.Helper()
@@ -85,7 +86,7 @@ func getPartition() string {
 }
 
 func matchesPartition(t *testing.T) bool {
-	partition := hash(t.Name()) % 4
+	partition := hash(t.Name()) % numberOfPartition
 	t.Logf("Assinged test %s to partition: %d", t.Name(), partition)
 
 	return strconv.FormatUint(partition, 10) == getPartition()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #8091  <!-- tracking issues that this PR will close -->


**Description**
 - change partition strategy to be the hash value of a test case name module the number of partition, this makes test distribute more balanced, and it's easier to maintain
 - refactor tests need to build cross-platform/multi-platform images to use example/multi-pods project, as cross-platform build is very slow when running, ``go build ...``, we should make project source code as simple as possible when using cross-platform/multi-platform builds.
 - comment out TestApplyFailure -- Config resource connector, the reason is in the comment. 

**Result**
 - cutting testing time from 50 mins to 25 mins. 

**Follow up work**
 - None-gpc test partitioning is also based on hash value now, but it's based on a test suit not per test case, as the unbalancing issue is not that bad, we probably also want to partition test based on test case, but I'd like to do it in a separate pr.
 - Gpc ci machine image change, may also reduce the test environment setup time. 


 


