### PR TITLE
fix: support alternative env var naming using support env variable + artifact-name (vs env variable + index)

### DIFF
--- a/docs-v2/content/en/docs/pipeline-stages/deployers/helm.md
+++ b/docs-v2/content/en/docs/pipeline-stages/deployers/helm.md
@@ -100,39 +100,40 @@ deploy:
         image2.pullPolicy: "IfNotPresent"
 ```
 
-The `setValues` configuration binds a Helm key to the specified value. The `setValueTemplates` configuration binds a Helm key to an environment variable.  Skaffold generates some environment variables for each build artifact (value in build.artifacts\[x\].image).  Currenty these include:
-- `.<artifactName>.IMAGE_FULLY_QUALIFIED` (ex: `{{.myImage.IMAGE_FULLY_QUALIFIED}})` -> `gcr.io/example-repo/skaffold-helm-image:latest@sha256:<sha256-hash>`
-- `.<artifactName>.IMAGE_REPO` (ex:)
-- `.<artifactName>.IMAGE_TAG`
-- `.<artifactName>.IMAGE_DOMAIN`
-- `.<artifactName>.IMAGE_REPO_NO_DOMAIN`
+The `setValues` configuration binds a Helm key to the specified value. The `setValueTemplates` configuration binds a Helm key to an environment variable.  Skaffold generates useful environment variables (available via `setValueTemplates`) for each build artifact (value in build.artifacts\[x\].image).  Currenty these include:
 
-### Multiple image overrides
+| Helm Template Value | Example Value |
+| --------------- | --------------- |
+| `{{.IMAGE_FULLY_QUALIFIED_<artifact-name>}}` | `gcr.io/example-repo/myImage:latest@sha256:<sha256-hash>`|
+| `{{.IMAGE_REPO_<artifact-name>}}` | `gcr.io/example-repo/myImage` |
+| `{{.IMAGE_TAG_<artifact-name>}}` | `latest` |
+| `{{.IMAGE_DIGEST_<artifact-name>}}` | `sha256:<sha256-hash>` |
+| `{{.IMAGE_DOMAIN_<artifact-name>}}` | `gcr.io` |
+| `{{.IMAGE_REPO_NO_DOMAIN_<artifact-name>}}` | `example-repo` |
 
-To override multiple images (ie a Pod with a side car) you can simply add additional variables. For example, the following helm install:
+### Sanitizing the artifact name from invalid go template characters
+The `<artifact-name>` (eg: `{{.IMAGE_FULLY_QUALIFIED_<artifact-name>}}`) when used with `setValueTemplates` cannot have `/` or `-` characters.  If you have an artifact name with these characters (eg: `localhost/nginx` or `gcr.io/foo-image/foo`), change them to use `_` in place of these characters in the `setValueTemplates` field
 
+| Artifact name | Sanitized Name |
+| --------------- | --------------- |
+| `localhost/nginx` | `localhost_nginx`|
+| `gcr.io/example-repo/myImage` | `gcr.io_example_repo_myImage` |
+
+Example
 ```yaml
-spec:
-  containers:
-    - name: firstContainer
-      image: "{{.Values.firstContainerImage}}"
-      ....
-    - name: secondContainer
-      image: "{{.Values.secondContainerImage}}"
-      ...
-```
-
-can be overriden with:
-
-```yaml
+build:
+  artifacts:
+    - image: localhost/nginx  # must match in setValueTemplates w/ `/` & `-` changed to `_`
 deploy:
   helm:
     releases:
-    - name: my-release
-      setValueTemplates:
-        firstContainerImage: "{{.firstContainer.IMAGE_FULLY_QUALIFIED}}"
-        secondContainerImage: "{{.secondContainerImage.IMAGE_FULLY_QUALIFIED}}"
+      - name: my-chart
+        chartPath: helm
+        setValueTemplates:
+          image: {{.IMAGE_FULLY_QUALIFIED_localhost_nginx}}
+
 ```
+
 
 ### Image reference strategies
 
@@ -158,8 +159,8 @@ deploy:
       - name: my-chart
         chartPath: helm
         setValueTemplates:
-          image: {{.myFirstImage.IMAGE_FULLY_QUALIFIED}} # no tag present!
-          image2: {{.mySecondImage.IMAGE_FULLY_QUALIFIED}} # no tag present!
+          image: {{.IMAGE_FULLY_QUALIFIED_myFirstImage}}
+          image2: {{.IMAGE_FULLY_QUALIFIED_mySecondImage}}
 ```
 The `values.yaml` (note that Skaffold overrides this value):
 ```
@@ -198,10 +199,10 @@ deploy:
       - name: my-chart
         chartPath: helm
         setValueTemplates:
-          image.repository: "{{.myFirstImage.IMAGE_REPO}}"
-          image.tag: "{{.myFirstImage.IMAGE_TAG}}"
-          image2.repository: "{{.mySecondImage.IMAGE_REPO}}"
-          image2.tag: "{{.mySecondImage.IMAGE_TAG}}"
+          image.repository: "{{.IMAGE_REPO_myFirstImage}}"
+          image.tag: "{{.IMAGE_TAG_myFirstImage}}"
+          image2.repository: "{{.IMAGE_REPO_mySecondImage}}"
+          image2.tag: "{{.IMAGE_TAG_mySecondImage}}"
 ```
 
 The `values.yaml` (note that Skaffold overrides these values):
@@ -245,12 +246,12 @@ deploy:
       - name: my-chart
         chartPath: helm
         setValueTemplates:
-          image.registry: "{{.myFirstImage.IMAGE_DOMAIN}}"
-          image.repository: "{{.myFirstImage.IMAGE_REPO_NO_DOMAIN}}"
-          image.tag: "{{.myFirstImage.IMAGE_TAG}}"
-          image2.registry: "{{.mySecondImage.IMAGE_DOMAIN}}"
-          image2.repository: "{{.mySecondImage.IMAGE_REPO_NO_DOMAIN}}"
-          image2.tag: "{{.mySecondImage.IMAGE_TAG}}"
+          image.registry: "{{.IMAGE_DOMAIN_myFirstImage}}"
+          image.repository: "{{.IMAGE_REPO_NO_DOMAIN_myFirstImage}}"
+          image.tag: "{{.IMAGE_TAG_myFirstImage}}"
+          image2.registry: "{{.IMAGE_DOMAIN_mySecondImage}}"
+          image2.repository: "{{.IMAGE_REPO_NO_DOMAIN_mySecondImage}}"
+          image2.tag: "{{.IMAGE_TAG_mySecondImage}}"
 ```
 
 The `values.yaml` (note that Skaffold overrides these values):

--- a/integration/testdata/helm-multi-config/skaffold/app1/skaffold.yml
+++ b/integration/testdata/helm-multi-config/skaffold/app1/skaffold.yml
@@ -15,5 +15,5 @@ manifests:
         createNamespace: true
         name: app1
         setValueTemplates:
-          image.repository: '{{.app1.IMAGE_REPO}}'
-          image.tag: "{{.app1.IMAGE_TAG}}@{{.app1.IMAGE_DIGEST}}"
+          image.repository: '{{.IMAGE_REPO_app1}}'
+          image.tag: "{{.IMAGE_TAG_app1}}@{{.IMAGE_DIGEST_app1}}"

--- a/integration/testdata/helm-multi-config/skaffold/app2/skaffold.yml
+++ b/integration/testdata/helm-multi-config/skaffold/app2/skaffold.yml
@@ -15,5 +15,5 @@ manifests:
         createNamespace: true
         name: app2
         setValueTemplates:
-          image.repository: '{{.app2.IMAGE_REPO}}'
-          image.tag: "{{.app2.IMAGE_TAG}}@{{.app2.IMAGE_DIGEST}}"
+          image.repository: '{{.IMAGE_REPO_app2}}'
+          image.tag: "{{.IMAGE_TAG_app2}}@{{.IMAGE_DIGEST_app2}}"

--- a/pkg/skaffold/helm/args.go
+++ b/pkg/skaffold/helm/args.go
@@ -54,15 +54,14 @@ func ConstructOverrideArgs(r *latest.HelmRelease, builds []graph.Artifact, args 
 	for idx, b := range builds {
 		idxSuffix := ""
 		// replace commonly used image name chars that are illegal helm template chars "/" & "-" with "_"
-		namePrefix := strings.ReplaceAll(strings.ReplaceAll(b.ImageName, "-", "_"), "/", "_")
-
+		nameSuffix := util.SanitizeHelmTemplateValue(b.ImageName)
 		if idx > 0 {
 			idxSuffix = strconv.Itoa(idx + 1)
 		}
 
 		for k, v := range envVarForImage(b.ImageName, b.Tag) {
 			envMap[k+idxSuffix] = v
-			envMap["."+namePrefix+"."+k] = v
+			envMap[k+"_"+nameSuffix] = v
 		}
 	}
 	log.Entry(context.TODO()).Debugf("EnvVarMap: %+v\n", envMap)

--- a/pkg/skaffold/kubernetes/manifest/images.go
+++ b/pkg/skaffold/kubernetes/manifest/images.go
@@ -225,7 +225,7 @@ func (r *imageReplacer) Visit(gk apimachinery.GroupKind, navpath string, o map[s
 	// works by looking for intermediate helm replacement of the form image:
 	// image: <artifactName>/<artifactName>:<artifactName>
 	// and treating that as just <artifact> by modifying the parsed representation.
-	if parsed.Domain != "" && parsed.Domain == parsed.Repo {
+	if parsed != nil && parsed.Domain != "" && parsed.Domain == parsed.Repo {
 		if _, present := r.tagsByImageName[parsed.Repo]; present {
 			parsed.BaseName = parsed.Repo
 		}
@@ -250,6 +250,10 @@ func (r *imageReplacer) Check() {
 type imageSelector func(tagsByImageName map[string]string, image *docker.ImageReference) (imageName, tag string, valid bool)
 
 func selectLocalManifestImages(tagsByImageName map[string]string, image *docker.ImageReference) (string, string, bool) {
+	if image == nil {
+		return "", "", false
+	}
+
 	// Leave images referenced by digest as they are
 	if image.Digest != "" {
 		return "", "", false

--- a/pkg/skaffold/util/util.go
+++ b/pkg/skaffold/util/util.go
@@ -315,3 +315,8 @@ func IsSubPath(basepath string, targetpath string) bool {
 func hasHiddenPrefix(s string) bool {
 	return strings.HasPrefix(s, hiddenPrefix)
 }
+
+func SanitizeHelmTemplateValue(s string) string {
+	// replace commonly used image name chars that are illegal helm template chars "/" & "-" with "_"
+	return strings.ReplaceAll(strings.ReplaceAll(s, "-", "_"), "/", "_")
+}


### PR DESCRIPTION
Some issues in the original PR with the updated naming .\<artifact-name\>.IMAGE_X.  Reverting env naming to working solution: .IMAGE_X_\<artifact-name\>.  Also updated to docs to reflect this change

fixes: https://github.com/GoogleContainerTools/skaffold/issues/7967

fixes: https://github.com/GoogleContainerTools/skaffold/issues/6207

fixes: https://github.com/GoogleContainerTools/skaffold/issues/7989

Manually tested as working using `skaffold-test-repro` which is a repro repo created in https://github.com/GoogleContainerTools/skaffold/issues/7989#issue-1424026513.  Logs showing correctness below:

```
aprindle@aprindle-ssd ~/skaffold-test-repo  [master]$ skaffold dev --default-repo=gcr.io/aprindle-test-cluster
Listing files to watch...
 - localhost/nginx
Generating tags...
 - localhost/nginx -> gcr.io/aprindle-test-cluster/localhost/nginx:2ff8c19-dirty
Checking cache...
 - localhost/nginx: Found Remotely
Tags used in deployment:
 - localhost/nginx -> gcr.io/aprindle-test-cluster/localhost/nginx:2ff8c19-dirty@sha256:5cfa549eefd73aea2f5bd2768d2b3e3a0955092be15eb6620b6c32ea17465f16
Starting deploy...
Helm release test not installed. Installing...
```

```
aprindle@aprindle-ssd ~/skaffold-test-repo  [master]$ kubectl get deployment -n test test-chart -o=jsonpath={.spec.template.spec.containers[0].image}
gcr.io/aprindle-test-cluster/localhost/nginx:2ff8c19-dirty@sha256:5cfa549eefd73aea2f5bd2768d2b3e3a0955092be15eb6620b6c32ea17465f16:1.1aprindle@aprindle-ssd ~/skaffold-test-repo  [master]$ ]$ kubectl  job -n test foo -o=jsonpath={.spec.template.spec.containers[0].image}
gcr.io/aprindle-test-cluster/localhost/nginx:2ff8c19-dirty@sha256:5cfa549eefd73aea2f5bd2768d2b3e3a0955092be15eb6620b6c32ea17465f16:1.16.0
```