### PR TITLE
fix: validate whether kubeContext is blank or not

### DIFF
--- a/pkg/skaffold/kubectl/cli.go
+++ b/pkg/skaffold/kubectl/cli.go
@@ -113,7 +113,10 @@ func (c *CLI) Kustomize(ctx context.Context, args []string) ([]byte, error) {
 // args builds an argument list for calling kubectl and consistently
 // adds the `--context` and `--namespace` flags.
 func (c *CLI) args(command string, namespace string, arg ...string) []string {
-	args := []string{"--context", c.KubeContext}
+	args := []string{}
+	if c.KubeContext != "" {
+		args = append(args, "--context", c.KubeContext)
+	}
 	namespace = c.resolveNamespace(namespace)
 	if namespace != "" {
 		args = append(args, "--namespace", namespace)


### PR DESCRIPTION
Fixes: #8225 

**Description**
When skaffold tries to use In-Cluster Config inside Pod instead of kubeConfig, `KubeContext` becomes blank character. I Added validation for kubeContext and `--context` option for kubectl command is omitted when `KubeContext` is blank character.

Please review it. Thanks a lot in advance.