### PR TITLE
chore: Revert re-enable TestBuildKanikoInsecureRegistry gcp test 

### DIFF
--- a/integration/build_cluster_test.go
+++ b/integration/build_cluster_test.go
@@ -33,6 +33,9 @@ import (
 
 // run on GCP as this test requires a load balancer
 func TestBuildKanikoInsecureRegistry(t *testing.T) {
+	// TODO: This test shall pass once render v2 is completed.
+	t.SkipNow()
+
 	MarkIntegrationTest(t, NeedsGcp)
 
 	ns, client := SetupNamespace(t)


### PR DESCRIPTION


This reverts commit 360977173ae7cb3191d36e41f5eb6cc52ac3997c. due to flakyness

<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #nnn <!-- tracking issues that this PR will close -->
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->

**Follow-up Work (remove if N/A)**
<!-- Mention any related follow up work to this PR. -->


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
