### PR TITLE
Tests with multi taggers

### DIFF
--- a/integration/examples/cross-platform-builds/images.json
+++ b/integration/examples/cross-platform-builds/images.json
@@ -1,8 +1,0 @@
-{
-    "builds": [
-        {
-            "imageName": "skaffold-example",
-            "tag": "gcr.io/k8s-skaffold/skaffold-example:shatest-c204d64ce5da1bd03326d418e274a0d04f0ea486-dirty@sha256:179a7032916c6696fdaf486d274f04c76ec09cf166fcf904e6a1fba7b2bed4a4"
-        }
-    ]
-}

--- a/integration/examples/cross-platform-builds/images.json
+++ b/integration/examples/cross-platform-builds/images.json
@@ -1,0 +1,1 @@
+{"builds":[{"imageName":"skaffold-example","tag":"gcr.io/k8s-skaffold/skaffold-example:13cd8a388b272dbd25eaf97f208de4ba9f358cb57d63c0a82e846f9044600e82@sha256:c0588dd55cc2c3a8ecaae89b080d6a6c9b3277027947c5d9d6d88938a257f929"}]}

--- a/integration/examples/cross-platform-builds/images.json
+++ b/integration/examples/cross-platform-builds/images.json
@@ -1,1 +1,1 @@
-{"builds":[{"imageName":"skaffold-example","tag":"gcr.io/k8s-skaffold/skaffold-example:13cd8a388b272dbd25eaf97f208de4ba9f358cb57d63c0a82e846f9044600e82@sha256:c0588dd55cc2c3a8ecaae89b080d6a6c9b3277027947c5d9d6d88938a257f929"}]}
+{"builds":[{"imageName":"skaffold-example","tag":"skaffold-example:766a8c2475999031b0fce4eef62c50aa984f6aaf32e7c8a26d4734adc1cdd7ce"}]}

--- a/integration/examples/cross-platform-builds/images.json
+++ b/integration/examples/cross-platform-builds/images.json
@@ -1,1 +1,8 @@
-{"builds":[{"imageName":"skaffold-example","tag":"skaffold-example:766a8c2475999031b0fce4eef62c50aa984f6aaf32e7c8a26d4734adc1cdd7ce"}]}
+{
+    "builds": [
+        {
+            "imageName": "skaffold-example",
+            "tag": "gcr.io/k8s-skaffold/skaffold-example:shatest-c204d64ce5da1bd03326d418e274a0d04f0ea486-dirty@sha256:179a7032916c6696fdaf486d274f04c76ec09cf166fcf904e6a1fba7b2bed4a4"
+        }
+    ]
+}

--- a/integration/examples/cross-platform-builds/render.yaml
+++ b/integration/examples/cross-platform-builds/render.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: getting-started
+  namespace: default
+spec:
+  containers:
+  - image: gcr.io/k8s-skaffold/skaffold-example:13cd8a388b272dbd25eaf97f208de4ba9f358cb57d63c0a82e846f9044600e82
+    name: getting-started

--- a/integration/examples/cross-platform-builds/render.yaml
+++ b/integration/examples/cross-platform-builds/render.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: getting-started
-  namespace: default
-spec:
-  containers:
-  - image: gcr.io/k8s-skaffold/skaffold-example:13cd8a388b272dbd25eaf97f208de4ba9f358cb57d63c0a82e846f9044600e82
-    name: getting-started

--- a/integration/examples/cross-platform-builds/skaffold.yaml
+++ b/integration/examples/cross-platform-builds/skaffold.yaml
@@ -10,7 +10,7 @@ build:
   tagPolicy:
     - gitCommit:
         variant: CommitSha
-        prefix: "renzor-"
+        prefix: "shatest-"
     - inputDigest: {}
   local:
     concurrency: 1

--- a/integration/examples/cross-platform-builds/skaffold.yaml
+++ b/integration/examples/cross-platform-builds/skaffold.yaml
@@ -8,7 +8,10 @@ build:
       dockerfile: Dockerfile
       noCache: true
   tagPolicy:
-    gitCommit: {}
+    # - gitCommit:
+    #     variant: CommitSha
+    #     prefix: "renzor-"
+    - inputDigest: {}
   local:
     concurrency: 1
 manifests:

--- a/integration/examples/cross-platform-builds/skaffold.yaml
+++ b/integration/examples/cross-platform-builds/skaffold.yaml
@@ -2,16 +2,21 @@ apiVersion: skaffold/v4beta1
 kind: Config
 build:
   artifacts:
-  - image: skaffold-example
+  - image: skaffold-example-1
+    context: .
+    docker:
+      dockerfile: Dockerfile
+      noCache: true
+  - image: skaffold-example-2
     context: .
     docker:
       dockerfile: Dockerfile
       noCache: true
   tagPolicy:
-    - gitCommit:
-        variant: CommitSha
-        prefix: "shatest-"
-    - inputDigest: {}
+    - sha256: {}
+    - customTemplate:
+        template: "secondtag"
+
   local:
     concurrency: 1
 manifests:

--- a/integration/examples/cross-platform-builds/skaffold.yaml
+++ b/integration/examples/cross-platform-builds/skaffold.yaml
@@ -8,9 +8,9 @@ build:
       dockerfile: Dockerfile
       noCache: true
   tagPolicy:
-    # - gitCommit:
-    #     variant: CommitSha
-    #     prefix: "renzor-"
+    - gitCommit:
+        variant: CommitSha
+        prefix: "renzor-"
     - inputDigest: {}
   local:
     concurrency: 1

--- a/pkg/skaffold/build/build.go
+++ b/pkg/skaffold/build/build.go
@@ -33,8 +33,6 @@ import (
 type Builder interface {
 	Build(ctx context.Context, out io.Writer, tags tag.ImageTagsList, platforms platform.Resolver, artifacts []*latest.Artifact) ([]graph.Artifact, error)
 
-	//Build2(ctx context.Context, out io.Writer, tags tag.ImageTagsList, platforms platform.Resolver, artifacts []*latest.Artifact) ([]graph.Artifact, error)
-
 	// Prune removes images built with Skaffold
 	Prune(context.Context, io.Writer) error
 }

--- a/pkg/skaffold/build/build.go
+++ b/pkg/skaffold/build/build.go
@@ -31,7 +31,9 @@ import (
 // This could include pushing to a authorized repository or loading the nodes with the image.
 // If artifacts is supplied, the builder should only rebuild those artifacts.
 type Builder interface {
-	Build(ctx context.Context, out io.Writer, tags tag.ImageTags, platforms platform.Resolver, artifacts []*latest.Artifact) ([]graph.Artifact, error)
+	Build(ctx context.Context, out io.Writer, tags tag.ImageTagsList, platforms platform.Resolver, artifacts []*latest.Artifact) ([]graph.Artifact, error)
+
+	//Build2(ctx context.Context, out io.Writer, tags tag.ImageTagsList, platforms platform.Resolver, artifacts []*latest.Artifact) ([]graph.Artifact, error)
 
 	// Prune removes images built with Skaffold
 	Prune(context.Context, io.Writer) error

--- a/pkg/skaffold/build/builder_mux.go
+++ b/pkg/skaffold/build/builder_mux.go
@@ -104,6 +104,7 @@ func (b *BuilderMux) Build(ctx context.Context, out io.Writer, tags tag.ImageTag
 		}
 		var built string
 
+		// NOTE: Commented for the POC. Pending: support multi-platform builds
 		// if platforms.IsMultiPlatform() && !SupportsMultiPlatformBuild(*artifact) {
 		// 	built, err = CreateMultiPlatformImage(ctx, out, artifact, tag, platforms, artifactBuilder)
 		// } else {

--- a/pkg/skaffold/build/cache/retrieve.go
+++ b/pkg/skaffold/build/cache/retrieve.go
@@ -37,6 +37,10 @@ import (
 	timeutil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/util/time"
 )
 
+func (c *cache) Build2(ctx context.Context, out io.Writer, tags tag.ImageTagsList, artifacts []*latest.Artifact, platforms platform.Resolver, buildAndTest BuildAndTestFn2) ([]graph.Artifact, error) {
+	return nil, nil
+}
+
 func (c *cache) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact, platforms platform.Resolver, buildAndTest BuildAndTestFn) ([]graph.Artifact, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/pkg/skaffold/build/cache/retrieve.go
+++ b/pkg/skaffold/build/cache/retrieve.go
@@ -20,145 +20,137 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"time"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
-	eventV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/v2"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/platform"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/tag"
-	timeutil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/util/time"
 )
 
-func (c *cache) Build2(ctx context.Context, out io.Writer, tags tag.ImageTagsList, artifacts []*latest.Artifact, platforms platform.Resolver, buildAndTest BuildAndTestFn2) ([]graph.Artifact, error) {
+func (c *cache) Build(ctx context.Context, out io.Writer, tags tag.ImageTagsList, artifacts []*latest.Artifact, platforms platform.Resolver, buildAndTest BuildAndTestFn2) ([]graph.Artifact, error) {
 	return nil, nil
 }
 
-func (c *cache) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact, platforms platform.Resolver, buildAndTest BuildAndTestFn) ([]graph.Artifact, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+// NOTE: Commenting retrieve cache logic for POC. This logic wil need to manage the multiple tags.
+// func (c *cache) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact, platforms platform.Resolver, buildAndTest BuildAndTestFn) ([]graph.Artifact, error) {
+// 	ctx, cancel := context.WithCancel(ctx)
+// 	defer cancel()
 
-	start := time.Now()
+// 	start := time.Now()
 
-	output.Default.Fprintln(out, "Checking cache...")
-	ctx, endTrace := instrumentation.StartTrace(ctx, "Build_CheckBuildCache")
-	defer endTrace()
+// 	output.Default.Fprintln(out, "Checking cache...")
+// 	ctx, endTrace := instrumentation.StartTrace(ctx, "Build_CheckBuildCache")
+// 	defer endTrace()
 
-	lookup := make(chan []cacheDetails)
-	go func() { lookup <- c.lookupArtifacts(ctx, tags, platforms, artifacts) }()
+// 	lookup := make(chan []cacheDetails)
+// 	go func() { lookup <- c.lookupArtifacts(ctx, tags, platforms, artifacts) }()
 
-	var results []cacheDetails
-	select {
-	case <-ctx.Done():
-		return nil, context.Canceled
-	case results = <-lookup:
-	}
+// 	var results []cacheDetails
+// 	select {
+// 	case <-ctx.Done():
+// 		return nil, context.Canceled
+// 	case results = <-lookup:
+// 	}
 
-	var needToBuild []*latest.Artifact
-	var alreadyBuilt []graph.Artifact
-	for i, artifact := range artifacts {
-		eventV2.CacheCheckInProgress(artifact.ImageName, platforms.GetPlatforms(artifact.ImageName).String())
-		out, ctx := output.WithEventContext(ctx, out, constants.Build, artifact.ImageName)
-		output.Default.Fprintf(out, " - %s: ", artifact.ImageName)
+// 	var needToBuild []*latest.Artifact
+// 	var alreadyBuilt []graph.Artifact
+// 	for i, artifact := range artifacts {
+// 		eventV2.CacheCheckInProgress(artifact.ImageName, platforms.GetPlatforms(artifact.ImageName).String())
+// 		out, ctx := output.WithEventContext(ctx, out, constants.Build, artifact.ImageName)
+// 		output.Default.Fprintf(out, " - %s: ", artifact.ImageName)
 
-		result := results[i]
-		switch result := result.(type) {
-		case failed:
-			output.Red.Fprintln(out, "Error checking cache.")
-			endTrace(instrumentation.TraceEndError(result.err))
-			return nil, result.err
+// 		result := results[i]
+// 		switch result := result.(type) {
+// 		case failed:
+// 			output.Red.Fprintln(out, "Error checking cache.")
+// 			endTrace(instrumentation.TraceEndError(result.err))
+// 			return nil, result.err
 
-		case needsBuilding:
-			eventV2.CacheCheckMiss(artifact.ImageName, platforms.GetPlatforms(artifact.ImageName).String())
-			output.Yellow.Fprintln(out, "Not found. Building")
-			c.hashByName[artifact.ImageName] = result.Hash()
-			needToBuild = append(needToBuild, artifact)
-			continue
+// 		case needsBuilding:
+// 			eventV2.CacheCheckMiss(artifact.ImageName, platforms.GetPlatforms(artifact.ImageName).String())
+// 			output.Yellow.Fprintln(out, "Not found. Building")
+// 			c.hashByName[artifact.ImageName] = result.Hash()
+// 			needToBuild = append(needToBuild, artifact)
+// 			continue
 
-		case needsTagging:
-			eventV2.CacheCheckHit(artifact.ImageName, platforms.GetPlatforms(artifact.ImageName).String())
-			output.Green.Fprintln(out, "Found. Tagging")
-			if err := result.Tag(ctx, c, platforms); err != nil {
-				endTrace(instrumentation.TraceEndError(err))
-				return nil, fmt.Errorf("tagging image: %w", err)
-			}
+// 		case needsTagging:
+// 			eventV2.CacheCheckHit(artifact.ImageName, platforms.GetPlatforms(artifact.ImageName).String())
+// 			output.Green.Fprintln(out, "Found. Tagging")
+// 			if err := result.Tag(ctx, c, platforms); err != nil {
+// 				endTrace(instrumentation.TraceEndError(err))
+// 				return nil, fmt.Errorf("tagging image: %w", err)
+// 			}
 
-		case needsPushing:
-			eventV2.CacheCheckHit(artifact.ImageName, platforms.GetPlatforms(artifact.ImageName).String())
-			output.Green.Fprintln(out, "Found. Pushing")
-			if err := result.Push(ctx, out, c); err != nil {
-				endTrace(instrumentation.TraceEndError(err))
+// 		case needsPushing:
+// 			eventV2.CacheCheckHit(artifact.ImageName, platforms.GetPlatforms(artifact.ImageName).String())
+// 			output.Green.Fprintln(out, "Found. Pushing")
+// 			if err := result.Push(ctx, out, c); err != nil {
+// 				endTrace(instrumentation.TraceEndError(err))
 
-				return nil, fmt.Errorf("%s: %w", sErrors.PushImageErr, err)
-			}
+// 				return nil, fmt.Errorf("%s: %w", sErrors.PushImageErr, err)
+// 			}
 
-		default:
-			eventV2.CacheCheckHit(artifact.ImageName, platforms.GetPlatforms(artifact.ImageName).String())
-			isLocal, err := c.isLocalImage(artifact.ImageName)
-			if err != nil {
-				endTrace(instrumentation.TraceEndError(err))
-				return nil, err
-			}
-			if isLocal {
-				output.Green.Fprintln(out, "Found Locally")
-			} else {
-				output.Green.Fprintln(out, "Found Remotely")
-			}
-		}
+// 		default:
+// 			eventV2.CacheCheckHit(artifact.ImageName, platforms.GetPlatforms(artifact.ImageName).String())
+// 			isLocal, err := c.isLocalImage(artifact.ImageName)
+// 			if err != nil {
+// 				endTrace(instrumentation.TraceEndError(err))
+// 				return nil, err
+// 			}
+// 			if isLocal {
+// 				output.Green.Fprintln(out, "Found Locally")
+// 			} else {
+// 				output.Green.Fprintln(out, "Found Remotely")
+// 			}
+// 		}
 
-		// Image is already built
-		c.cacheMutex.RLock()
-		entry := c.artifactCache[result.Hash()]
-		c.cacheMutex.RUnlock()
-		tag := tags[artifact.ImageName]
+// 		// Image is already built
+// 		c.cacheMutex.RLock()
+// 		entry := c.artifactCache[result.Hash()]
+// 		c.cacheMutex.RUnlock()
+// 		tag := tags[artifact.ImageName]
 
-		var uniqueTag string
-		isLocal, err := c.isLocalImage(artifact.ImageName)
-		if err != nil {
-			endTrace(instrumentation.TraceEndError(err))
-			return nil, err
-		}
-		if isLocal {
-			var err error
-			uniqueTag, err = build.TagWithImageID(ctx, tag, entry.ID, c.client)
-			if err != nil {
-				endTrace(instrumentation.TraceEndError(err))
-				return nil, err
-			}
-		} else {
-			uniqueTag = build.TagWithDigest(tag, entry.Digest)
-		}
-		c.artifactStore.Record(artifact, uniqueTag)
-		alreadyBuilt = append(alreadyBuilt, graph.Artifact{
-			ImageName: artifact.ImageName,
-			Tag:       uniqueTag,
-		})
-	}
+// 		var uniqueTag string
+// 		isLocal, err := c.isLocalImage(artifact.ImageName)
+// 		if err != nil {
+// 			endTrace(instrumentation.TraceEndError(err))
+// 			return nil, err
+// 		}
+// 		if isLocal {
+// 			var err error
+// 			uniqueTag, err = build.TagWithImageID(ctx, tag, entry.ID, c.client)
+// 			if err != nil {
+// 				endTrace(instrumentation.TraceEndError(err))
+// 				return nil, err
+// 			}
+// 		} else {
+// 			uniqueTag = build.TagWithDigest(tag, entry.Digest)
+// 		}
+// 		c.artifactStore.Record(artifact, uniqueTag)
+// 		alreadyBuilt = append(alreadyBuilt, graph.Artifact{
+// 			ImageName: artifact.ImageName,
+// 			Tag:       uniqueTag,
+// 		})
+// 	}
 
-	log.Entry(ctx).Infoln("Cache check completed in", timeutil.Humanize(time.Since(start)))
+// 	log.Entry(ctx).Infoln("Cache check completed in", timeutil.Humanize(time.Since(start)))
 
-	defer func() {
-		if err := saveArtifactCache(c.cacheFile, c.artifactCache); err != nil {
-			log.Entry(ctx).Warnf("error saving cache file; caching may not work as expected: %v", err)
-		}
-	}()
+// 	defer func() {
+// 		if err := saveArtifactCache(c.cacheFile, c.artifactCache); err != nil {
+// 			log.Entry(ctx).Warnf("error saving cache file; caching may not work as expected: %v", err)
+// 		}
+// 	}()
 
-	bRes, err := buildAndTest(ctx, out, tags, needToBuild, platforms)
+// 	bRes, err := buildAndTest(ctx, out, tags, needToBuild, platforms)
 
-	if err != nil {
-		endTrace(instrumentation.TraceEndError(err))
-		return nil, err
-	}
+// 	if err != nil {
+// 		endTrace(instrumentation.TraceEndError(err))
+// 		return nil, err
+// 	}
 
-	return maintainArtifactOrder(append(bRes, alreadyBuilt...), artifacts), err
-}
+// 	return maintainArtifactOrder(append(bRes, alreadyBuilt...), artifacts), err
+// }
 
 func maintainArtifactOrder(built []graph.Artifact, artifacts []*latest.Artifact) []graph.Artifact {
 	byName := make(map[string]graph.Artifact)

--- a/pkg/skaffold/build/cache/types.go
+++ b/pkg/skaffold/build/cache/types.go
@@ -27,9 +27,11 @@ import (
 )
 
 type BuildAndTestFn func(context.Context, io.Writer, tag.ImageTags, []*latest.Artifact, platform.Resolver) ([]graph.Artifact, error)
+type BuildAndTestFn2 func(context.Context, io.Writer, tag.ImageTagsList, []*latest.Artifact, platform.Resolver) ([]graph.Artifact, error)
 
 type Cache interface {
 	Build(context.Context, io.Writer, tag.ImageTags, []*latest.Artifact, platform.Resolver, BuildAndTestFn) ([]graph.Artifact, error)
+	Build2(ctx context.Context, out io.Writer, tags tag.ImageTagsList, artifacts []*latest.Artifact, platforms platform.Resolver, buildAndTest BuildAndTestFn2) ([]graph.Artifact, error)
 	AddArtifact(ctx context.Context, a graph.Artifact) error
 }
 
@@ -42,4 +44,8 @@ func (n *noCache) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, 
 func (n *noCache) AddArtifact(ctx context.Context, a graph.Artifact) error {
 	// noop
 	return nil
+}
+
+func (n *noCache) Build2(ctx context.Context, out io.Writer, tags tag.ImageTagsList, artifacts []*latest.Artifact, platforms platform.Resolver, buildAndTest BuildAndTestFn2) ([]graph.Artifact, error) {
+	return buildAndTest(ctx, out, tags, artifacts, platforms)
 }

--- a/pkg/skaffold/build/cache/types.go
+++ b/pkg/skaffold/build/cache/types.go
@@ -30,22 +30,17 @@ type BuildAndTestFn func(context.Context, io.Writer, tag.ImageTags, []*latest.Ar
 type BuildAndTestFn2 func(context.Context, io.Writer, tag.ImageTagsList, []*latest.Artifact, platform.Resolver) ([]graph.Artifact, error)
 
 type Cache interface {
-	Build(context.Context, io.Writer, tag.ImageTags, []*latest.Artifact, platform.Resolver, BuildAndTestFn) ([]graph.Artifact, error)
-	Build2(ctx context.Context, out io.Writer, tags tag.ImageTagsList, artifacts []*latest.Artifact, platforms platform.Resolver, buildAndTest BuildAndTestFn2) ([]graph.Artifact, error)
+	Build(ctx context.Context, out io.Writer, tags tag.ImageTagsList, artifacts []*latest.Artifact, platforms platform.Resolver, buildAndTest BuildAndTestFn2) ([]graph.Artifact, error)
 	AddArtifact(ctx context.Context, a graph.Artifact) error
 }
 
 type noCache struct{}
-
-func (n *noCache) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact, platforms platform.Resolver, buildAndTest BuildAndTestFn) ([]graph.Artifact, error) {
-	return buildAndTest(ctx, out, tags, artifacts, platforms)
-}
 
 func (n *noCache) AddArtifact(ctx context.Context, a graph.Artifact) error {
 	// noop
 	return nil
 }
 
-func (n *noCache) Build2(ctx context.Context, out io.Writer, tags tag.ImageTagsList, artifacts []*latest.Artifact, platforms platform.Resolver, buildAndTest BuildAndTestFn2) ([]graph.Artifact, error) {
+func (n *noCache) Build(ctx context.Context, out io.Writer, tags tag.ImageTagsList, artifacts []*latest.Artifact, platforms platform.Resolver, buildAndTest BuildAndTestFn2) ([]graph.Artifact, error) {
 	return buildAndTest(ctx, out, tags, artifacts, platforms)
 }

--- a/pkg/skaffold/build/cluster/cluster.go
+++ b/pkg/skaffold/build/cluster/cluster.go
@@ -62,7 +62,8 @@ func (b *Builder) PostBuild(_ context.Context, _ io.Writer) error {
 	return nil
 }
 
-func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string, m platform.Matcher) (string, error) {
+func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, artifact *latest.Artifact, tags []string, m platform.Matcher) (string, error) {
+	tag := tags[0]
 	// TODO: Implement building multiplatform images for cluster builder
 	if m.IsMultiPlatform() {
 		log.Entry(ctx).Println("skaffold doesn't yet support multi platform builds for the cluster builder")

--- a/pkg/skaffold/build/docker/docker.go
+++ b/pkg/skaffold/build/docker/docker.go
@@ -41,7 +41,8 @@ func (b *Builder) SupportedPlatforms() platform.Matcher {
 	return platform.All
 }
 
-func (b *Builder) Build(ctx context.Context, out io.Writer, a *latest.Artifact, tag string, matcher platform.Matcher) (string, error) {
+func (b *Builder) Build(ctx context.Context, out io.Writer, a *latest.Artifact, tags []string, matcher platform.Matcher) (string, error) {
+	tag := tags[0]
 	var pl v1.Platform
 	if len(matcher.Platforms) == 1 {
 		pl = util.ConvertToV1Platform(matcher.Platforms[0])
@@ -65,7 +66,7 @@ func (b *Builder) Build(ctx context.Context, out io.Writer, a *latest.Artifact, 
 	if err := b.pullCacheFromImages(ctx, out, a.ArtifactType.DockerArtifact, pl); err != nil {
 		return "", cacheFromPullErr(err, a.ImageName)
 	}
-	opts := docker.BuildOptions{Tag: tag, Mode: b.cfg.Mode(), ExtraBuildArgs: docker.ResolveDependencyImages(a.Dependencies, b.artifacts, true)}
+	opts := docker.BuildOptions{Tag: tag, Tags: tags, Mode: b.cfg.Mode(), ExtraBuildArgs: docker.ResolveDependencyImages(a.Dependencies, b.artifacts, true)}
 
 	var imageID string
 

--- a/pkg/skaffold/build/gcb/cloud_build.go
+++ b/pkg/skaffold/build/gcb/cloud_build.go
@@ -70,7 +70,8 @@ func (b *Builder) Concurrency() *int {
 	return util.Ptr(b.GoogleCloudBuild.Concurrency)
 }
 
-func (b *Builder) buildArtifactWithCloudBuild(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string, platform platform.Matcher) (string, error) {
+func (b *Builder) buildArtifactWithCloudBuild(ctx context.Context, out io.Writer, artifact *latest.Artifact, tags []string, platform platform.Matcher) (string, error) {
+	tag := tags[0]
 	instrumentation.AddAttributesToCurrentSpanFromContext(ctx, map[string]string{
 		"Destination": instrumentation.PII(tag),
 	})

--- a/pkg/skaffold/build/local/local.go
+++ b/pkg/skaffold/build/local/local.go
@@ -65,7 +65,7 @@ func (b *Builder) PushImages() bool {
 
 func (b *Builder) SupportedPlatforms() platform.Matcher { return platform.All }
 
-func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, a *latest.Artifact, tag string, platforms platform.Matcher) (string, error) {
+func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, a *latest.Artifact, tag []string, platforms platform.Matcher) (string, error) {
 	digestOrImageID, err := b.runBuildForArtifact(ctx, out, a, tag, platforms)
 	if err != nil {
 		return "", err
@@ -75,7 +75,7 @@ func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, a *latest.Ar
 		// only track images for pruning when building with docker
 		// if we're pushing a bazel image, it was built directly to the registry
 		if a.DockerArtifact != nil {
-			imageID, err := b.getImageIDForTag(ctx, tag)
+			imageID, err := b.getImageIDForTag(ctx, tag[0])
 			if err != nil {
 				log.Entry(ctx).Warn("unable to inspect image: built images may not be cleaned up correctly by skaffold")
 			}
@@ -85,15 +85,15 @@ func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, a *latest.Ar
 		}
 
 		digest := digestOrImageID
-		return build.TagWithDigest(tag, digest), nil
+		return build.TagWithDigest(tag[0], digest), nil
 	}
 
 	imageID := digestOrImageID
 	b.builtImages = append(b.builtImages, imageID)
-	return build.TagWithImageID(ctx, tag, imageID, b.localDocker)
+	return build.TagWithImageID(ctx, tag[0], imageID, b.localDocker)
 }
 
-func (b *Builder) runBuildForArtifact(ctx context.Context, out io.Writer, a *latest.Artifact, tag string, platforms platform.Matcher) (string, error) {
+func (b *Builder) runBuildForArtifact(ctx context.Context, out io.Writer, a *latest.Artifact, tag []string, platforms platform.Matcher) (string, error) {
 	if !b.pushImages {
 		// All of the builders will rely on a local Docker:
 		// + Either to build the image,

--- a/pkg/skaffold/build/local/types.go
+++ b/pkg/skaffold/build/local/types.go
@@ -22,12 +22,7 @@ import (
 	"io"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/bazel"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/buildpacks"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/custom"
 	dockerbuilder "github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/jib"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/ko"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/misc"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
@@ -35,7 +30,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/platform"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
 // Builder uses the host docker daemon to build and tag the image.
@@ -140,7 +134,7 @@ func (b *Builder) Prune(ctx context.Context, _ io.Writer) error {
 
 // artifactBuilder represents a per artifact builder interface
 type artifactBuilder interface {
-	Build(ctx context.Context, out io.Writer, a *latest.Artifact, tag string, platforms platform.Matcher) (string, error)
+	Build(ctx context.Context, out io.Writer, a *latest.Artifact, tag []string, platforms platform.Matcher) (string, error)
 	SupportedPlatforms() platform.Matcher
 }
 
@@ -150,22 +144,22 @@ func newPerArtifactBuilder(b *Builder, a *latest.Artifact) (artifactBuilder, err
 	case a.DockerArtifact != nil:
 		return dockerbuilder.NewArtifactBuilder(b.localDocker, b.cfg, b.local.UseDockerCLI, b.local.UseBuildkit, b.pushImages, b.artifactStore, b.sourceDependencies), nil
 
-	case a.BazelArtifact != nil:
-		return bazel.NewArtifactBuilder(b.localDocker, b.cfg, b.pushImages), nil
+	// case a.BazelArtifact != nil:
+	// 	return bazel.NewArtifactBuilder(b.localDocker, b.cfg, b.pushImages), nil
 
-	case a.JibArtifact != nil:
-		return jib.NewArtifactBuilder(b.localDocker, b.cfg, b.pushImages, b.skipTests, b.artifactStore), nil
+	// case a.JibArtifact != nil:
+	// 	return jib.NewArtifactBuilder(b.localDocker, b.cfg, b.pushImages, b.skipTests, b.artifactStore), nil
 
-	case a.CustomArtifact != nil:
-		// required artifacts as environment variables
-		dependencies := util.EnvPtrMapToSlice(docker.ResolveDependencyImages(a.Dependencies, b.artifactStore, true), "=")
-		return custom.NewArtifactBuilder(b.localDocker, b.cfg, b.pushImages, b.skipTests, append(b.retrieveExtraEnv(), dependencies...)), nil
+	// case a.CustomArtifact != nil:
+	// 	// required artifacts as environment variables
+	// 	dependencies := util.EnvPtrMapToSlice(docker.ResolveDependencyImages(a.Dependencies, b.artifactStore, true), "=")
+	// 	return custom.NewArtifactBuilder(b.localDocker, b.cfg, b.pushImages, b.skipTests, append(b.retrieveExtraEnv(), dependencies...)), nil
 
-	case a.BuildpackArtifact != nil:
-		return buildpacks.NewArtifactBuilder(b.localDocker, b.pushImages, b.mode, b.artifactStore), nil
+	// case a.BuildpackArtifact != nil:
+	// 	return buildpacks.NewArtifactBuilder(b.localDocker, b.pushImages, b.mode, b.artifactStore), nil
 
-	case a.KoArtifact != nil:
-		return ko.NewArtifactBuilder(b.localDocker, b.pushImages, b.mode, b.insecureRegistries), nil
+	// case a.KoArtifact != nil:
+	// 	return ko.NewArtifactBuilder(b.localDocker, b.pushImages, b.mode, b.insecureRegistries), nil
 
 	default:
 		return nil, fmt.Errorf("unexpected type %q for local artifact:\n%s", misc.ArtifactType(a), misc.FormatArtifact(a))

--- a/pkg/skaffold/build/logfile.go
+++ b/pkg/skaffold/build/logfile.go
@@ -36,7 +36,7 @@ func WithLogFile(builder ArtifactBuilder, muted Muted) ArtifactBuilder {
 		return builder
 	}
 
-	return func(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string, platforms platform.Matcher) (string, error) {
+	return func(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag []string, platforms platform.Matcher) (string, error) {
 		file, err := logfile.Create("build", artifact.ImageName+".log")
 		if err != nil {
 			return "", fmt.Errorf("unable to create log file for %s: %w", artifact.ImageName, err)

--- a/pkg/skaffold/build/platform.go
+++ b/pkg/skaffold/build/platform.go
@@ -59,7 +59,7 @@ func buildImageForPlatforms(ctx context.Context, out io.Writer, a *latest.Artifa
 			Platforms: []specs.Platform{p},
 		}
 		tagWithPlatform := fmt.Sprintf("%s_%s", tag, strings.ReplaceAll(platform.Format(p), "/", "_"))
-		imageID, err := ab(ctx, out, a, tagWithPlatform, m)
+		imageID, err := ab(ctx, out, a, []string{tagWithPlatform}, m)
 
 		if err != nil {
 			return nil, err

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -109,6 +109,7 @@ type LocalDaemon interface {
 // BuildOptions provides parameters related to the LocalDaemon build.
 type BuildOptions struct {
 	Tag            string
+	Tags           []string
 	Mode           config.RunMode
 	ExtraBuildArgs map[string]*string
 }
@@ -345,7 +346,7 @@ func (l *localDaemon) Build(ctx context.Context, out io.Writer, workspace string
 	body := progress.NewProgressReader(buildCtx, progressOutput, 0, "", "Sending build context to Docker daemon")
 
 	resp, err := l.apiClient.ImageBuild(ctx, body, types.ImageBuildOptions{
-		Tags:        []string{opts.Tag},
+		Tags:        opts.Tags,
 		Dockerfile:  a.DockerfilePath,
 		BuildArgs:   buildArgs,
 		CacheFrom:   a.CacheFrom,

--- a/pkg/skaffold/hooks/build.go
+++ b/pkg/skaffold/hooks/build.go
@@ -33,10 +33,10 @@ func BuildRunner(d latest.BuildHooks, opts BuildEnvOpts) Runner {
 }
 
 // NewBuildEnvOpts returns `BuildEnvOpts` required to create a `Runner` for build lifecycle hooks
-func NewBuildEnvOpts(a *latest.Artifact, image string, pushImage bool) (BuildEnvOpts, error) {
-	ref, err := docker.ParseReference(image)
+func NewBuildEnvOpts(a *latest.Artifact, images []string, pushImage bool) (BuildEnvOpts, error) {
+	ref, err := docker.ParseReference(images[0])
 	if err != nil {
-		return BuildEnvOpts{}, fmt.Errorf("parsing image %v: %w", image, err)
+		return BuildEnvOpts{}, fmt.Errorf("parsing image %v: %w", images, err)
 	}
 
 	w, err := filepath.Abs(a.Workspace)
@@ -44,7 +44,7 @@ func NewBuildEnvOpts(a *latest.Artifact, image string, pushImage bool) (BuildEnv
 		return BuildEnvOpts{}, fmt.Errorf("determining build workspace directory for image %v: %w", a.ImageName, err)
 	}
 	return BuildEnvOpts{
-		Image:        image,
+		Image:        images[0],
 		PushImage:    pushImage,
 		ImageRepo:    ref.Repo,
 		ImageTag:     ref.Tag,

--- a/pkg/skaffold/runner/build.go
+++ b/pkg/skaffold/runner/build.go
@@ -103,13 +103,6 @@ func (r *Builder) Build(ctx context.Context, out io.Writer, artifacts []*latest.
 	// }
 
 	bRes, err := r.cache.Build2(ctx, out, tags, artifacts, r.platforms, func(ctx context.Context, out io.Writer, tags tag.ImageTagsList, artifacts []*latest.Artifact, platforms platform.Resolver) ([]graph.Artifact, error) {
-
-		tmpTags := make(map[string]string, len(tags))
-
-		for key, tags := range tags {
-			tmpTags[key] = tags[0]
-		}
-
 		if len(artifacts) == 0 {
 			return nil, nil
 		}
@@ -118,7 +111,7 @@ func (r *Builder) Build(ctx context.Context, out io.Writer, artifacts []*latest.
 		if err != nil {
 			return nil, err
 		}
-		bRes, err := r.Builder.Build(ctx, out, tmpTags, platforms, artifacts)
+		bRes, err := r.Builder.Build(ctx, out, tags, platforms, artifacts)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/skaffold/runner/build.go
+++ b/pkg/skaffold/runner/build.go
@@ -102,7 +102,7 @@ func (r *Builder) Build(ctx context.Context, out io.Writer, artifacts []*latest.
 	// default:
 	// }
 
-	bRes, err := r.cache.Build2(ctx, out, tags, artifacts, r.platforms, func(ctx context.Context, out io.Writer, tags tag.ImageTagsList, artifacts []*latest.Artifact, platforms platform.Resolver) ([]graph.Artifact, error) {
+	bRes, err := r.cache.Build(ctx, out, tags, artifacts, r.platforms, func(ctx context.Context, out io.Writer, tags tag.ImageTagsList, artifacts []*latest.Artifact, platforms platform.Resolver) ([]graph.Artifact, error) {
 		if len(artifacts) == 0 {
 			return nil, nil
 		}

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -44,6 +44,7 @@ var ErrorConfigurationChanged = errors.New("configuration changed")
 type Runner interface {
 	Apply(context.Context, io.Writer) error
 	ApplyDefaultRepo(tag string) (string, error)
+	ApplyDefaultRepo2(tags []string) ([]string, error)
 	Build(context.Context, io.Writer, []*latest.Artifact) ([]graph.Artifact, error)
 	Cleanup(context.Context, io.Writer, bool, manifest.ManifestListByConfig) error
 	Dev(context.Context, io.Writer, []*latest.Artifact) error

--- a/pkg/skaffold/runner/timings.go
+++ b/pkg/skaffold/runner/timings.go
@@ -56,21 +56,6 @@ type withTimings struct {
 	cacheArtifacts bool
 }
 
-// func (w withTimings) Build2(ctx context.Context, out io.Writer, tags tag.ImageTagsList, platforms platform.Resolver, artifacts []*latest.Artifact) ([]graph.Artifact, error) {
-// 	if len(artifacts) == 0 && w.cacheArtifacts {
-// 		return nil, nil
-// 	}
-// 	start := time.Now()
-// 	output.Default.Fprintln(out, "Starting build...")
-
-// 	bRes, err := w.Builder.Build2(ctx, out, tags, platforms, artifacts)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	log.Entry(ctx).Infoln("Build completed in", timeutil.Humanize(time.Since(start)))
-// 	return bRes, nil
-// }
-
 func (w withTimings) Build(ctx context.Context, out io.Writer, tags tag.ImageTagsList, platforms platform.Resolver, artifacts []*latest.Artifact) ([]graph.Artifact, error) {
 	if len(artifacts) == 0 && w.cacheArtifacts {
 		return nil, nil

--- a/pkg/skaffold/runner/timings.go
+++ b/pkg/skaffold/runner/timings.go
@@ -56,7 +56,22 @@ type withTimings struct {
 	cacheArtifacts bool
 }
 
-func (w withTimings) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, platforms platform.Resolver, artifacts []*latest.Artifact) ([]graph.Artifact, error) {
+// func (w withTimings) Build2(ctx context.Context, out io.Writer, tags tag.ImageTagsList, platforms platform.Resolver, artifacts []*latest.Artifact) ([]graph.Artifact, error) {
+// 	if len(artifacts) == 0 && w.cacheArtifacts {
+// 		return nil, nil
+// 	}
+// 	start := time.Now()
+// 	output.Default.Fprintln(out, "Starting build...")
+
+// 	bRes, err := w.Builder.Build2(ctx, out, tags, platforms, artifacts)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	log.Entry(ctx).Infoln("Build completed in", timeutil.Humanize(time.Since(start)))
+// 	return bRes, nil
+// }
+
+func (w withTimings) Build(ctx context.Context, out io.Writer, tags tag.ImageTagsList, platforms platform.Resolver, artifacts []*latest.Artifact) ([]graph.Artifact, error) {
 	if len(artifacts) == 0 && w.cacheArtifacts {
 		return nil, nil
 	}

--- a/pkg/skaffold/schema/defaults/defaults.go
+++ b/pkg/skaffold/schema/defaults/defaults.go
@@ -210,11 +210,11 @@ func setDefaultCloudBuildKoImage(gcb *latest.GoogleCloudBuild) {
 }
 
 func setDefaultTagger(c *latest.SkaffoldConfig) {
-	if c.Build.TagPolicy != (latest.TagPolicy{}) {
+	if len(c.Build.TagPolicies) > 0 {
 		return
 	}
-
-	c.Build.TagPolicy = latest.TagPolicy{GitTagger: &latest.GitTagger{}}
+	c.Build.TagPolicies = append(c.Build.TagPolicies, latest.TagPolicy{GitTagger: &latest.GitTagger{}})
+	//c.Build.TagPolicy = latest.TagPolicy{GitTagger: &latest.GitTagger{}} //Sets default TagPolicy to GitTagger
 }
 
 func setDefaultLogsConfig(c *latest.SkaffoldConfig) {

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -181,7 +181,7 @@ type BuildConfig struct {
 	// TagPolicy *beta* determines how images are tagged.
 	// A few strategies are provided here, although you most likely won't need to care!
 	// If not specified, it defaults to `gitCommit: {variant: Tags}`.
-	TagPolicy TagPolicy `yaml:"tagPolicy,omitempty"`
+	TagPolicies []TagPolicy `yaml:"tagPolicy,omitempty"`
 
 	// Platforms is the list of platforms to build all artifact images for.
 	// It can be overridden by the individual artifact's `platforms` property.

--- a/pkg/skaffold/schema/validation/validation.go
+++ b/pkg/skaffold/schema/validation/validation.go
@@ -158,14 +158,24 @@ func ProcessWithRunContext(ctx context.Context, runCtx *runcontext.RunContext) e
 func validateTaggingPolicy(cfg *parser.SkaffoldConfigEntry, bc latest.BuildConfig) (cfgErrs []ErrorWithLocation) {
 	if bc.LocalBuild != nil {
 		// sha256 just uses `latest` tag, so tryImportMissing will virtually always succeed (#4889)
-		if bc.LocalBuild.TryImportMissing && bc.TagPolicy.ShaTagger != nil {
+		if bc.LocalBuild.TryImportMissing && isThereAShaTagger(&bc.TagPolicies) {
 			cfgErrs = append(cfgErrs, ErrorWithLocation{
 				Error:    fmt.Errorf("tagging policy 'sha256' can not be used when 'tryImportMissing' is enabled"),
-				Location: cfg.YAMLInfos.Locate(cfg.Build.TagPolicy.ShaTagger),
+				Location: cfg.YAMLInfos.Locate(cfg.Build.TagPolicies),
 			})
 		}
 	}
 	return
+}
+
+func isThereAShaTagger(tagPolicies *[]latest.TagPolicy) bool {
+	for _, tagger := range *tagPolicies {
+		if tagger.ShaTagger != nil {
+			return true
+		}
+	}
+
+	return false
 }
 
 // validateImageNames makes sure the artifact image names are unique and valid base names,

--- a/pkg/skaffold/tag/custom.go
+++ b/pkg/skaffold/tag/custom.go
@@ -35,3 +35,7 @@ func (t *CustomTag) GenerateTag(ctx context.Context, _ latest.Artifact) (string,
 	}
 	return tag, nil
 }
+
+func (t *CustomTag) GenerateTags(ctx context.Context, _ latest.Artifact) ([]string, error) {
+	return nil, nil
+}

--- a/pkg/skaffold/tag/custom_template.go
+++ b/pkg/skaffold/tag/custom_template.go
@@ -65,6 +65,10 @@ func (t *customTemplateTagger) GenerateTag(ctx context.Context, image latest.Art
 	return tag, nil
 }
 
+func (t *customTemplateTagger) GenerateTags(ctx context.Context, image latest.Artifact) ([]string, error) {
+	return nil, nil
+}
+
 // EvaluateComponents creates a custom mapping of component names to their tagger string representation.
 func (t *customTemplateTagger) EvaluateComponents(ctx context.Context, image latest.Artifact) (map[string]string, error) {
 	taggers := map[string]Tagger{}

--- a/pkg/skaffold/tag/date_time.go
+++ b/pkg/skaffold/tag/date_time.go
@@ -64,3 +64,7 @@ func (t *dateTimeTagger) GenerateTag(ctx context.Context, image latest.Artifact)
 
 	return t.timeFn().In(loc).Format(format), nil
 }
+
+func (t *dateTimeTagger) GenerateTags(ctx context.Context, image latest.Artifact) ([]string, error) {
+	return nil, nil
+}

--- a/pkg/skaffold/tag/env_template.go
+++ b/pkg/skaffold/tag/env_template.go
@@ -54,3 +54,7 @@ func (t *envTemplateTagger) GenerateTag(ctx context.Context, image latest.Artifa
 
 	return tag, nil
 }
+
+func (t *envTemplateTagger) GenerateTags(ctx context.Context, image latest.Artifact) ([]string, error) {
+	return nil, nil
+}

--- a/pkg/skaffold/tag/git_commit.go
+++ b/pkg/skaffold/tag/git_commit.go
@@ -84,6 +84,10 @@ func (t *GitCommit) GenerateTag(ctx context.Context, image latest.Artifact) (str
 	return t.prefix + ref, nil
 }
 
+func (t *GitCommit) GenerateTags(ctx context.Context, _ latest.Artifact) ([]string, error) {
+	return nil, nil
+}
+
 // sanitizeTag takes a git tag and converts it to a docker tag by removing
 // all the characters that are not allowed by docker.
 func sanitizeTag(tag string) string {

--- a/pkg/skaffold/tag/input_digest.go
+++ b/pkg/skaffold/tag/input_digest.go
@@ -75,6 +75,10 @@ func (t *inputDigestTagger) GenerateTag(ctx context.Context, image latest.Artifa
 	return encode(inputs)
 }
 
+func (t *inputDigestTagger) GenerateTags(ctx context.Context, image latest.Artifact) ([]string, error) {
+	return nil, nil
+}
+
 func encode(inputs []string) (string, error) {
 	// get a key for the hashes
 	hasher := sha256.New()

--- a/pkg/skaffold/tag/sha256.go
+++ b/pkg/skaffold/tag/sha256.go
@@ -41,3 +41,7 @@ func (t *ChecksumTagger) GenerateTag(ctx context.Context, image latest.Artifact)
 	// imageName already has a tag
 	return "", nil
 }
+
+func (t *ChecksumTagger) GenerateTags(ctx context.Context, image latest.Artifact) ([]string, error) {
+	return nil, nil
+}


### PR DESCRIPTION
**POC for multi-tagging**

**Description**
This PR introduces a small POC to test and understand the impact to develop a multi-tagging feature in Skaffold. This POC only cover the `Docker` builder.

**How to use the POC**
- Build Skaffold from source code in this PR
- Go inside the `cross-platform-builds` example in `integration/examples/cross-platform-builds`
  - Here you'll see the `skaffold.yaml` file with the following value:
```
...
build:
  artifacts:
    - image: skaffold-example-1
      context: .
      docker:
        dockerfile: Dockerfile
        noCache: true
    - image: skaffold-example-2
      context: .
      docker:
        dockerfile: Dockerfile
        noCache: true
  tagPolicy:
    - sha256: {}
    - customTemplate:
        template: "secondtag"
...
```
- Two tag policies were added
- Run `skaffold build --default-repo=gcr.io/k8s-skaffold --cache-artifacts=false`. You will see the following output
```
...
Generating tags...
 - skaffold-example-1 -> [gcr.io/k8s-skaffold/skaffold-example-1:latest gcr.io/k8s-skaffold/skaffold-example-1:secondtag]
 - skaffold-example-2 -> [gcr.io/k8s-skaffold/skaffold-example-2:latest gcr.io/k8s-skaffold/skaffold-example-2:secondtag]
...
Building [skaffold-example-2]...
...
Successfully built 37007a8bb791
Successfully tagged gcr.io/k8s-skaffold/skaffold-example-2:latest
Successfully tagged gcr.io/k8s-skaffold/skaffold-example-2:secondtag
...
Building [skaffold-example-1]...
...
Successfully built 9d81556d5c92
Successfully tagged gcr.io/k8s-skaffold/skaffold-example-1:latest
Successfully tagged gcr.io/k8s-skaffold/skaffold-example-1:secondtag
...
```
- Each image was build once, and tagged twice, according to the `skaffold.yaml` config
- You can try adding more tag policies to the images 😄 

**Please take into account**
- The POC do not push the images to a registry, this is WIP
- The `tagPolicy` key is still in singular even when it does support an array, this is a WIP
- Some parts of the code are commented just for the POC, making some feature (e.g: retrieve cache) to not work 