### PR TITLE
fix: correct recently released schemas to have correct schema field key

### DIFF
--- a/docs-v2/content/en/schemas/v2beta29.json
+++ b/docs-v2/content/en/schemas/v2beta29.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v3.json
+++ b/docs-v2/content/en/schemas/v3.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v3alpha1.json
+++ b/docs-v2/content/en/schemas/v3alpha1.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v4beta1.json
+++ b/docs-v2/content/en/schemas/v4beta1.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v2beta29.json
+++ b/docs/content/en/schemas/v2beta29.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {


### PR DESCRIPTION
Related to https://github.com/GoogleContainerTools/skaffold/pull/7387

Fixes the schemas that were released since that PR was created.  The code to generate schemas was also updated in that PR so this should be future proofed