### PR TITLE
fix: add unique tag to test image to avoid collisions with other tests

### DIFF
--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/GoogleContainerTools/skaffold/integration/skaffold"
@@ -395,6 +396,8 @@ func TestRunGCPOnly(t *testing.T) {
 		}
 		t.Run(test.description, func(t *testing.T) {
 			ns, client := SetupNamespace(t)
+
+			test.args = append(test.args, "--tag", uuid.New().String())
 
 			skaffold.Run(test.args...).InDir(test.dir).InNs(ns.Name).RunOrFail(t)
 


### PR DESCRIPTION
Fixes: #8025

**Description**
Add unique tag to test image to avoid collision with other tests running at the same time using the same image.