### PR TITLE
feat: changing messages when no artifacts are detected

### DIFF
--- a/pkg/skaffold/build/cache/retrieve.go
+++ b/pkg/skaffold/build/cache/retrieve.go
@@ -43,7 +43,10 @@ func (c *cache) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, ar
 
 	start := time.Now()
 
-	output.Default.Fprintln(out, "Checking cache...")
+	if len(artifacts) > 0 {
+		output.Default.Fprintln(out, "Checking cache...")
+	}
+
 	ctx, endTrace := instrumentation.StartTrace(ctx, "Build_CheckBuildCache")
 	defer endTrace()
 

--- a/pkg/skaffold/runner/build.go
+++ b/pkg/skaffold/runner/build.go
@@ -161,7 +161,12 @@ func (r *Builder) ApplyDefaultRepo(tag string) (string, error) {
 func (r *Builder) imageTags(ctx context.Context, out io.Writer, artifacts []*latest.Artifact) (tag.ImageTags, error) {
 	start := time.Now()
 	maxWorkers := runtime.GOMAXPROCS(0)
-	output.Default.Fprintln(out, "Generating tags...")
+
+	if len(artifacts) > 0 {
+		output.Default.Fprintln(out, "Generating tags...")
+	} else {
+		output.Default.Fprintln(out, "No tags generated")
+	}
 
 	tagErrs := make([]chan tagErr, len(artifacts))
 

--- a/pkg/skaffold/runner/deploy.go
+++ b/pkg/skaffold/runner/deploy.go
@@ -68,7 +68,9 @@ func (r *SkaffoldRunner) Deploy(ctx context.Context, out io.Writer, artifacts []
 
 	out, ctx = output.WithEventContext(ctx, out, constants.Deploy, constants.SubtaskIDNone)
 
-	output.Default.Fprintln(out, "Tags used in deployment:")
+	if len(artifacts) > 0 {
+		output.Default.Fprintln(out, "Tags used in deployment:")
+	}
 
 	for _, artifact := range artifacts {
 		output.Default.Fprintf(out, " - %s -> ", artifact.ImageName)

--- a/pkg/skaffold/runner/dev.go
+++ b/pkg/skaffold/runner/dev.go
@@ -227,7 +227,12 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*la
 	g := getTransposeGraph(artifacts)
 	// Watch artifacts
 	start := time.Now()
-	output.Default.Fprintln(out, "Listing files to watch...")
+
+	if len(artifacts) > 0 {
+		output.Default.Fprintln(out, "Listing files to watch...")
+	} else {
+		output.Default.Fprintln(out, "No artifacts found to watch")
+	}
 
 	for i := range artifacts {
 		artifact := artifacts[i]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #5624

**Description**
This PR changes the messages in the command line when skaffold is used without artifacts to build. So, for the following skaffold configuration without build stanza:

```
apiVersion: skaffold/v4beta1
kind: Config
# build:
#   artifacts:
#   - image: skaffold-example
manifests:
  rawYaml:
  - k8s-pod.yaml
```

With the following k8s pod:
```
apiVersion: v1
kind: Pod
metadata:
  name: getting-started
spec:
  containers:
  - name: getting-started
    image: gcr.io/k8s-skaffold/skaffold-example:latest
````

The following messages will appear:
```
No artifacts found to watch
No tags generated
Starting deploy...
 - pod/getting-started created
Waiting for deployments to stabilize...
 - pods is ready.
Deployments stabilized in 4.166 seconds
...
```

If the image used in the k8s pod can't be pulled, the following output will appear:
```
No artifacts found to watch
No tags generated
Starting deploy...
 - pod/getting-started created
Waiting for deployments to stabilize...
 - pods: container getting-started is waiting to start: skaffold-example can't be pulled
    - pod/getting-started: container getting-started is waiting to start: skaffold-example can't be pulled
 - pods failed. Error: container getting-started is waiting to start: skaffold-example can't be pulled.
Cleaning up...
 - pod "getting-started" deleted
1/1 deployment(s) failed
```