### PR TITLE
docs: Update Quickstart and Tutorials pages with new Skaffold onboarding walkthrough

### DIFF
--- a/docs-v2/content/en/docs/tutorials/build-and-deploy-to-kubernetes.md
+++ b/docs-v2/content/en/docs/tutorials/build-and-deploy-to-kubernetes.md
@@ -1,0 +1,14 @@
+---
+title: "Use Skaffold to build and deploy an application on Kubernetes"
+linkTitle: "Build and deploy on Kubernetes"
+weight: 90
+---
+
+This is a link to an introductory Cloud Shell tutorial. In this tutorial, you will:
+
+* Use **skaffold init** to bootstrap your Skaffold config.
+* Use **skaffold dev** to automatically build and deploy your application when your code changes.
+* Use **skaffold build** and **skaffold test** to tag, push, and test your container images.
+* Use **skaffold render** and **skaffold apply** to generate and deploy Kubernetes manifests as part of a GitOps workflow.
+
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.png)](https://ssh.cloud.google.com/cloudshell/editor?show=ide%2Cterminal&cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&walkthrough_id=skaffold--skaffold_onboarding&cloudshell_workspace=/examples/buildpacks-node-tutorial&cloudshell_open_in_editor=src/index.js)


### PR DESCRIPTION
Fixes: https://github.com/GoogleContainerTools/skaffold/issues/8228

**Description**
Update Quickstart and Tutorials pages with new Skaffold onboarding walkthrough.

**User facing changes**
* Adds a new page to the Tutorials section that includes a link to open the new tutorial in Cloud Shell.
* Updates the Quickstart page to include the new tutorial text-only version and Cloud Shell link.
