### PR TITLE
feat: enable --tag flag in render command

### DIFF
--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -402,7 +402,7 @@ var flagRegistry = []Flag{
 		Value:         &opts.CustomTag,
 		DefValue:      "",
 		FlagAddMethod: "StringVar",
-		DefinedOn:     []string{"build", "debug", "dev", "run", "deploy"},
+		DefinedOn:     []string{"build", "debug", "dev", "run", "deploy", "render"},
 	},
 	{
 		Name:          "platform",

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -1010,6 +1010,7 @@ Options:
       --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
       --resource-selector-rules-file='': Path to JSON file specifying the deny list of yaml objects for skaffold to NOT transform with 'image' and 'label' field replacements.  NOTE: this list is additive to skaffold's default denylist and denylist has priority over allowlist
       --sync-remote-cache='always': Controls how Skaffold manages the remote config cache (see `remote-cache-dir`). One of `always` (default), `missing`, or `never`. `always` syncs remote repositories to latest on access. `missing` only clones remote repositories if they do not exist locally. `never` means the user takes responsibility for updating remote repositories.
+  -t, --tag='': The optional custom tag to use for images which overrides the current Tagger configuration
       --wait-for-connection=false: Blocks ending execution of skaffold until the /v2/events gRPC/HTTP endpoint is hit
 
 Usage:
@@ -1043,6 +1044,7 @@ Env vars:
 * `SKAFFOLD_REMOTE_CACHE_DIR` (same as `--remote-cache-dir`)
 * `SKAFFOLD_RESOURCE_SELECTOR_RULES_FILE` (same as `--resource-selector-rules-file`)
 * `SKAFFOLD_SYNC_REMOTE_CACHE` (same as `--sync-remote-cache`)
+* `SKAFFOLD_TAG` (same as `--tag`)
 * `SKAFFOLD_WAIT_FOR_CONNECTION` (same as `--wait-for-connection`)
 
 ### skaffold run

--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -837,3 +837,59 @@ spec:
 		})
 	}
 }
+
+func TestRenderWithTagFlag(t *testing.T) {
+	MarkIntegrationTest(t, CanRunWithoutGcp)
+
+	tests := []struct {
+		description    string
+		projectDir     string
+		expectedOutput string
+	}{
+		{
+			description: "tag flag in a single module project",
+			projectDir:  "testdata/getting-started",
+			expectedOutput: `apiVersion: v1
+kind: Pod
+metadata:
+  name: getting-started
+  namespace: default
+spec:
+  containers:
+  - image: gcr.io/k8s-skaffold/skaffold-example:customtag
+    name: getting-started
+`,
+		},
+		{
+			description: "tag flag in a multi module project",
+			projectDir:  "testdata/multi-config-pods",
+			expectedOutput: `apiVersion: v1
+kind: Pod
+metadata:
+  name: module1
+  namespace: default
+spec:
+  containers:
+  - image: gcr.io/k8s-skaffold/multi-config-module1:customtag
+    name: module1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: module2
+  namespace: default
+spec:
+  containers:
+  - image: gcr.io/k8s-skaffold/multi-config-module2:customtag
+    name: module2
+`,
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			output := skaffold.Render("--tag", "customtag", "--default-repo", "gcr.io/k8s-skaffold").InDir(test.projectDir).RunOrFailOutput(t.T)
+			t.CheckDeepEqual(string(output), test.expectedOutput)
+		})
+	}
+}


### PR DESCRIPTION
Fixes: #5587

**Description**
Enables the `--tag` flag in the `render` command.