### PR TITLE
chore: fix github workflow linux unit diagnostics tests run command

### DIFF
--- a/.github/workflows/linters-checks-and-unit-tests-linux.yml
+++ b/.github/workflows/linters-checks-and-unit-tests-linux.yml
@@ -51,4 +51,4 @@ jobs:
     - name: Run diagnostics tests
       if: ${{ env.NON_DOCS_FILES_CHANGED != 0 }}
       run: |
-        make coverage
+        make -f Makefile.diag coverage


### PR DESCRIPTION
 **Description**
 - The run diagnostics tests command is not correct in linux unit test workflow, update to the right one. 