### PR TITLE
feat: completion for the Fish shell

### DIFF
--- a/cmd/skaffold/app/cmd/completion.go
+++ b/cmd/skaffold/app/cmd/completion.go
@@ -27,19 +27,21 @@ import (
 
 const (
 	longDescription = `
-	Outputs shell completion for the given shell (bash or zsh)
+	Outputs shell completion for the given shell (bash, fish or zsh)
 
 	This depends on the bash-completion binary.  Example installation instructions:
 	OS X:
 		$ brew install bash-completion
 		$ source $(brew --prefix)/etc/bash_completion
 		$ skaffold completion bash > ~/.skaffold-completion  # for bash users
+		$ skaffold completion fish > ~/.skaffold-completion  # for fish users
 		$ skaffold completion zsh > ~/.skaffold-completion   # for zsh users
 		$ source ~/.skaffold-completion
 	Ubuntu:
 		$ apt-get install bash-completion
 		$ source /etc/bash-completion
 		$ source <(skaffold completion bash) # for bash users
+		$ skaffold completion fish | source  # for fish users
 		$ source <(skaffold completion zsh)  # for zsh users
 
 	Additionally, you may want to output the completion to a file and source in your .bashrc
@@ -52,6 +54,8 @@ func completion(cmd *cobra.Command, args []string) {
 	switch args[0] {
 	case "bash":
 		rootCmd(cmd).GenBashCompletion(os.Stdout)
+	case "fish":
+		rootCmd(cmd).GenFishCompletion(os.Stdout, true)
 	case "zsh":
 		runCompletionZsh(cmd, os.Stdout)
 	}
@@ -67,8 +71,8 @@ func NewCmdCompletion() *cobra.Command {
 			}
 			return cobra.OnlyValidArgs(cmd, args)
 		},
-		ValidArgs: []string{"bash", "zsh"},
-		Short:     "Output shell completion for the given shell (bash or zsh)",
+		ValidArgs: []string{"bash", "fish", "zsh"},
+		Short:     "Output shell completion for the given shell (bash, fish or zsh)",
 		Long:      longDescription,
 		Run:       completion,
 	}

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -85,7 +85,7 @@ Getting Started With a New Project:
   init              Generate configuration for deploying an application
 
 Other Commands:
-  completion        Output shell completion for the given shell (bash or zsh)
+  completion        Output shell completion for the given shell (bash, fish or zsh)
   config            Interact with the global Skaffold config file (defaults to `$HOME/.skaffold/config`)
   diagnose          Run a diagnostic on Skaffold
   fix               Update old configuration to a newer schema version
@@ -280,7 +280,7 @@ Env vars:
 
 ### skaffold completion
 
-Output shell completion for the given shell (bash or zsh)
+Output shell completion for the given shell (bash, fish or zsh)
 
 ```
 


### PR DESCRIPTION
**Description**
This patch enables Skaffold to generate completion for the Fish shell.

**User-facing changes (remove if N/A)**
Currently, there's no out-of-the-box completion for the Fish shell, so it needs to be generated manually.

With these changes, the completion looks like the following:
```
→ ~ skaffold <TAB>
apply                                                  (Apply hydrated manifests to a cluster)
build                                                                    (Build the artifacts)
completion                   (Output shell completion for the given shell (bash, fish or zsh))
config  (Interact with the global Skaffold config file (defaults to `$HOME/.skaffold/config`))
debug                                                           (Run a pipeline in debug mode)
delete                                             (Delete any resources deployed by Skaffold)
deploy                                                            (Deploy pre-built artifacts)
dev                                                       (Run a pipeline in development mode)
diagnose                                                        (Run a diagnostic on Skaffold)
fix                                       (Update old configuration to a newer schema version)
help                                                                  (Help about any command)
init                                     (Generate configuration for deploying an application)
options
render                                                (Generate rendered Kubernetes manifests)
run                                                                           (Run a pipeline)
schema                        (List JSON schemas used to validate skaffold.yaml configuration)
survey                                   (Opens a web browser to fill out the Skaffold survey)
test                                         (Run tests against your built application images)
verify                                   (Run verification tests against skaffold deployments)
version                                                        (Print the version information)
```