### PR TITLE
feat: new `--auto` flag

### DIFF
--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -434,6 +434,15 @@ var flagRegistry = []Flag{
 		IsEnum:        true,
 	},
 	{
+		Name:          "auto",
+		Usage:         "Run with an auto-generated skaffold configuration. This will create a temporary `skaffold.yaml` file and kubernetes manifests necessary to run the application",
+		Value:         &opts.AutoInit,
+		DefValue:      false,
+		FlagAddMethod: "BoolVar",
+		DefinedOn:     []string{"debug", "dev", "run"},
+		IsEnum:        true,
+	},
+	{
 		Name:          "propagate-profiles",
 		Usage:         "Setting '--propagate-profiles=false' disables propagating profiles set by the '--profile' flag across config dependencies. This mean that only profiles defined directly in the target 'skaffold.yaml' file are activated.",
 		Value:         &opts.PropagateProfiles,

--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -112,9 +112,9 @@ func withFallbackConfig(ctx context.Context, out io.Writer, opts config.Skaffold
 	}
 	var e sErrors.Error
 	if errors.As(err, &e) && e.StatusCode() == proto.StatusCode_CONFIG_FILE_NOT_FOUND_ERR {
-		if opts.AutoCreateConfig && initializer.ValidCmd(opts) {
+		if (opts.AutoCreateConfig || opts.AutoInit) && initializer.ValidCmd(opts) {
 			output.Default.Fprintf(out, "Skaffold config file %s not found - Trying to create one for you...\n", opts.ConfigurationFile)
-			config, err := initializer.Transparent(context.Background(), out, initConfig.Config{Opts: opts})
+			config, err := initializer.Transparent(context.Background(), out, initConfig.Config{Opts: opts, EnableManifestGeneration: opts.AutoInit})
 			if err != nil {
 				return nil, fmt.Errorf("unable to generate skaffold config file automatically - try running `skaffold init`: %w", err)
 			}

--- a/docs-v1/content/en/docs/references/cli/_index.md
+++ b/docs-v1/content/en/docs/references/cli/_index.md
@@ -411,6 +411,7 @@ Examples:
 
 Options:
       --assume-yes=false: If true, skaffold will skip yes/no confirmation from the user and default to yes
+      --auto=false: Run with an auto-generated skaffold configuration. This will create a temporary `skaffold.yaml` file and kubernetes manifests necessary to run the application
       --auto-build=false: When set to false, builds wait for API request instead of running automatically
       --auto-create-config=true: If true, skaffold will try to create a config for the user's run if it doesn't find one
       --auto-deploy=false: When set to false, deploys wait for API request instead of running automatically
@@ -475,6 +476,7 @@ Use "skaffold options" for a list of global command-line options (applies to all
 Env vars:
 
 * `SKAFFOLD_ASSUME_YES` (same as `--assume-yes`)
+* `SKAFFOLD_AUTO` (same as `--auto`)
 * `SKAFFOLD_AUTO_BUILD` (same as `--auto-build`)
 * `SKAFFOLD_AUTO_CREATE_CONFIG` (same as `--auto-create-config`)
 * `SKAFFOLD_AUTO_DEPLOY` (same as `--auto-deploy`)
@@ -713,6 +715,7 @@ Run a pipeline in development mode
 
 Options:
       --assume-yes=false: If true, skaffold will skip yes/no confirmation from the user and default to yes
+      --auto=false: Run with an auto-generated skaffold configuration. This will create a temporary `skaffold.yaml` file and kubernetes manifests necessary to run the application
       --auto-build=true: When set to false, builds wait for API request instead of running automatically
       --auto-create-config=true: If true, skaffold will try to create a config for the user's run if it doesn't find one
       --auto-deploy=true: When set to false, deploys wait for API request instead of running automatically
@@ -777,6 +780,7 @@ Use "skaffold options" for a list of global command-line options (applies to all
 Env vars:
 
 * `SKAFFOLD_ASSUME_YES` (same as `--assume-yes`)
+* `SKAFFOLD_AUTO` (same as `--auto`)
 * `SKAFFOLD_AUTO_BUILD` (same as `--auto-build`)
 * `SKAFFOLD_AUTO_CREATE_CONFIG` (same as `--auto-create-config`)
 * `SKAFFOLD_AUTO_DEPLOY` (same as `--auto-deploy`)
@@ -1085,6 +1089,7 @@ Examples:
 
 Options:
       --assume-yes=false: If true, skaffold will skip yes/no confirmation from the user and default to yes
+      --auto=false: Run with an auto-generated skaffold configuration. This will create a temporary `skaffold.yaml` file and kubernetes manifests necessary to run the application
       --auto-create-config=true: If true, skaffold will try to create a config for the user's run if it doesn't find one
       --build-concurrency=-1: Number of concurrently running builds. Set to 0 to run all builds in parallel. Doesn't violate build order among dependencies.
   -b, --build-image=[]: Only build artifacts with image names that contain the given substring. Default is to build sources for all artifacts
@@ -1144,6 +1149,7 @@ Use "skaffold options" for a list of global command-line options (applies to all
 Env vars:
 
 * `SKAFFOLD_ASSUME_YES` (same as `--assume-yes`)
+* `SKAFFOLD_AUTO` (same as `--auto`)
 * `SKAFFOLD_AUTO_CREATE_CONFIG` (same as `--auto-create-config`)
 * `SKAFFOLD_BUILD_CONCURRENCY` (same as `--build-concurrency`)
 * `SKAFFOLD_BUILD_IMAGE` (same as `--build-image`)

--- a/docs-v2/content/en/docs/references/cli/_index.md
+++ b/docs-v2/content/en/docs/references/cli/_index.md
@@ -411,6 +411,7 @@ Examples:
 
 Options:
       --assume-yes=false: If true, skaffold will skip yes/no confirmation from the user and default to yes
+      --auto=false: Run with an auto-generated skaffold configuration. This will create a temporary `skaffold.yaml` file and kubernetes manifests necessary to run the application
       --auto-build=false: When set to false, builds wait for API request instead of running automatically
       --auto-create-config=true: If true, skaffold will try to create a config for the user's run if it doesn't find one
       --auto-deploy=false: When set to false, deploys wait for API request instead of running automatically
@@ -475,6 +476,7 @@ Use "skaffold options" for a list of global command-line options (applies to all
 Env vars:
 
 * `SKAFFOLD_ASSUME_YES` (same as `--assume-yes`)
+* `SKAFFOLD_AUTO` (same as `--auto`)
 * `SKAFFOLD_AUTO_BUILD` (same as `--auto-build`)
 * `SKAFFOLD_AUTO_CREATE_CONFIG` (same as `--auto-create-config`)
 * `SKAFFOLD_AUTO_DEPLOY` (same as `--auto-deploy`)
@@ -713,6 +715,7 @@ Run a pipeline in development mode
 
 Options:
       --assume-yes=false: If true, skaffold will skip yes/no confirmation from the user and default to yes
+      --auto=false: Run with an auto-generated skaffold configuration. This will create a temporary `skaffold.yaml` file and kubernetes manifests necessary to run the application
       --auto-build=true: When set to false, builds wait for API request instead of running automatically
       --auto-create-config=true: If true, skaffold will try to create a config for the user's run if it doesn't find one
       --auto-deploy=true: When set to false, deploys wait for API request instead of running automatically
@@ -777,6 +780,7 @@ Use "skaffold options" for a list of global command-line options (applies to all
 Env vars:
 
 * `SKAFFOLD_ASSUME_YES` (same as `--assume-yes`)
+* `SKAFFOLD_AUTO` (same as `--auto`)
 * `SKAFFOLD_AUTO_BUILD` (same as `--auto-build`)
 * `SKAFFOLD_AUTO_CREATE_CONFIG` (same as `--auto-create-config`)
 * `SKAFFOLD_AUTO_DEPLOY` (same as `--auto-deploy`)
@@ -1085,6 +1089,7 @@ Examples:
 
 Options:
       --assume-yes=false: If true, skaffold will skip yes/no confirmation from the user and default to yes
+      --auto=false: Run with an auto-generated skaffold configuration. This will create a temporary `skaffold.yaml` file and kubernetes manifests necessary to run the application
       --auto-create-config=true: If true, skaffold will try to create a config for the user's run if it doesn't find one
       --build-concurrency=-1: Number of concurrently running builds. Set to 0 to run all builds in parallel. Doesn't violate build order among dependencies.
   -b, --build-image=[]: Only build artifacts with image names that contain the given substring. Default is to build sources for all artifacts
@@ -1144,6 +1149,7 @@ Use "skaffold options" for a list of global command-line options (applies to all
 Env vars:
 
 * `SKAFFOLD_ASSUME_YES` (same as `--assume-yes`)
+* `SKAFFOLD_AUTO` (same as `--auto`)
 * `SKAFFOLD_AUTO_CREATE_CONFIG` (same as `--auto-create-config`)
 * `SKAFFOLD_BUILD_CONCURRENCY` (same as `--build-concurrency`)
 * `SKAFFOLD_BUILD_IMAGE` (same as `--build-image`)

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -59,6 +59,7 @@ type SkaffoldOptions struct {
 	SkipConfigDefaults          bool
 	Tail                        bool
 	WaitForConnection           bool
+	AutoInit                    bool
 	EnablePlatformNodeAffinity  bool
 	EnableGKEARMNodeToleration  bool
 	DisableMultiPlatformBuild   bool

--- a/pkg/skaffold/initializer/init.go
+++ b/pkg/skaffold/initializer/init.go
@@ -121,7 +121,7 @@ func WriteData(out io.Writer, c config.Config, newConfig *latest.SkaffoldConfig,
 		return nil
 	}
 
-	if !c.Force {
+	if !c.Force && !c.Opts.AutoInit {
 		if done, err := prompt.WriteSkaffoldConfig(out, pipeline, newManifests, c.Opts.ConfigurationFile); done {
 			return err
 		}
@@ -132,6 +132,10 @@ func WriteData(out io.Writer, c config.Config, newConfig *latest.SkaffoldConfig,
 			return fmt.Errorf("writing k8s manifest to file: %w", err)
 		}
 		fmt.Fprintf(out, "Generated manifest %s was written\n", path)
+	}
+
+	if c.Opts.AutoInit {
+		return nil
 	}
 
 	if err = os.WriteFile(c.Opts.ConfigurationFile, pipeline, 0644); err != nil {

--- a/pkg/skaffold/initializer/transparent.go
+++ b/pkg/skaffold/initializer/transparent.go
@@ -55,7 +55,7 @@ func Transparent(ctx context.Context, out io.Writer, c initConfig.Config) (*late
 	}
 
 	// Prompt the user with information about what will happen if they continue with this config.
-	if !c.Opts.AssumeYes {
+	if !c.Opts.AssumeYes && !c.Opts.AutoInit {
 		if done, err := confirmInitOptions(out, newConfig); done {
 			return nil, err
 		}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #6568 <!-- tracking issues that this PR will close -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
This PR creates a new flag `--auto` that enables:
- Creating a `skaffold.yaml` configuration that isn't persisted
- running `init` with generating kubernetes manifests if they don't exist

This lets us run `skaffold dev --auto` on any application without requiring more convoluted group of flags.

**Testing instructions**
- Download any sample Cloud Run app (like [here](https://github.com/GoogleCloudPlatform/cloud-code-samples))
- Run `skaffold dev --auto`
- Should see the output with build and deploy against a generated kubernetes manifest.
  ```
  ❯ skaffold dev --auto
  Skaffold config file skaffold.yaml not found - Trying to create one for you...
  Generated manifest deployment.yaml was written
  Listing files to watch...
  - dockerfile-image
  ...
  Starting build...
  Found [minikube] context, using local docker daemon.
  Building [dockerfile-image]...
  Target platforms: [linux/arm64]
  ...
  Starting deploy...
   - service/dockerfile-image created
   - deployment.apps/dockerfile-image created
  Waiting for deployments to stabilize...
   - deployment/dockerfile-image is ready.
  Deployments stabilized in 2.095 seconds
  Port forwarding service/dockerfile-image in namespace default, remote port 8080 -> http://127.0.0.1:8080
  ```