### PR TITLE
fix: new condition to create hydrate-dir only if a kpt renderer or deployer

### DIFF
--- a/.github/workflows/integration-linux.yml
+++ b/.github/workflows/integration-linux.yml
@@ -19,6 +19,7 @@ jobs:
         kustomize_version: [3.5.4]
         ko_version: [0.4.0]
         kompose_version: [1.21.0]
+        kpt_version: [1.0.0-beta.13]
         gcloud_sdk_version: [410.0.0]
         container_structure_tests_version: [1.8.0]
         integration_test_partitions: [0, 1, 2, 3]
@@ -77,6 +78,13 @@ jobs:
       run: |
         wget -O kompose https://github.com/kubernetes/kompose/releases/download/v${{ matrix.kompose_version }}/kompose-linux-amd64 && chmod +x kompose
         sudo mv kompose /usr/local/bin/
+
+    - name: Install Kpt
+      if: ${{ env.NON_DOCS_FILES_CHANGED != 0 }}
+      run: |
+        wget -O kpt https://github.com/GoogleContainerTools/kpt/releases/download/v{{ matrix.kpt_version }}/kpt_linux_amd64 && chmod +x kpt
+        sudo mv kpt /usr/local/bin/
+
 
     - name: Install GCloud
       if: ${{ env.NON_DOCS_FILES_CHANGED != 0 }}

--- a/.github/workflows/integration-linux.yml
+++ b/.github/workflows/integration-linux.yml
@@ -82,9 +82,8 @@ jobs:
     - name: Install Kpt
       if: ${{ env.NON_DOCS_FILES_CHANGED != 0 }}
       run: |
-        wget -O kpt https://github.com/GoogleContainerTools/kpt/releases/download/v{{ matrix.kpt_version }}/kpt_linux_amd64 && chmod +x kpt
+        wget -O kpt https://github.com/GoogleContainerTools/kpt/releases/download/v${{ matrix.kpt_version }}/kpt_linux_amd64 && chmod +x kpt
         sudo mv kpt /usr/local/bin/
-
 
     - name: Install GCloud
       if: ${{ env.NON_DOCS_FILES_CHANGED != 0 }}

--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -708,8 +708,6 @@ spec:
 }
 
 func TestRenderHydrationDirCreation(t *testing.T) {
-	MarkIntegrationTest(t, CanRunWithoutGcp)
-
 	const hydrationDir = "hydration-dir"
 
 	tests := []struct {
@@ -818,6 +816,8 @@ spec:
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
+			MarkIntegrationTest(t.T, NeedsGcp)
+
 			tmpDir := t.NewTempDir()
 			tmpDir.Write("skaffold.yaml", test.config)
 			tmpDir.Write("k8s-pod.yaml", test.manifest)

--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"regexp"
 	"testing"
 
@@ -702,6 +703,137 @@ spec:
 
 			t.RequireNoError(err)
 			t.CheckDeepEqual(test.expectedOut, string(fileContentReplaced))
+		})
+	}
+}
+
+func TestRenderHydrationDirCreation(t *testing.T) {
+	MarkIntegrationTest(t, CanRunWithoutGcp)
+
+	const hydrationDir = "hydration-dir"
+
+	tests := []struct {
+		description              string
+		shouldCreateHydrationDir bool
+		config                   string
+		manifest                 string
+	}{
+		{
+			description:              "project with kpt renderer should create hydration dir",
+			shouldCreateHydrationDir: true,
+			config: `
+apiVersion: skaffold/v4beta1
+kind: Config
+
+build:
+  artifacts: []
+manifests:
+  kpt: []
+`,
+			manifest: `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: getting-started
+spec:
+  containers:
+    - name: getting-started
+      image: skaffold-example`,
+		},
+		{
+			description:              "project with kpt deployer should create hydration dir",
+			shouldCreateHydrationDir: true,
+			config: `
+apiVersion: skaffold/v4beta1
+kind: Config
+
+build:
+  artifacts: []
+manifests:
+  kpt: []
+deploy:
+  kpt: {}
+`,
+			manifest: `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: getting-started
+spec:
+  containers:
+    - name: getting-started
+      image: skaffold-example`,
+		},
+		{
+			description:              "project with rawYaml and transform should create hydration dir (uses kpt renderer)",
+			shouldCreateHydrationDir: true,
+			config: `
+apiVersion: skaffold/v4beta1
+kind: Config
+
+build:
+  artifacts: []
+manifests:
+  rawYaml:
+    - k8s-pod.yaml
+  transform:
+    - name: set-annotations
+      configMap:
+        - "author:fake-author"
+`,
+			manifest: `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: getting-started
+spec:
+  containers:
+    - name: getting-started
+      image: skaffold-example`,
+		},
+		{
+			description:              "project without kpt should not create hydration dir",
+			shouldCreateHydrationDir: false,
+			config: `
+apiVersion: skaffold/v4beta1
+kind: Config
+
+build:
+  artifacts: []
+manifests:
+  rawYaml:
+    - k8s-pod.yaml
+`,
+			manifest: `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: getting-started
+spec:
+  containers:
+  - name: getting-started
+    image: skaffold-example`,
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			tmpDir := t.NewTempDir()
+			tmpDir.Write("skaffold.yaml", test.config)
+			tmpDir.Write("k8s-pod.yaml", test.manifest)
+			tmpDir.Chdir()
+
+			args := []string{"--hydration-dir", hydrationDir}
+
+			skaffold.Render(args...).RunOrFail(t.T)
+
+			_, err := os.Stat(filepath.Join(tmpDir.Root(), hydrationDir))
+
+			if test.shouldCreateHydrationDir {
+				t.CheckFalse(os.IsNotExist(err))
+			} else {
+				t.CheckTrue(os.IsNotExist(err))
+			}
 		})
 	}
 }

--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -708,6 +708,7 @@ spec:
 }
 
 func TestRenderHydrationDirCreation(t *testing.T) {
+	MarkIntegrationTest(t, CanRunWithoutGcp)
 	const hydrationDir = "hydration-dir"
 
 	tests := []struct {
@@ -773,7 +774,7 @@ build:
   artifacts: []
 manifests:
   rawYaml:
-    - k8s-pod.yaml
+    - k8s/k8s-pod.yaml
   transform:
     - name: set-annotations
       configMap:
@@ -800,7 +801,7 @@ build:
   artifacts: []
 manifests:
   rawYaml:
-    - k8s-pod.yaml
+    - k8s/k8s-pod.yaml
 `,
 			manifest: `
 apiVersion: v1
@@ -816,11 +817,10 @@ spec:
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			MarkIntegrationTest(t.T, NeedsGcp)
-
 			tmpDir := t.NewTempDir()
+			tmpDir.Mkdir("k8s")
 			tmpDir.Write("skaffold.yaml", test.config)
-			tmpDir.Write("k8s-pod.yaml", test.manifest)
+			tmpDir.Write("k8s/k8s-pod.yaml", test.manifest)
 			tmpDir.Chdir()
 
 			args := []string{"--hydration-dir", hydrationDir}

--- a/pkg/skaffold/deploy/util/util_test.go
+++ b/pkg/skaffold/deploy/util/util_test.go
@@ -112,7 +112,7 @@ func TestGetHydrationDir_Default(t *testing.T) {
 		tmpDir.Chdir()
 		actual, err := GetHydrationDir(
 			config.SkaffoldOptions{HydrationDir: constants.DefaultHydrationDir, AssumeYes: true},
-			tmpDir.Root(), false)
+			tmpDir.Root(), false, true)
 		t.CheckNoError(err)
 		t.CheckDeepEqual(filepath.Join(tmpDir.Root(), ".kpt-pipeline"), actual)
 	})
@@ -124,7 +124,7 @@ func TestGetHydrationDir_CustomHydrationDir(t *testing.T) {
 		tmpDir.Chdir()
 		expected := filepath.Join(tmpDir.Root(), "test-hydration")
 		actual, err := GetHydrationDir(
-			config.SkaffoldOptions{HydrationDir: expected, AssumeYes: true}, "", false)
+			config.SkaffoldOptions{HydrationDir: expected, AssumeYes: true}, "", false, true)
 		t.CheckNoError(err)
 		t.CheckDeepEqual(expected, actual)
 		_, err = os.Stat(actual)


### PR DESCRIPTION
Fixes: #8041

**Description**
This PR adds an extra condition before creating the `hydration-dir`, so it is created only when kpt is used (as renderer, deployer, or both).