### PR TITLE
fix: override protocols argument pass to helm post-renderer

### DIFF
--- a/cmd/skaffold/app/cmd/filter.go
+++ b/cmd/skaffold/app/cmd/filter.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/flags"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/debugging"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
@@ -53,6 +54,7 @@ func NewCmdFilter() *cobra.Command {
 		WithFlags([]*Flag{
 			{Value: &renderFromBuildOutputFile, Name: "build-artifacts", Shorthand: "a", Usage: "File containing build result from a previous 'skaffold build --file-output'"},
 			{Value: &debuggingFilters, Name: "debugging", DefValue: false, Usage: `Apply debug transforms similar to "skaffold debug"`, IsEnum: true},
+			{Value: &debug.Protocols, Name: "protocols", DefValue: []string{}, Usage: "Priority sorted order of debugger protocols to support."},
 		}).
 		NoArgs(func(ctx context.Context, out io.Writer) error {
 			return doFilter(ctx, out, debuggingFilters, renderFromBuildOutputFile.BuildArtifacts())

--- a/pkg/skaffold/deploy/helm/helm.go
+++ b/pkg/skaffold/deploy/helm/helm.go
@@ -104,9 +104,10 @@ type Deployer struct {
 
 	labels map[string]string
 
-	forceDeploy   bool
-	enableDebug   bool
-	isMultiConfig bool
+	forceDeploy       bool
+	enableDebug       bool
+	overrideProtocols []string
+	isMultiConfig     bool
 	// bV is the helm binary version
 	bV semver.Version
 
@@ -114,12 +115,13 @@ type Deployer struct {
 	transformableDenylist  map[apimachinery.GroupKind]latest.ResourceFilter
 }
 
-func (h Deployer) EnableDebug() bool         { return h.enableDebug }
-func (h Deployer) ConfigFile() string        { return h.configFile }
-func (h Deployer) KubeContext() string       { return h.kubeContext }
-func (h Deployer) KubeConfig() string        { return h.kubeConfig }
-func (h Deployer) Labels() map[string]string { return h.labels }
-func (h Deployer) GlobalFlags() []string     { return h.LegacyHelmDeploy.Flags.Global }
+func (h Deployer) EnableDebug() bool           { return h.enableDebug }
+func (h Deployer) OverrideProtocols() []string { return h.overrideProtocols }
+func (h Deployer) ConfigFile() string          { return h.configFile }
+func (h Deployer) KubeContext() string         { return h.kubeContext }
+func (h Deployer) KubeConfig() string          { return h.kubeConfig }
+func (h Deployer) Labels() map[string]string   { return h.labels }
+func (h Deployer) GlobalFlags() []string       { return h.LegacyHelmDeploy.Flags.Global }
 
 type Config interface {
 	kubectl.Config
@@ -180,6 +182,7 @@ func NewDeployer(ctx context.Context, cfg Config, labeller *label.DefaultLabelle
 		labels:                 labeller.Labels(),
 		bV:                     hv,
 		enableDebug:            cfg.Mode() == config.RunModes.Debug,
+		overrideProtocols:      debug.Protocols,
 		isMultiConfig:          cfg.IsMultiConfig(),
 		transformableAllowlist: transformableAllowlist,
 		transformableDenylist:  transformableDenylist,

--- a/pkg/skaffold/helm/bin.go
+++ b/pkg/skaffold/helm/bin.go
@@ -44,6 +44,7 @@ var (
 
 type Client interface {
 	EnableDebug() bool
+	OverrideProtocols() []string
 	ConfigFile() string
 	KubeConfig() string
 	KubeContext() string
@@ -91,6 +92,9 @@ func generateSkaffoldFilter(h Client, buildsFile string) []string {
 	args := []string{"filter", "--kube-context", h.KubeContext()}
 	if h.EnableDebug() {
 		args = append(args, "--debugging")
+		for _, overrideProtocol := range h.OverrideProtocols() {
+			args = append(args, fmt.Sprintf("--protocols=%s", overrideProtocol))
+		}
 	}
 	for k, v := range h.Labels() {
 		args = append(args, fmt.Sprintf("--label=%s=%s", k, v))

--- a/pkg/skaffold/helm/bin_test.go
+++ b/pkg/skaffold/helm/bin_test.go
@@ -35,20 +35,22 @@ var (
 )
 
 type mockClient struct {
-	enableDebug bool
-	configFile  string
-	kubeContext string
-	kubeConfig  string
-	labels      map[string]string
-	globalFlags []string
+	enableDebug       bool
+	overrideProtocols []string
+	configFile        string
+	kubeContext       string
+	kubeConfig        string
+	labels            map[string]string
+	globalFlags       []string
 }
 
-func (h mockClient) EnableDebug() bool         { return h.enableDebug }
-func (h mockClient) ConfigFile() string        { return h.configFile }
-func (h mockClient) KubeContext() string       { return h.kubeContext }
-func (h mockClient) KubeConfig() string        { return h.kubeConfig }
-func (h mockClient) Labels() map[string]string { return h.labels }
-func (h mockClient) GlobalFlags() []string     { return h.globalFlags }
+func (h mockClient) EnableDebug() bool           { return h.enableDebug }
+func (h mockClient) OverrideProtocols() []string { return h.overrideProtocols }
+func (h mockClient) ConfigFile() string          { return h.configFile }
+func (h mockClient) KubeContext() string         { return h.kubeContext }
+func (h mockClient) KubeConfig() string          { return h.kubeConfig }
+func (h mockClient) Labels() map[string]string   { return h.labels }
+func (h mockClient) GlobalFlags() []string       { return h.globalFlags }
 
 func TestBinVer(t *testing.T) {
 	tests := []struct {

--- a/pkg/skaffold/render/renderer/helm/helm.go
+++ b/pkg/skaffold/render/renderer/helm/helm.go
@@ -25,6 +25,7 @@ import (
 	apimachinery "k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/helm"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
@@ -42,23 +43,25 @@ type Helm struct {
 	generate.Generator
 	config *latest.Helm
 
-	kubeContext string
-	kubeConfig  string
-	namespace   string
-	configFile  string
-	labels      map[string]string
-	enableDebug bool
+	kubeContext       string
+	kubeConfig        string
+	namespace         string
+	configFile        string
+	labels            map[string]string
+	enableDebug       bool
+	overrideProtocols []string
 
 	transformAllowlist map[apimachinery.GroupKind]latest.ResourceFilter
 	transformDenylist  map[apimachinery.GroupKind]latest.ResourceFilter
 }
 
-func (h Helm) EnableDebug() bool         { return h.enableDebug }
-func (h Helm) ConfigFile() string        { return h.configFile }
-func (h Helm) KubeContext() string       { return h.kubeContext }
-func (h Helm) KubeConfig() string        { return h.kubeConfig }
-func (h Helm) Labels() map[string]string { return h.labels }
-func (h Helm) GlobalFlags() []string     { return h.config.Flags.Global }
+func (h Helm) EnableDebug() bool           { return h.enableDebug }
+func (h Helm) OverrideProtocols() []string { return h.overrideProtocols }
+func (h Helm) ConfigFile() string          { return h.configFile }
+func (h Helm) KubeContext() string         { return h.kubeContext }
+func (h Helm) KubeConfig() string          { return h.kubeConfig }
+func (h Helm) Labels() map[string]string   { return h.labels }
+func (h Helm) GlobalFlags() []string       { return h.config.Flags.Global }
 
 func New(cfg render.Config, rCfg latest.RenderConfig, labels map[string]string, configName string) (Helm, error) {
 	generator := generate.NewGenerator(cfg.GetWorkingDir(), rCfg.Generate, "")
@@ -71,12 +74,13 @@ func New(cfg render.Config, rCfg latest.RenderConfig, labels map[string]string, 
 		Generator:  generator,
 		config:     rCfg.Helm,
 
-		enableDebug: cfg.Mode() == config.RunModes.Debug,
-		configFile:  cfg.ConfigurationFile(),
-		kubeContext: cfg.GetKubeContext(),
-		kubeConfig:  cfg.GetKubeConfig(),
-		labels:      labels,
-		namespace:   cfg.GetNamespace(),
+		enableDebug:       cfg.Mode() == config.RunModes.Debug,
+		overrideProtocols: debug.Protocols,
+		configFile:        cfg.ConfigurationFile(),
+		kubeContext:       cfg.GetKubeContext(),
+		kubeConfig:        cfg.GetKubeConfig(),
+		labels:            labels,
+		namespace:         cfg.GetNamespace(),
 
 		transformAllowlist: transformAllowlist,
 		transformDenylist:  transformDenylist,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #8045 
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
I add override protocols args on filter cmd use by helm post render.

<!-- Mention any related follow up work to this PR. -->


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
