### PR TITLE
Allow skipping namespace hydration on render

### DIFF
--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -116,6 +116,15 @@ var flagRegistry = []Flag{
 		DefinedOn:     []string{"dev", "run", "debug", "deploy", "render", "build", "delete", "apply"},
 	},
 	{
+		Name:          "set-namespace",
+		Usage:         "Set the namespace in the kubernetes manifest files.",
+		Value:         &opts.SetNamespace,
+		DefValue:      true,
+		FlagAddMethod: "BoolVar",
+		DefinedOn:     []string{"render"},
+		IsEnum:        true,
+	},
+	{
 		Name:          "default-repo",
 		Shorthand:     "d",
 		Usage:         "Default repository value (overrides global config)",

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -55,6 +55,7 @@ type SkaffoldOptions struct {
 	ProfileAutoActivation       bool
 	PropagateProfiles           bool
 	RenderOnly                  bool
+	SetNamespace                bool
 	SkipTests                   bool
 	SkipConfigDefaults          bool
 	Tail                        bool

--- a/pkg/skaffold/deploy/kubectl/cli.go
+++ b/pkg/skaffold/deploy/kubectl/cli.go
@@ -58,6 +58,7 @@ type Config interface {
 	Mode() config.RunMode
 	HydratedManifests() []string
 	GetNamespace() string
+	ShouldSetNamespace() bool
 	DefaultPipeline() latest.Pipeline
 	Tail() bool
 	PipelineForImage(imageName string) (latest.Pipeline, bool)

--- a/pkg/skaffold/render/config.go
+++ b/pkg/skaffold/render/config.go
@@ -33,6 +33,7 @@ type Config interface {
 	Mode() config.RunMode
 	EnablePlatformNodeAffinityInRenderedManifests() bool
 	EnableGKEARMNodeTolerationInRenderedManifests() bool
+	ShouldSetNamespace() bool
 }
 
 type MockConfig struct {
@@ -51,3 +52,4 @@ func (mc MockConfig) Mode() config.RunMode                                { retu
 func (mc MockConfig) EnablePlatformNodeAffinityInRenderedManifests() bool { return true }
 func (mc MockConfig) EnableGKEARMNodeTolerationInRenderedManifests() bool { return true }
 func (mc MockConfig) GetNamespace() string                                { return mc.Namespace }
+func (mc MockConfig) ShouldSetNamespace() bool                            { return true }

--- a/pkg/skaffold/render/renderer/kpt/kpt.go
+++ b/pkg/skaffold/render/renderer/kpt/kpt.go
@@ -163,6 +163,7 @@ func (r *Kpt) Render(ctx context.Context, out io.Writer, builds []graph.Artifact
 		EnableGKEARMNodeToleration: r.cfg.EnableGKEARMNodeTolerationInRenderedManifests(),
 		Offline:                    offline,
 		KubeContext:                r.cfg.GetKubeContext(),
+		SetNamespace:               r.cfg.ShouldSetNamespace(),
 	}
 	manifests, errH := rUtil.GenerateHydratedManifests(ctx, out, builds, r.Generator, r.labels, r.namespace, opts)
 	if errH != nil {

--- a/pkg/skaffold/render/renderer/kubectl/kubectl.go
+++ b/pkg/skaffold/render/renderer/kubectl/kubectl.go
@@ -76,6 +76,7 @@ func (r Kubectl) Render(ctx context.Context, out io.Writer, builds []graph.Artif
 		EnableGKEARMNodeToleration: r.cfg.EnableGKEARMNodeTolerationInRenderedManifests(),
 		Offline:                    offline,
 		KubeContext:                r.cfg.GetKubeContext(),
+		SetNamespace:               r.cfg.ShouldSetNamespace(),
 	}
 	manifests, err := util.GenerateHydratedManifests(ctx, out, builds, r.Generator, r.labels, r.namespace, opts)
 	endTrace()

--- a/pkg/skaffold/render/renderer/util/util.go
+++ b/pkg/skaffold/render/renderer/util/util.go
@@ -40,6 +40,7 @@ type GenerateHydratedManifestsOptions struct {
 	EnableGKEARMNodeToleration bool
 	Offline                    bool
 	KubeContext                string
+	SetNamespace               bool
 }
 
 func GenerateHydratedManifests(ctx context.Context, out io.Writer, builds []graph.Artifact, g generate.Generator, labels map[string]string, ns string, opts GenerateHydratedManifestsOptions) (manifest.ManifestList, error) {
@@ -64,8 +65,10 @@ func GenerateHydratedManifests(ctx context.Context, out io.Writer, builds []grap
 		return nil, err
 	}
 
-	if manifests, err = manifests.SetNamespace(ns, rs); err != nil {
-		return nil, err
+	if opts.SetNamespace {
+		if manifests, err = manifests.SetNamespace(ns, rs); err != nil {
+			return nil, err
+		}
 	}
 	endTrace()
 

--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -284,6 +284,7 @@ func (rc *RunContext) GetNamespace() string {
 	}
 	return strings.Trim(string(b), "'")
 }
+func (rc *RunContext) ShouldSetNamespace() bool                      { return rc.Opts.SetNamespace }
 func (rc *RunContext) AutoBuild() bool                               { return rc.Opts.AutoBuild }
 func (rc *RunContext) DisableMultiPlatformBuild() bool               { return rc.Opts.DisableMultiPlatformBuild }
 func (rc *RunContext) CheckClusterNodePlatforms() bool               { return rc.Opts.CheckClusterNodePlatforms }


### PR DESCRIPTION
Fixes: #8233

**Description**
As per the original issue, this PR adds a `--set-namespace` flag to `render` that defaults to `true` (old behavior) but allows skipping namespace hydration.
