### PR TITLE
chore: fix profile patch validation against original config

### DIFF
--- a/pkg/skaffold/schema/profiles.go
+++ b/pkg/skaffold/schema/profiles.go
@@ -275,7 +275,6 @@ func applyProfile(config *latest.SkaffoldConfig, fieldsOverrodeByProfile map[str
 		return err
 	}
 
-	var patches []yamlpatch.Operation
 	for i, patch := range profile.Patches {
 		// Default patch operation to `replace`
 		op := patch.Op
@@ -301,7 +300,6 @@ func applyProfile(config *latest.SkaffoldConfig, fieldsOverrodeByProfile map[str
 			return fmt.Errorf("invalid path: %s", patch.Path)
 		}
 
-		patches = append(patches, patch)
 		// TODO(aaron-prindle) we can ignore - op:'remove' - patch profiles as there is no corresponding schema object for them (it is removed already)
 		yamlOverrideInfo := configlocations.YAMLOverrideInfo{
 			ProfileName:    profile.Name,

--- a/pkg/skaffold/schema/profiles_test.go
+++ b/pkg/skaffold/schema/profiles_test.go
@@ -54,6 +54,14 @@ profiles:
       image: second
       docker:
         dockerfile: Dockerfile.second
+  - op: add
+    path: /build/artifacts/-
+    value:
+      image: third
+  - op: replace
+    path: /build/artifacts/2
+    value:
+      image: third-replaced
   - op: remove
     path: /manifests
 `
@@ -74,6 +82,7 @@ profiles:
 		t.CheckDeepEqual("replacement", skaffoldConfig.Build.Artifacts[0].ImageName)
 		t.CheckDeepEqual("Dockerfile.DEV", skaffoldConfig.Build.Artifacts[0].DockerArtifact.DockerfilePath)
 		t.CheckDeepEqual("Dockerfile.second", skaffoldConfig.Build.Artifacts[1].DockerArtifact.DockerfilePath)
+		t.CheckDeepEqual("third-replaced", skaffoldConfig.Build.Artifacts[2].ImageName)
 		t.CheckDeepEqual(latest.DeployConfig{}, skaffoldConfig.Deploy)
 	})
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #8121 <!-- tracking issues that this PR will close -->
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->

**User facing changes (remove if N/A)**
 
 - profile patch validation is now against an on-the-fly buffer from a previous patched operation instead of a fixed buffer
 - This enables user to use patched stanza for their following patches 
 - This is not breaking some stuff, it will also fail fast compared to the original implementation, as the original implementation will apply these patches one by one anyway, if applying patches would fail eventually, it's better to fail it when we just do try patch.
