### PR TITLE
fix: scanning ignored files in dev session

### DIFF
--- a/pkg/skaffold/docker/dependencies.go
+++ b/pkg/skaffold/docker/dependencies.go
@@ -252,16 +252,14 @@ func WalkWorkspace(workspace string, excludes, deps []string) (map[string]bool, 
 		absFrom := filepath.Join(workspace, dep)
 
 		keepFile := func(path string, info walk.Dirent) (bool, error) {
-			// Ignore non empty dirs
-			if info.IsDir() && !util.IsEmptyDir(path) {
-				return false, nil
+			if info.IsDir() && path == absFrom {
+				return true, nil
 			}
 
 			ignored, err := dockerIgnored(path, info)
 			if err != nil {
 				return false, err
 			}
-
 			return !ignored, nil
 		}
 
@@ -270,8 +268,10 @@ func WalkWorkspace(workspace string, excludes, deps []string) (map[string]bool, 
 			if err != nil {
 				return err
 			}
+			if util.IsEmptyDir(path) || !info.IsDir() {
+				files[relPath] = true
+			}
 
-			files[relPath] = true
 			return nil
 		}); err != nil {
 			return nil, fmt.Errorf("walking %q: %w", absFrom, err)

--- a/pkg/skaffold/docker/syncmap.go
+++ b/pkg/skaffold/docker/syncmap.go
@@ -77,11 +77,13 @@ func walkWorkspaceWithDestinations(workspace string, excludes []string, fts []Fr
 		switch mode := fi.Mode(); {
 		case mode.IsDir():
 			keepFile := func(path string, info walk.Dirent) (bool, error) {
-				// Ignore non empty dirs
-				if info.IsDir() && !util.IsEmptyDir(path) {
-					return false, nil
+				if info.IsDir() && path == absFrom {
+					return true, nil
 				}
 
+				if util.IsEmptyDir(path) {
+					return true, nil
+				}
 				ignored, err := dockerIgnored(path, info)
 				if err != nil {
 					return false, err

--- a/pkg/skaffold/walk/walk.go
+++ b/pkg/skaffold/walk/walk.go
@@ -116,6 +116,12 @@ func (w *builder) CollectPathsGrouped(depth int) (map[string][]string, error) {
 	return m, err
 }
 
+// Do traverses w.dir and performs actions. The predicate method in the builder returns a bool and an error,
+// if it returns any error, the action will not be performed when visiting the target entry and the entry's children
+// directories will be skipped. If the predicate returns false and nil, the action will not be performed on
+// the visiting entry, but the walk method will continue to visit its children directories. If the predicate
+// returns true and nil, the action will be performed when visiting the target entry and its children directories
+// will be visited as well.
 func (w *builder) Do(action Action) error {
 	info, err := os.Lstat(w.dir)
 	if err != nil {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #8166 <!-- tracking issues that this PR will close -->
**Related**: #6851


**Description**
 - This fixes skaffold dev slow session start and syncing files due to skaffold scans ignored files. 
 - The root cause is that WalkWorkspace method traverses docker ignored folder which can contain too many files even the method is not performing actions on the unintended traversal result,  too many system calls for querying files can be very time consuming.  All the unnecessary visiting ignored folder should be avoided. 
 - The keepfile method was not properly updated when adding support for copying empty folder to docker, that's probably because the behavior of walk.Do is not obvious, so I added description for that method.

**Test Plan**
 - in example/nodejs project do the followings
    - create a folder under backend dir, you can name it as ``test_folder``
    - Inside the folder, run ``touch ab{1..50000}`` , ``touch abc{1..50000}`` , ``touch azz{1..50000}`` to generate files
    - edit backend/.dockerignore file to include ``test_folder``
    - run ``skaffold dev`` in the project root folder.  The dev session should start very quick and update a file to test syncing it should be fast as well. 
    - if you do the same without this change, dev session start and syncing will be slow

