### PR TITLE
feat: get image digest from container logs for kaniko builder

### DIFF
--- a/pkg/skaffold/build/cluster/pod.go
+++ b/pkg/skaffold/build/cluster/pod.go
@@ -66,13 +66,14 @@ func (b *Builder) kanikoPodSpec(artifact *latest.KanikoArtifact, tag string, pla
 				Resources:       resourceRequirements(b.ClusterDetails.Resources),
 			}},
 			Containers: []v1.Container{{
-				Name:            kaniko.DefaultContainerName,
-				Image:           artifact.Image,
-				ImagePullPolicy: v1.PullIfNotPresent,
-				Args:            args,
-				Env:             b.env(artifact, b.ClusterDetails.HTTPProxy, b.ClusterDetails.HTTPSProxy),
-				VolumeMounts:    []v1.VolumeMount{vm},
-				Resources:       resourceRequirements(b.ClusterDetails.Resources),
+				Name:                   kaniko.DefaultContainerName,
+				Image:                  artifact.Image,
+				ImagePullPolicy:        v1.PullIfNotPresent,
+				Args:                   args,
+				Env:                    b.env(artifact, b.ClusterDetails.HTTPProxy, b.ClusterDetails.HTTPSProxy),
+				VolumeMounts:           []v1.VolumeMount{vm},
+				Resources:              resourceRequirements(b.ClusterDetails.Resources),
+				TerminationMessagePath: artifact.DigestFile, // setting this lets us get the built image digest from container logs directly
 			}},
 			RestartPolicy: v1.RestartPolicyNever,
 			Volumes: []v1.Volume{{

--- a/pkg/skaffold/constants/constants.go
+++ b/pkg/skaffold/constants/constants.go
@@ -128,6 +128,8 @@ var (
 	AllowedUserPattern = `^%v(\/.+)?$`
 
 	KustomizeFilePaths = []string{"kustomization.yaml", "kustomization.yml", "Kustomization"}
+
+	DefaultKanikoDigestFile = "/dev/termination-log"
 )
 
 var ImageRef = struct {

--- a/pkg/skaffold/schema/defaults/defaults.go
+++ b/pkg/skaffold/schema/defaults/defaults.go
@@ -361,6 +361,7 @@ func setKanikoArtifactDefaults(a *latest.KanikoArtifact) {
 	a.Image = valueOrDefault(a.Image, kaniko.DefaultImage)
 	a.DockerfilePath = valueOrDefault(a.DockerfilePath, constants.DefaultDockerfilePath)
 	a.InitImage = valueOrDefault(a.InitImage, constants.DefaultBusyboxImage)
+	a.DigestFile = valueOrDefault(a.DigestFile, constants.DefaultKanikoDigestFile)
 }
 
 func valueOrDefault(v, def string) string {

--- a/pkg/skaffold/schema/versions_test.go
+++ b/pkg/skaffold/schema/versions_test.go
@@ -628,6 +628,7 @@ func withKanikoArtifact() func(*latest.BuildConfig) {
 					DockerfilePath: "Dockerfile",
 					InitImage:      constants.DefaultBusyboxImage,
 					Image:          kaniko.DefaultImage,
+					DigestFile:     "/dev/termination-log",
 				},
 			},
 		})


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #8099 <!-- tracking issues that this PR will close -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
This PR modifies kaniko builder to run with the `--digest-file` flag that can be used to get the image digest from the kubernetes logs instead of connecting to the image registry locally.

**Testing instructions**
- Stop the local docker daemon.
- Set kubernetes context to a cluster with kaniko setup. Maintainers can use the `integration-tests` GKE cluster.
- Run `skaffold dev --cache-artifacts=false --default-repo=<your-image-registry>` from the `examples/kaniko` project
- The image should be successfully built and pushed to the container registy, and deployed to the active kubernetes cluster.