### PR TITLE
fix: always add namespaces in generated manifests regardless of offline=[true|false]

### DIFF
--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -459,11 +459,11 @@ spec:
   - image: gcr.io/my/project-b
     name: b
 `},
-			// No `metadata.namespace` in offline mode
 			expectedOut: `apiVersion: v1
 kind: Pod
 metadata:
   name: my-pod-123
+  namespace: default
 spec:
   containers:
   - image: 12345.dkr.ecr.eu-central-1.amazonaws.com/my/project-a:4da6a56988057d23f68a4e988f4905dd930ea438-dirty@sha256:d8a33c260c50385ea54077bc7032dba0a860dc8870464f6795fd0aa548d117bf
@@ -502,11 +502,11 @@ spec:
   - image: gcr.io/my/project-b
     name: b
 `},
-			// No `metadata.namespace` in offline mode
 			expectedOut: `apiVersion: v1
 kind: Pod
 metadata:
   name: my-pod-123
+  namespace: default
 spec:
   containers:
   - image: 12345.dkr.ecr.eu-central-1.amazonaws.com/my/project-a:4da6a56988057d23f68a4e988f4905dd930ea438-dirty@sha256:d8a33c260c50385ea54077bc7032dba0a860dc8870464f6795fd0aa548d117bf
@@ -550,13 +550,13 @@ commonLabels:
 resources:
   - deployment.yaml
 `},
-			// No `metadata.namespace` in offline mode
 			expectedOut: `apiVersion: v1
 kind: Pod
 metadata:
   labels:
     this-is-from: kustomization.yaml
   name: my-pod-123
+  namespace: default
 spec:
   containers:
   - image: 12345.dkr.ecr.eu-central-1.amazonaws.com/my/project-a:4da6a56988057d23f68a4e988f4905dd930ea438-dirty@sha256:d8a33c260c50385ea54077bc7032dba0a860dc8870464f6795fd0aa548d117bf
@@ -600,13 +600,13 @@ commonLabels:
 resources:
   - deployment.yaml
 `},
-			// No `metadata.namespace` in offline mode
 			expectedOut: `apiVersion: v1
 kind: Pod
 metadata:
   labels:
     this-is-from: kustomization.yaml
   name: my-pod-123
+  namespace: default
 spec:
   containers:
   - image: 12345.dkr.ecr.eu-central-1.amazonaws.com/my/project-a:4da6a56988057d23f68a4e988f4905dd930ea438-dirty@sha256:d8a33c260c50385ea54077bc7032dba0a860dc8870464f6795fd0aa548d117bf

--- a/pkg/skaffold/deploy/kubectl/constants.go
+++ b/pkg/skaffold/deploy/kubectl/constants.go
@@ -26,6 +26,7 @@ const DeploymentWebYAML = `apiVersion: v1
 kind: Pod
 metadata:
   name: leeroy-web
+  namespace: default
 spec:
   containers:
   - name: leeroy-web
@@ -35,6 +36,7 @@ const DeploymentWebYAMLv1 = `apiVersion: v1
 kind: Pod
 metadata:
   name: leeroy-web
+  namespace: default
 spec:
   containers:
   - image: leeroy-web:v1
@@ -44,6 +46,7 @@ const DeploymentAppYAML = `apiVersion: v1
 kind: Pod
 metadata:
   name: leeroy-app
+  namespace: default
 spec:
   containers:
   - name: leeroy-app
@@ -53,6 +56,7 @@ const DeploymentAppYAMLv1 = `apiVersion: v1
 kind: Pod
 metadata:
   name: leeroy-app
+  namespace: default
 spec:
   containers:
   - image: leeroy-app:v1
@@ -62,6 +66,7 @@ const DeploymentAppYAMLv2 = `apiVersion: v1
 kind: Pod
 metadata:
   name: leeroy-app
+  namespace: default
 spec:
   containers:
   - image: leeroy-app:v2

--- a/pkg/skaffold/render/renderer/util/util.go
+++ b/pkg/skaffold/render/renderer/util/util.go
@@ -63,14 +63,12 @@ func GenerateHydratedManifests(ctx context.Context, out io.Writer, builds []grap
 	if manifests, err = manifests.SetLabels(labels, manifest.NewResourceSelectorLabels(opts.TransformAllowList, opts.TransformDenylist)); err != nil {
 		return nil, err
 	}
-	// TODO(tejaldesai) consult with cloud deploy team if namespaces can be set in offline mode
-	// in case namespace is set on the skaffold render cli command.
-	if !opts.Offline {
-		if manifests, err = manifests.SetNamespace(ns, rs); err != nil {
-			return nil, err
-		}
-		endTrace()
+
+	if manifests, err = manifests.SetNamespace(ns, rs); err != nil {
+		return nil, err
 	}
+	endTrace()
+
 	var platforms manifest.PodPlatforms
 
 	if opts.EnableGKEARMNodeToleration && isGKECluster(opts.KubeContext) {


### PR DESCRIPTION
fixes #8105 

The comment there:
```
consult with cloud deploy team if namespaces can be set in offline mode
	// in case namespace is set on the skaffold render cli command.
```

mentioned talking w/ Cloud Deploy team.  In a recent discussion w/ the Cloud Deploy team they have stated that the functionality they want here is that namespaces are modified in manifests during `skaffold render` for both offline=[true|false].  