### PR TITLE
docs: add link to Cloud Run YAML reference in deployer doc

### DIFF
--- a/docs-v2/content/en/docs/pipeline-stages/deployers/cloudrun.md
+++ b/docs-v2/content/en/docs/pipeline-stages/deployers/cloudrun.md
@@ -15,6 +15,7 @@ Cloud Run is a managed compute platform on Google Cloud that allows you to run c
 ## Deploying applications to Cloud Run
 
 Skaffold can deploy services to Cloud Run. If this deployer is used, all provided manifests must be valid Cloud Run services, using the serving.knative.dev/v1 schema.
+See the [Cloud Run YAML reference](https://cloud.google.com/run/docs/reference/yaml/v1) for supported fields.
 
 This deployer will use the [application default credentials](https://cloud.google.com/docs/authentication/production#automatically) to deploy.  You can configure this to use your user credentials by running `gcloud auth application-default login`.
 


### PR DESCRIPTION

**Description**
Add a direct link to the Cloud Run YAML reference in the Cloud Run deployer docs.