### PR TITLE
fix: support alternative env var naming using support env variable + artifact-name (vs env variable + index)

### DIFF
--- a/integration/testdata/helm-multi-config/skaffold/app1/skaffold.yml
+++ b/integration/testdata/helm-multi-config/skaffold/app1/skaffold.yml
@@ -14,6 +14,6 @@ manifests:
       - chartPath: ../../charts/app
         createNamespace: true
         name: app1
-        setValues:
-          image.repository: app1
-          image.tag: app1
+        setValueTemplates:
+          image.repository: '{{.app1.IMAGE_REPO}}'
+          image.tag: "{{.app1.IMAGE_TAG}}@{{.app1.IMAGE_DIGEST}}"

--- a/integration/testdata/helm-multi-config/skaffold/app2/skaffold.yml
+++ b/integration/testdata/helm-multi-config/skaffold/app2/skaffold.yml
@@ -14,6 +14,6 @@ manifests:
       - chartPath: ../../charts/app
         createNamespace: true
         name: app2
-        setValues:
-          image.repository: app2
-          image.tag: app2
+        setValueTemplates:
+          image.repository: '{{.app2.IMAGE_REPO}}'
+          image.tag: "{{.app2.IMAGE_TAG}}@{{.app2.IMAGE_DIGEST}}"


### PR DESCRIPTION
fixes: #7967 

fixes: #6207 

fixes: #7989 

This PR:
- adds .\<artifact-name\>.IMAGE_[REPO|TAG|DOMAIN|REPO_NO_DOMAIN] vars for each artifact
- updates v2beta29 upgrade.go to fix code to use `setValuesTemplates` and the above env vars vs `setValues`

Major reason using `setValueTemplates` is better here is that:
- This replacement is done with `helm` vs the skaffold post-renderer so that user expectations are in line with how helm replaces values vs how to skaffold postrenderer replaces values which is non-obvious/unexpected given the field names `setValues`, etc.
- no longer requires hacks in our post-renderer to get the helm replacements to work as expected for various image strategies