### PR TITLE
fix: expand namespace with env variables

### DIFF
--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -582,3 +582,32 @@ func TestRunNoOptFlags(t *testing.T) {
 		WaitForLogs(t, out, test.targetLog)
 	})
 }
+
+func TestRunKubectlDefaultNamespace(t *testing.T) {
+	tests := []struct {
+		description       string
+		namespaceToCreate string
+		projectDir        string
+		podName           string
+		envVariable       string
+	}{
+		{
+			description:       "run with defaultNamespace when namespace exists in cluster",
+			namespaceToCreate: "namespace-test",
+			projectDir:        "testdata/kubectl-with-default-namespace",
+			podName:           "getting-started",
+			envVariable:       "ENV1",
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			MarkIntegrationTest(t.T, CanRunWithoutGcp)
+			ns, client := SetupNamespace(t.T)
+			t.SetEnvs(map[string]string{test.envVariable: ns.Name})
+			skaffold.Run().InDir(test.projectDir).RunOrFail(t.T)
+			pod := client.GetPod(test.podName)
+			t.CheckNotNil(pod)
+		})
+	}
+}

--- a/integration/testdata/kubectl-with-default-namespace/Dockerfile
+++ b/integration/testdata/kubectl-with-default-namespace/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.18 as builder
+WORKDIR /code
+COPY main.go .
+COPY go.mod .
+# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
+ARG SKAFFOLD_GO_GCFLAGS
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app main.go
+
+FROM alpine:3
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
+CMD ["./app"]
+COPY --from=builder /app .

--- a/integration/testdata/kubectl-with-default-namespace/go.mod
+++ b/integration/testdata/kubectl-with-default-namespace/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/examples/cross-platform-builds
+
+go 1.18

--- a/integration/testdata/kubectl-with-default-namespace/k8s-pod.yaml
+++ b/integration/testdata/kubectl-with-default-namespace/k8s-pod.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: getting-started
+spec:
+  containers:
+  - name: getting-started
+    image: skaffold-example

--- a/integration/testdata/kubectl-with-default-namespace/main.go
+++ b/integration/testdata/kubectl-with-default-namespace/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+	"time"
+)
+
+func main() {
+	for {
+		fmt.Printf("Hello world! Running on %s/%s\n", runtime.GOOS, runtime.GOARCH)
+
+		time.Sleep(time.Second * 1)
+	}
+}

--- a/integration/testdata/kubectl-with-default-namespace/skaffold.yaml
+++ b/integration/testdata/kubectl-with-default-namespace/skaffold.yaml
@@ -1,0 +1,17 @@
+apiVersion: skaffold/v4beta1
+kind: Config
+
+build:  
+  artifacts:
+  - image: skaffold-example
+    context: .
+    docker:
+      dockerfile: Dockerfile
+
+manifests:
+  rawYaml:
+  - k8s-*
+
+deploy:
+  kubectl:
+    defaultNamespace: "{{.ENV1}}"

--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -271,6 +271,11 @@ func (rc *RunContext) GetNamespace() string {
 		}
 	}
 	if defaultNamespace != "" {
+		defaultNamespace, err := util.ExpandEnvTemplate(defaultNamespace, nil)
+		if err != nil {
+			return ""
+		}
+
 		return defaultNamespace
 	}
 	b, err := (&util.Commander{}).RunCmdOut(context.Background(), exec.Command("kubectl", "config", "view", "--minify", "-o", "jsonpath='{..namespace}'"))


### PR DESCRIPTION
Fixes: #8183

**Description**
Now, before returning the namespace from the runcontext, we replace the env variables if any is present.