### PR TITLE
test: use `T.Setenv` to set env vars in tests

### DIFF
--- a/cmd/skaffold/app/skaffold_test.go
+++ b/cmd/skaffold/app/skaffold_test.go
@@ -61,7 +61,7 @@ func TestSkaffoldCmdline_MainHelp(t *testing.T) {
 			errOutput bytes.Buffer
 		)
 
-		t.SetEnvs(map[string]string{"SKAFFOLD_CMDLINE": "help"})
+		t.Setenv("SKAFFOLD_CMDLINE", "help")
 		t.Override(&os.Args, []string{"skaffold"})
 
 		err := Run(&output, &errOutput)
@@ -76,7 +76,7 @@ func TestSkaffoldCmdline_MainHelp(t *testing.T) {
 func TestSkaffoldCmdline_MainUnknownCommand(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
 		t.Override(&os.Args, []string{"skaffold"})
-		t.SetEnvs(map[string]string{"SKAFFOLD_CMDLINE": "unknown"})
+		t.Setenv("SKAFFOLD_CMDLINE", "unknown")
 
 		err := Run(io.Discard, io.Discard)
 

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -604,7 +604,7 @@ func TestRunKubectlDefaultNamespace(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			MarkIntegrationTest(t.T, CanRunWithoutGcp)
 			ns, client := SetupNamespace(t.T)
-			t.SetEnvs(map[string]string{test.envVariable: ns.Name})
+			t.Setenv(test.envVariable, ns.Name)
 			skaffold.Run().InDir(test.projectDir).RunOrFail(t.T)
 			pod := client.GetPod(test.podName)
 			t.CheckNotNil(pod)

--- a/integration/verify_test.go
+++ b/integration/verify_test.go
@@ -29,8 +29,7 @@ import (
 
 func TestVerifyPassingTestsWithEnvVar(t *testing.T) {
 	MarkIntegrationTest(t, CanRunWithoutGcp)
-	os.Setenv("FOO", "foo-var")
-	defer os.Unsetenv("FOO")
+	t.Setenv("FOO", "foo-var")
 	tmp := t.TempDir()
 	logFile := filepath.Join(tmp, uuid.New().String()+"logs.json")
 
@@ -59,8 +58,7 @@ func TestVerifyPassingTestsWithEnvVar(t *testing.T) {
 
 func TestVerifyOneTestFailsWithEnvVar(t *testing.T) {
 	MarkIntegrationTest(t, CanRunWithoutGcp)
-	os.Setenv("FOO", "foo-var")
-	defer os.Unsetenv("FOO")
+	t.Setenv("FOO", "foo-var")
 	tmp := t.TempDir()
 	logFile := filepath.Join(tmp, uuid.New().String()+"logs.json")
 

--- a/pkg/skaffold/build/ko/builder_test.go
+++ b/pkg/skaffold/build/ko/builder_test.go
@@ -18,7 +18,6 @@ package ko
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -154,9 +153,8 @@ func TestBuildOptions(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			os.Setenv(testKoBuildOptionsEnvVar, test.envVarValue)
+			t.Setenv(testKoBuildOptionsEnvVar, test.envVarValue)
 			gotBo, err := buildOptions(&test.artifact, test.runMode, test.platforms)
-			defer os.Unsetenv(testKoBuildOptionsEnvVar)
 			t.CheckErrorAndFailNow(false, err)
 			t.CheckDeepEqual(test.wantBo, *gotBo,
 				cmpopts.EquateEmpty(),

--- a/pkg/skaffold/docker/auth_test.go
+++ b/pkg/skaffold/docker/auth_test.go
@@ -64,7 +64,7 @@ echo "{\"Username\":\"<token>\",\"Secret\":\"TOKEN_$server\"}"`).
 read server
 echo "{\"Username\":\"<token>\",\"Secret\":\"TOKEN_$server\"}"`)
 		t.Override(&configDir, tmpDir.Root())
-		t.SetEnvs(map[string]string{"PATH": tmpDir.Root()})
+		t.Setenv("PATH", tmpDir.Root())
 
 		auth, err := DefaultAuthHelper.GetAllAuthConfigs(context.Background())
 

--- a/pkg/skaffold/gcp/auth_test.go
+++ b/pkg/skaffold/gcp/auth_test.go
@@ -99,7 +99,7 @@ func TestAutoConfigureGCRCredentialHelper(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			tmpDir := t.NewTempDir()
-			t.SetEnvs(map[string]string{"PATH": tmpDir.Root()})
+			t.Setenv("PATH", tmpDir.Root())
 
 			if test.helperInPath {
 				tmpDir.Write("docker-credential-gcloud", "")

--- a/pkg/skaffold/instrumentation/trace_test.go
+++ b/pkg/skaffold/instrumentation/trace_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -60,8 +59,7 @@ func TestInitCloudTrace(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.name, func(t *testutil.T) {
 			if len(test.traceEnvVar) > 0 {
-				os.Setenv("SKAFFOLD_TRACE", test.traceEnvVar)
-				defer os.Unsetenv(("SKAFFOLD_TRACE"))
+				t.Setenv("SKAFFOLD_TRACE", test.traceEnvVar)
 			}
 			var b bytes.Buffer
 			func() {

--- a/pkg/skaffold/kubernetes/context/context_test.go
+++ b/pkg/skaffold/kubernetes/context/context_test.go
@@ -151,7 +151,7 @@ func TestGetRestClientConfig(t *testing.T) {
 		log.SetLevel(log.InfoLevel)
 		kubeConfig := t.TempFile("config", []byte(validKubeConfig))
 		kubeContext = clusterBarContext
-		t.SetEnvs(map[string]string{"KUBECONFIG": kubeConfig})
+		t.Setenv("KUBECONFIG", kubeConfig)
 		resetConfig()
 
 		cfg, err := GetRestClientConfig("")
@@ -182,7 +182,7 @@ func TestGetRestClientConfig(t *testing.T) {
 	})
 
 	testutil.Run(t, "REST client in-cluster", func(t *testutil.T) {
-		t.SetEnvs(map[string]string{"KUBECONFIG": "non-valid"})
+		t.Setenv("KUBECONFIG", "non-valid")
 		resetConfig()
 
 		_, err := getRestClientConfig("", "")
@@ -238,7 +238,7 @@ func resetConfig() {
 
 func resetKubeConfig(t *testutil.T, content string) {
 	kubeConfig := t.TempFile("config", []byte(content))
-	t.SetEnvs(map[string]string{"KUBECONFIG": kubeConfig})
+	t.Setenv("KUBECONFIG", kubeConfig)
 	kubeContext = ""
 	kubeConfigFile = ""
 	resetConfig()

--- a/testutil/env.go
+++ b/testutil/env.go
@@ -16,25 +16,10 @@ limitations under the License.
 
 package testutil
 
-import "os"
-
-// SetEnvs takes a map of key values to set using os.Setenv and returns
-// a function that can be called to reset the envs to their previous values.
+// SetEnvs takes a map of key values to set using t.Setenv and restore
+// the environment variable to its original value after the test.
 func (t *T) SetEnvs(envs map[string]string) {
-	prevEnvs := map[string]string{}
-	for key := range envs {
-		prevEnvs[key] = os.Getenv(key)
-	}
-
-	t.Cleanup(func() { setEnvs(t, prevEnvs) })
-
-	setEnvs(t, envs)
-}
-
-func setEnvs(t *T, envs map[string]string) {
 	for key, value := range envs {
-		if err := os.Setenv(key, value); err != nil {
-			t.Error(err)
-		}
+		t.Setenv(key, value)
 	}
 }

--- a/testutil/kubecontext.go
+++ b/testutil/kubecontext.go
@@ -30,5 +30,5 @@ func (t *T) SetupFakeKubernetesContext(config api.Config) {
 		t.Fatalf("writing temp kubeconfig")
 	}
 
-	t.SetEnvs(map[string]string{"KUBECONFIG": kubeConfig})
+	t.Setenv("KUBECONFIG", kubeConfig)
 }


### PR DESCRIPTION
**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->

A testing cleanup.

This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

Reference: https://pkg.go.dev/testing#T.Setenv

```go
func TestFoo(t *testing.T) {
	// before
	key := "ENV"
	originalEnv := os.Getenv(key)

	if err := os.Setenv(key, "new value"); err != nil {
		t.Fatal(err)
	}
	defer func() {
		if err := os.Setenv(key, originalEnv); err != nil {
			t.Logf("failed to set env %s back to original value: %v", key, err)
		}
	}()

	// after
	t.Setenv(key, "new value")
}
```