### PR TITLE
feat: add life cycle hooks to Cloud Run deployer

### DIFF
--- a/docs-v2/content/en/schemas/v4beta2.json
+++ b/docs-v2/content/en/schemas/v4beta2.json
@@ -967,6 +967,11 @@
     },
     "CloudRunDeploy": {
       "properties": {
+        "hooks": {
+          "$ref": "#/definitions/CloudRunDeployHooks",
+          "description": "describes a set of lifecycle host hooks that are executed before and after the Cloud Run deployer.",
+          "x-intellij-html-description": "describes a set of lifecycle host hooks that are executed before and after the Cloud Run deployer."
+        },
         "projectid": {
           "type": "string",
           "description": "the GCP Project to use for Cloud Run. If specified, all Services will be deployed to this project. If not specified, each Service will be deployed to the project specified in `metadata.namespace` of the Cloud Run manifest.",
@@ -980,12 +985,41 @@
       },
       "preferredOrder": [
         "projectid",
-        "region"
+        "region",
+        "hooks"
       ],
       "additionalProperties": false,
       "type": "object",
       "description": "*alpha* deploys the container to Google Cloud Run.",
       "x-intellij-html-description": "<em>alpha</em> deploys the container to Google Cloud Run."
+    },
+    "CloudRunDeployHooks": {
+      "properties": {
+        "after": {
+          "items": {
+            "$ref": "#/definitions/HostHook"
+          },
+          "type": "array",
+          "description": "describes the list of lifecycle hooks to execute *after* the Cloud Run deployer.",
+          "x-intellij-html-description": "describes the list of lifecycle hooks to execute <em>after</em> the Cloud Run deployer."
+        },
+        "before": {
+          "items": {
+            "$ref": "#/definitions/HostHook"
+          },
+          "type": "array",
+          "description": "describes the list of lifecycle hooks to execute *before* the Cloud Run deployer.",
+          "x-intellij-html-description": "describes the list of lifecycle hooks to execute <em>before</em> the Cloud Run deployer."
+        }
+      },
+      "preferredOrder": [
+        "before",
+        "after"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "describes the list of lifecycle hooks to execute in the host before and after the Cloud Run deployer.",
+      "x-intellij-html-description": "describes the list of lifecycle hooks to execute in the host before and after the Cloud Run deployer."
     },
     "ClusterDetails": {
       "properties": {

--- a/examples/lifecycle-hooks/k8s-pod.yaml
+++ b/examples/lifecycle-hooks/k8s-pod.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   containers:
   - name: getting-started
-    image: skaffold-example
+    image: hooks-example

--- a/examples/lifecycle-hooks/skaffold.yaml
+++ b/examples/lifecycle-hooks/skaffold.yaml
@@ -2,7 +2,7 @@ apiVersion: skaffold/v4beta1
 kind: Config
 manifests:
   rawYaml:
-  - k8s-pod.yaml
+  - deployment.yaml
   hooks:
     before:
       - host:

--- a/integration/deploy_cloudrun_test.go
+++ b/integration/deploy_cloudrun_test.go
@@ -19,12 +19,14 @@ package integration
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"google.golang.org/api/run/v1"
 
 	"github.com/GoogleContainerTools/skaffold/integration/skaffold"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/gcp"
+	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
 func TestDeployCloudRun(t *testing.T) {
@@ -40,6 +42,31 @@ func TestDeployCloudRun(t *testing.T) {
 	if err = checkReady(svc); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestDeployCloudRunWithHooks(t *testing.T) {
+	MarkIntegrationTest(t, NeedsGcp)
+
+	testutil.Run(t, "cloud run deploy with hooks", func(t *testutil.T) {
+		expectedOutput := []string{
+			"PRE-DEPLOY Cloud Run MODULE1 host hook",
+			"POST-DEPLOY Cloud Run MODULE1 host hook",
+			"PRE-DEPLOY Cloud Run MODULE2 host hook",
+			"POST-DEPLOY Cloud Run MODULE2 host hook",
+		}
+
+		out := skaffold.Run().InDir("testdata/deploy-cloudrun-with-hooks").RunOrFailOutput(t.T)
+
+		commandOutput := string(out)
+		previousFoundIndex := -1
+
+		for _, expectedOutput := range expectedOutput {
+			expectedOutputFoundIndex := strings.Index(commandOutput, expectedOutput)
+			isPreviousOutpuBeforeThanCurrent := previousFoundIndex < expectedOutputFoundIndex
+			t.CheckTrue(isPreviousOutpuBeforeThanCurrent)
+			previousFoundIndex = expectedOutputFoundIndex
+		}
+	})
 }
 
 // TODO: remove nolint when test is unskipped

--- a/integration/deploy_cloudrun_test.go
+++ b/integration/deploy_cloudrun_test.go
@@ -62,8 +62,8 @@ func TestDeployCloudRunWithHooks(t *testing.T) {
 
 		for _, expectedOutput := range expectedOutput {
 			expectedOutputFoundIndex := strings.Index(commandOutput, expectedOutput)
-			isPreviousOutpuBeforeThanCurrent := previousFoundIndex < expectedOutputFoundIndex
-			t.CheckTrue(isPreviousOutpuBeforeThanCurrent)
+			isPreviousOutputBeforeThanCurrent := previousFoundIndex < expectedOutputFoundIndex
+			t.CheckTrue(isPreviousOutputBeforeThanCurrent)
 			previousFoundIndex = expectedOutputFoundIndex
 		}
 	})

--- a/integration/testdata/deploy-cloudrun-with-hooks/module1/service.yaml
+++ b/integration/testdata/deploy-cloudrun-with-hooks/module1/service.yaml
@@ -1,0 +1,9 @@
+apiVersion: "serving.knative.dev/v1"
+kind: Service
+metadata:
+  name: cloud-run-hooks-module1
+spec:
+  template:
+    spec:
+      containers:
+      - image: gcr.io/cloudrun/hello

--- a/integration/testdata/deploy-cloudrun-with-hooks/module1/skaffold.yaml
+++ b/integration/testdata/deploy-cloudrun-with-hooks/module1/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta1 
+apiVersion: skaffold/v4beta2
 kind: Config
 metadata:
    name: cloud-run-hooks-module1

--- a/integration/testdata/deploy-cloudrun-with-hooks/module1/skaffold.yaml
+++ b/integration/testdata/deploy-cloudrun-with-hooks/module1/skaffold.yaml
@@ -1,0 +1,21 @@
+apiVersion: skaffold/v4beta1 
+kind: Config
+metadata:
+   name: cloud-run-hooks-module1
+
+manifests:
+  rawYaml:
+    - service.yaml
+
+deploy:
+  cloudrun:
+    projectid: k8s-skaffold
+    region: us-central1
+    hooks:
+      before:
+        - command: ["sh", "-c", "echo PRE-DEPLOY Cloud Run MODULE1 host hook"]
+          os: [darwin, linux]
+      
+      after:
+        - command: ["sh", "-c", "echo POST-DEPLOY Cloud Run MODULE1 host hook!"]
+          os: [darwin, linux]

--- a/integration/testdata/deploy-cloudrun-with-hooks/module2/service.yaml
+++ b/integration/testdata/deploy-cloudrun-with-hooks/module2/service.yaml
@@ -1,0 +1,9 @@
+apiVersion: "serving.knative.dev/v1"
+kind: Service
+metadata:
+  name: cloud-run-hooks-module2
+spec:
+  template:
+    spec:
+      containers:
+      - image: gcr.io/cloudrun/hello

--- a/integration/testdata/deploy-cloudrun-with-hooks/module2/skaffold.yaml
+++ b/integration/testdata/deploy-cloudrun-with-hooks/module2/skaffold.yaml
@@ -1,0 +1,21 @@
+apiVersion: skaffold/v4beta1 
+kind: Config
+metadata:
+   name: cloud-run-hooks-module2
+
+manifests:
+  rawYaml:
+    - service.yaml
+
+deploy:
+  cloudrun:
+    projectid: k8s-skaffold
+    region: us-central1
+    hooks:
+      before:
+        - command: ["sh", "-c", "echo PRE-DEPLOY Cloud Run MODULE2 host hook!"]
+          os: [darwin, linux]
+      
+      after:
+        - command: ["sh", "-c", "echo POST-DEPLOY Cloud Run MODULE2 host hook!"]
+          os: [darwin, linux]

--- a/integration/testdata/deploy-cloudrun-with-hooks/module2/skaffold.yaml
+++ b/integration/testdata/deploy-cloudrun-with-hooks/module2/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta1 
+apiVersion: skaffold/v4beta2
 kind: Config
 metadata:
    name: cloud-run-hooks-module2

--- a/integration/testdata/deploy-cloudrun-with-hooks/skaffold.yaml
+++ b/integration/testdata/deploy-cloudrun-with-hooks/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta1
+apiVersion: skaffold/v4beta2
 kind: Config
 requires:
 - path: ./module1

--- a/integration/testdata/deploy-cloudrun-with-hooks/skaffold.yaml
+++ b/integration/testdata/deploy-cloudrun-with-hooks/skaffold.yaml
@@ -1,0 +1,5 @@
+apiVersion: skaffold/v4beta1
+kind: Config
+requires:
+- path: ./module1
+- path: ./module2

--- a/pkg/skaffold/hooks/deploy_test.go
+++ b/pkg/skaffold/hooks/deploy_test.go
@@ -112,3 +112,151 @@ func TestDeployHooks(t *testing.T) {
 		t.CheckContains(postContainerHookOut, postOut.String())
 	})
 }
+
+func TestNewCloudRunDeployRunnerHooksMapping(t *testing.T) {
+	tests := []struct {
+		description   string
+		expectedHooks latest.DeployHooks
+		inputConfig   latest.CloudRunDeployHooks
+	}{
+		{
+			description: "no hooks specified",
+			expectedHooks: latest.DeployHooks{
+				PreHooks:  []latest.DeployHookItem{},
+				PostHooks: []latest.DeployHookItem{},
+			},
+			inputConfig: latest.CloudRunDeployHooks{},
+		},
+		{
+			description: "pre hooks specified",
+			expectedHooks: latest.DeployHooks{
+				PreHooks: []latest.DeployHookItem{
+					{
+						HostHook: &latest.HostHook{
+							Command: []string{"no-real-command-1 arg1 arg2"},
+							OS:      []string{"darwin", "linux"},
+							Dir:     ".",
+						},
+					},
+					{
+						HostHook: &latest.HostHook{
+							Command: []string{"no-real-command-2 arg1 arg2"},
+							OS:      []string{"linux", "darwin"},
+							Dir:     "~/",
+						},
+					},
+				},
+				PostHooks: []latest.DeployHookItem{},
+			},
+			inputConfig: latest.CloudRunDeployHooks{
+				PreHooks: []latest.HostHook{
+					{
+						Command: []string{"no-real-command-1 arg1 arg2"},
+						OS:      []string{"darwin", "linux"},
+						Dir:     ".",
+					},
+					{
+						Command: []string{"no-real-command-2 arg1 arg2"},
+						OS:      []string{"linux", "darwin"},
+						Dir:     "~/",
+					},
+				},
+			},
+		},
+		{
+			description: "post hooks specified",
+			expectedHooks: latest.DeployHooks{
+				PreHooks: []latest.DeployHookItem{},
+				PostHooks: []latest.DeployHookItem{
+					{
+						HostHook: &latest.HostHook{
+							Command: []string{"no-real-command-1 arg1 arg2"},
+							OS:      []string{"darwin", "linux"},
+							Dir:     ".",
+						},
+					},
+					{
+						HostHook: &latest.HostHook{
+							Command: []string{"no-real-command-2 arg1 arg2"},
+							OS:      []string{"linux", "darwin"},
+							Dir:     "~/",
+						},
+					},
+				},
+			},
+			inputConfig: latest.CloudRunDeployHooks{
+				PostHooks: []latest.HostHook{
+					{
+						Command: []string{"no-real-command-1 arg1 arg2"},
+						OS:      []string{"darwin", "linux"},
+						Dir:     ".",
+					},
+					{
+						Command: []string{"no-real-command-2 arg1 arg2"},
+						OS:      []string{"linux", "darwin"},
+						Dir:     "~/",
+					},
+				},
+			},
+		},
+		{
+			description: "post and pre hooks specified",
+			expectedHooks: latest.DeployHooks{
+				PreHooks: []latest.DeployHookItem{
+					{
+						HostHook: &latest.HostHook{
+							Command: []string{"pre-no-real-command-1 arg1 arg2"},
+							OS:      []string{"darwin", "linux"},
+							Dir:     ".",
+						},
+					},
+				},
+				PostHooks: []latest.DeployHookItem{
+					{
+						HostHook: &latest.HostHook{
+							Command: []string{"post-no-real-command-1 arg1 arg2"},
+							OS:      []string{"darwin", "linux"},
+							Dir:     ".",
+						},
+					},
+					{
+						HostHook: &latest.HostHook{
+							Command: []string{"post-no-real-command-2 arg1 arg2"},
+							OS:      []string{"linux", "darwin"},
+							Dir:     "~/",
+						},
+					},
+				},
+			},
+			inputConfig: latest.CloudRunDeployHooks{
+				PreHooks: []latest.HostHook{
+					{
+						Command: []string{"pre-no-real-command-1 arg1 arg2"},
+						OS:      []string{"darwin", "linux"},
+						Dir:     ".",
+					},
+				},
+				PostHooks: []latest.HostHook{
+					{
+						Command: []string{"post-no-real-command-1 arg1 arg2"},
+						OS:      []string{"darwin", "linux"},
+						Dir:     ".",
+					},
+					{
+						Command: []string{"post-no-real-command-2 arg1 arg2"},
+						OS:      []string{"linux", "darwin"},
+						Dir:     "~/",
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			runner, ok := (NewCloudRunDeployRunner(test.inputConfig, DeployEnvOpts{})).(deployRunner)
+			t.CheckTrue(ok)
+			t.CheckDeepEqual(runner.DeployHooks, test.expectedHooks)
+		})
+	}
+}

--- a/pkg/skaffold/runner/deployer.go
+++ b/pkg/skaffold/runner/deployer.go
@@ -335,5 +335,6 @@ func getCloudRunDeployer(runCtx *runcontext.RunContext, labeller *label.DefaultL
 			}
 		}
 	}
-	return cloudrun.NewDeployer(runCtx, labeller, &latest.CloudRunDeploy{Region: region, ProjectID: defaultProject}, configName)
+	currentPipeline := runCtx.Pipelines.GetForConfigName(configName)
+	return cloudrun.NewDeployer(runCtx, labeller, &latest.CloudRunDeploy{Region: region, ProjectID: defaultProject, LifecycleHooks: currentPipeline.Deploy.CloudRunDeploy.LifecycleHooks}, configName)
 }

--- a/pkg/skaffold/runner/deployer.go
+++ b/pkg/skaffold/runner/deployer.go
@@ -335,6 +335,12 @@ func getCloudRunDeployer(runCtx *runcontext.RunContext, labeller *label.DefaultL
 			}
 		}
 	}
-	currentPipeline := runCtx.Pipelines.GetForConfigName(configName)
-	return cloudrun.NewDeployer(runCtx, labeller, &latest.CloudRunDeploy{Region: region, ProjectID: defaultProject, LifecycleHooks: currentPipeline.Deploy.CloudRunDeploy.LifecycleHooks}, configName)
+
+	lifecycleHooks := latest.CloudRunDeployHooks{}
+	if configName != "" {
+		currentPipeline := runCtx.Pipelines.GetForConfigName(configName)
+		lifecycleHooks = currentPipeline.Deploy.CloudRunDeploy.LifecycleHooks
+	}
+
+	return cloudrun.NewDeployer(runCtx, labeller, &latest.CloudRunDeploy{Region: region, ProjectID: defaultProject, LifecycleHooks: lifecycleHooks}, configName)
 }

--- a/pkg/skaffold/runner/deployer_test.go
+++ b/pkg/skaffold/runner/deployer_test.go
@@ -484,7 +484,7 @@ func TestGetCloudRunDeployer(tOuter *testing.T) {
 			cfgs: map[string]latest.DeployType{"": {
 				CloudRunDeploy: &latest.CloudRunDeploy{ProjectID: "test-project", Region: "test-region"},
 			}},
-			expected: &cloudrun.Deployer{Project: "test-project", Region: "test-region"},
+			expected: &cloudrun.Deployer{Project: "test-project", Region: "test-region", CloudRunDeploy: &latest.CloudRunDeploy{ProjectID: "test-project", Region: "test-region"}},
 		},
 		{
 			name: "deploy with two configs and conflicting processes",
@@ -502,7 +502,7 @@ func TestGetCloudRunDeployer(tOuter *testing.T) {
 			cfgs: map[string]latest.DeployType{"": {
 				CloudRunDeploy: &latest.CloudRunDeploy{ProjectID: "test-project", Region: "test-region"},
 			}},
-			expected: &cloudrun.Deployer{Project: "overridden-project", Region: "test-region"},
+			expected: &cloudrun.Deployer{Project: "overridden-project", Region: "test-region", CloudRunDeploy: &latest.CloudRunDeploy{ProjectID: "overridden-project", Region: "test-region"}},
 		},
 	}
 	for _, test := range tests {

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -751,6 +751,9 @@ type CloudRunDeploy struct {
 	// Region GCP location to use for the Cloud Run Deploy.
 	// Must be one of the regions listed in https://cloud.google.com/run/docs/locations.
 	Region string `yaml:"region,omitempty"`
+
+	// LifecycleHooks describes a set of lifecycle host hooks that are executed before and after the Cloud Run deployer.
+	LifecycleHooks CloudRunDeployHooks `yaml:"hooks,omitempty"`
 }
 
 // DockerDeploy uses the `docker` CLI to create application containers in Docker.
@@ -1565,6 +1568,14 @@ type RenderHooks struct {
 	PreHooks []RenderHookItem `yaml:"before,omitempty"`
 	// PostHooks describes the list of lifecycle hooks to execute *after* each render step.
 	PostHooks []RenderHookItem `yaml:"after,omitempty"`
+}
+
+// CloudRunDeployHooks describes the list of lifecycle hooks to execute in the host before and after the Cloud Run deployer.
+type CloudRunDeployHooks struct {
+	// PreHooks describes the list of lifecycle hooks to execute *before* the Cloud Run deployer.
+	PreHooks []HostHook `yaml:"before,omitempty"`
+	// PreHooks describes the list of lifecycle hooks to execute *after* the Cloud Run deployer.
+	PostHooks []HostHook `yaml:"after,omitempty"`
 }
 
 // DeployHookItem describes a single lifecycle hook to execute before or after each deployer step.

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -1574,7 +1574,7 @@ type RenderHooks struct {
 type CloudRunDeployHooks struct {
 	// PreHooks describes the list of lifecycle hooks to execute *before* the Cloud Run deployer.
 	PreHooks []HostHook `yaml:"before,omitempty"`
-	// PreHooks describes the list of lifecycle hooks to execute *after* the Cloud Run deployer.
+	// PostHooks describes the list of lifecycle hooks to execute *after* the Cloud Run deployer.
 	PostHooks []HostHook `yaml:"after,omitempty"`
 }
 


### PR DESCRIPTION
<!-- Include if applicable: -->
Fixes: #7901

**Description**
This PR adds host hooks to Cloud Run deployer. It adds a new configuration property to setup the hooks and the logic to trigger those.

**Follow-up Work (remove if N/A)**
- Document Cloud Run hooks