### PR TITLE
feat: always override `skaffold.dev/run-id` label and allow setting it via `--label` flag

### DIFF
--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -230,7 +230,7 @@ var flagRegistry = []Flag{
 		Value:         &opts.CustomLabels,
 		DefValue:      []string{},
 		FlagAddMethod: "StringSliceVar",
-		DefinedOn:     []string{"dev", "run", "debug", "deploy", "render", "filter"},
+		DefinedOn:     []string{"dev", "run", "debug", "deploy", "render", "filter", "apply"},
 	},
 	{
 		Name:          "toot",

--- a/docs-v2/content/en/docs/references/cli/_index.md
+++ b/docs-v2/content/en/docs/references/cli/_index.md
@@ -130,6 +130,7 @@ Options:
       --iterative-status-check=false: Run `status-check` iteratively after each deploy step, instead of all-together at the end of all deploys (default).
       --kube-context='': Deploy to this Kubernetes context
       --kubeconfig='': Path to the kubeconfig file to use for CLI requests.
+  -l, --label=[]: Add custom labels to deployed objects. Set multiple times for multiple labels
   -m, --module=[]: Filter Skaffold configs to only the provided named modules
   -n, --namespace='': Runs deployments in the specified namespace. When used with 'render' command, renders manifests contain the namespace
   -p, --profile=[]: Activate profiles by name (prefixed with `-` to disable a profile)
@@ -160,6 +161,7 @@ Env vars:
 * `SKAFFOLD_ITERATIVE_STATUS_CHECK` (same as `--iterative-status-check`)
 * `SKAFFOLD_KUBE_CONTEXT` (same as `--kube-context`)
 * `SKAFFOLD_KUBECONFIG` (same as `--kubeconfig`)
+* `SKAFFOLD_LABEL` (same as `--label`)
 * `SKAFFOLD_MODULE` (same as `--module`)
 * `SKAFFOLD_NAMESPACE` (same as `--namespace`)
 * `SKAFFOLD_PROFILE` (same as `--profile`)

--- a/pkg/skaffold/kubernetes/manifest/labels.go
+++ b/pkg/skaffold/kubernetes/manifest/labels.go
@@ -158,8 +158,10 @@ func (r *labelsSetter) Visit(gk apimachinery.GroupKind, navpath string, o map[st
 		return true
 	}
 	for k, v := range r.labels {
-		// Don't overwrite existing labels
-		if _, present := labels[k]; !present {
+		_, present := labels[k]
+		if !present { // Don't overwrite existing labels
+			labels[k] = v
+		} else if k == "skaffold.dev/run-id" { // Always override skaffold run-id
 			labels[k] = v
 		}
 	}

--- a/pkg/skaffold/kubernetes/manifest/labels_test.go
+++ b/pkg/skaffold/kubernetes/manifest/labels_test.go
@@ -197,3 +197,37 @@ spec:
 
 	testutil.CheckErrorAndDeepEqual(t, false, err, expected.String(), resultManifest.String())
 }
+
+func TestAlwaysSetRunIDLabel(t *testing.T) {
+	manifests := ManifestList{[]byte(`
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    skaffold.dev/run-id: foo
+  name: getting-started
+spec:
+  containers:
+  - image: gcr.io/k8s-skaffold/example
+    name: example
+`)}
+
+	expected := ManifestList{[]byte(`
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    skaffold.dev/run-id: bar
+  name: getting-started
+spec:
+  containers:
+  - image: gcr.io/k8s-skaffold/example
+    name: example
+`)}
+
+	resultManifest, err := manifests.SetLabels(map[string]string{
+		"skaffold.dev/run-id": "bar",
+	}, NewResourceSelectorLabels(TransformAllowlist, TransformDenylist))
+
+	testutil.CheckErrorAndDeepEqual(t, false, err, expected.String(), resultManifest.String())
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #5966 <!-- tracking issues that this PR will close -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Manually specifying the `skaffold.dev/run-id` label in any deployment manifest causes the status-checker from omitting that resource from being monitored.

The `skaffold.dev/run-id` label is a reserved label and shouldn't be manually set by the user in the kubernetes manifests directly. However, making that an error case will not be backwards-compatible for users that do not care about this behavior. This PR mandates that this label is always overwritten with the current skaffold session run-id so that all the monitors work correctly. Additionally the flag `--label` is enabled for the `skaffold apply` command so that it can be set that way
```
skaffold apply --label skaffold.dev/run-id=blah
```
