### PR TITLE
chore: fix doc edit url

### DIFF
--- a/docs-v2/layouts/partials/page-meta-links.html
+++ b/docs-v2/layouts/partials/page-meta-links.html
@@ -2,7 +2,7 @@
 {{ $gh_repo := ($.Param "github_repo") }}
 {{ if $gh_repo }}
 <div class="td-page-meta ml-2 pb-1 pt-2 mb-0">
-{{ $editURL := printf "%s/edit/main/docs/content/%s/%s" $gh_repo ($.Site.Language.Lang) .Path }}
+{{ $editURL := printf "%s/edit/main/docs-v2/content/%s/%s" $gh_repo ($.Site.Language.Lang) .Path }}
 {{ $issuesURL := printf "%s/issues/new?title=%s" $gh_repo (htmlEscape $.Title )}}
 <a href="{{ $editURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>
 <a href="{{ $issuesURL }}" target="_blank"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #8163 <!-- tracking issues that this PR will close -->

 - The doc edit url is pointing to the wrong place, this pr change it to v2-doc
 - we're planing doing a doc folder renaming,  doc -> doc-v1, doc-v2 -> doc
 - depending on the rollout time of the above two steps of doc renaming changes, this pr may not be necessary