### PR TITLE
feat: allow specifying debug runtime in `skaffold.yaml` for artifact

### DIFF
--- a/cmd/skaffold/app/cmd/util.go
+++ b/cmd/skaffold/app/cmd/util.go
@@ -54,7 +54,8 @@ func mergeBuildArtifacts(fromFile, fromCLI []graph.Artifact, artifacts []*latest
 	var buildArtifacts []graph.Artifact
 	for _, artifact := range artifacts {
 		buildArtifacts = append(buildArtifacts, graph.Artifact{
-			ImageName: artifact.ImageName,
+			ImageName:   artifact.ImageName,
+			RuntimeType: artifact.RuntimeType,
 		})
 	}
 

--- a/docs-v2/content/en/schemas/v4beta2.json
+++ b/docs-v2/content/en/schemas/v4beta2.json
@@ -88,6 +88,11 @@
               "description": "describes build artifacts that this artifact depends on.",
               "x-intellij-html-description": "describes build artifacts that this artifact depends on."
             },
+            "runtimeType": {
+              "type": "string",
+              "description": "specifies the target language runtime for this artifact that is used to configure debug support. Should be one of `go`, `nodejs`, `jvm`, `python` or `netcore`. If unspecified the language runtime is inferred from common heuristics for the list of supported runtimes.",
+              "x-intellij-html-description": "specifies the target language runtime for this artifact that is used to configure debug support. Should be one of <code>go</code>, <code>nodejs</code>, <code>jvm</code>, <code>python</code> or <code>netcore</code>. If unspecified the language runtime is inferred from common heuristics for the list of supported runtimes."
+            },
             "sync": {
               "$ref": "#/definitions/Sync",
               "description": "*beta* local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
@@ -101,7 +106,8 @@
             "sync",
             "requires",
             "hooks",
-            "platforms"
+            "platforms",
+            "runtimeType"
           ],
           "additionalProperties": false
         },
@@ -148,6 +154,11 @@
               "description": "describes build artifacts that this artifact depends on.",
               "x-intellij-html-description": "describes build artifacts that this artifact depends on."
             },
+            "runtimeType": {
+              "type": "string",
+              "description": "specifies the target language runtime for this artifact that is used to configure debug support. Should be one of `go`, `nodejs`, `jvm`, `python` or `netcore`. If unspecified the language runtime is inferred from common heuristics for the list of supported runtimes.",
+              "x-intellij-html-description": "specifies the target language runtime for this artifact that is used to configure debug support. Should be one of <code>go</code>, <code>nodejs</code>, <code>jvm</code>, <code>python</code> or <code>netcore</code>. If unspecified the language runtime is inferred from common heuristics for the list of supported runtimes."
+            },
             "sync": {
               "$ref": "#/definitions/Sync",
               "description": "*beta* local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
@@ -162,6 +173,7 @@
             "requires",
             "hooks",
             "platforms",
+            "runtimeType",
             "docker"
           ],
           "additionalProperties": false
@@ -209,6 +221,11 @@
               "description": "describes build artifacts that this artifact depends on.",
               "x-intellij-html-description": "describes build artifacts that this artifact depends on."
             },
+            "runtimeType": {
+              "type": "string",
+              "description": "specifies the target language runtime for this artifact that is used to configure debug support. Should be one of `go`, `nodejs`, `jvm`, `python` or `netcore`. If unspecified the language runtime is inferred from common heuristics for the list of supported runtimes.",
+              "x-intellij-html-description": "specifies the target language runtime for this artifact that is used to configure debug support. Should be one of <code>go</code>, <code>nodejs</code>, <code>jvm</code>, <code>python</code> or <code>netcore</code>. If unspecified the language runtime is inferred from common heuristics for the list of supported runtimes."
+            },
             "sync": {
               "$ref": "#/definitions/Sync",
               "description": "*beta* local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
@@ -223,6 +240,7 @@
             "requires",
             "hooks",
             "platforms",
+            "runtimeType",
             "bazel"
           ],
           "additionalProperties": false
@@ -270,6 +288,11 @@
               "description": "describes build artifacts that this artifact depends on.",
               "x-intellij-html-description": "describes build artifacts that this artifact depends on."
             },
+            "runtimeType": {
+              "type": "string",
+              "description": "specifies the target language runtime for this artifact that is used to configure debug support. Should be one of `go`, `nodejs`, `jvm`, `python` or `netcore`. If unspecified the language runtime is inferred from common heuristics for the list of supported runtimes.",
+              "x-intellij-html-description": "specifies the target language runtime for this artifact that is used to configure debug support. Should be one of <code>go</code>, <code>nodejs</code>, <code>jvm</code>, <code>python</code> or <code>netcore</code>. If unspecified the language runtime is inferred from common heuristics for the list of supported runtimes."
+            },
             "sync": {
               "$ref": "#/definitions/Sync",
               "description": "*beta* local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
@@ -284,6 +307,7 @@
             "requires",
             "hooks",
             "platforms",
+            "runtimeType",
             "ko"
           ],
           "additionalProperties": false
@@ -331,6 +355,11 @@
               "description": "describes build artifacts that this artifact depends on.",
               "x-intellij-html-description": "describes build artifacts that this artifact depends on."
             },
+            "runtimeType": {
+              "type": "string",
+              "description": "specifies the target language runtime for this artifact that is used to configure debug support. Should be one of `go`, `nodejs`, `jvm`, `python` or `netcore`. If unspecified the language runtime is inferred from common heuristics for the list of supported runtimes.",
+              "x-intellij-html-description": "specifies the target language runtime for this artifact that is used to configure debug support. Should be one of <code>go</code>, <code>nodejs</code>, <code>jvm</code>, <code>python</code> or <code>netcore</code>. If unspecified the language runtime is inferred from common heuristics for the list of supported runtimes."
+            },
             "sync": {
               "$ref": "#/definitions/Sync",
               "description": "*beta* local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
@@ -345,6 +374,7 @@
             "requires",
             "hooks",
             "platforms",
+            "runtimeType",
             "jib"
           ],
           "additionalProperties": false
@@ -392,6 +422,11 @@
               "description": "describes build artifacts that this artifact depends on.",
               "x-intellij-html-description": "describes build artifacts that this artifact depends on."
             },
+            "runtimeType": {
+              "type": "string",
+              "description": "specifies the target language runtime for this artifact that is used to configure debug support. Should be one of `go`, `nodejs`, `jvm`, `python` or `netcore`. If unspecified the language runtime is inferred from common heuristics for the list of supported runtimes.",
+              "x-intellij-html-description": "specifies the target language runtime for this artifact that is used to configure debug support. Should be one of <code>go</code>, <code>nodejs</code>, <code>jvm</code>, <code>python</code> or <code>netcore</code>. If unspecified the language runtime is inferred from common heuristics for the list of supported runtimes."
+            },
             "sync": {
               "$ref": "#/definitions/Sync",
               "description": "*beta* local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
@@ -406,6 +441,7 @@
             "requires",
             "hooks",
             "platforms",
+            "runtimeType",
             "kaniko"
           ],
           "additionalProperties": false
@@ -453,6 +489,11 @@
               "description": "describes build artifacts that this artifact depends on.",
               "x-intellij-html-description": "describes build artifacts that this artifact depends on."
             },
+            "runtimeType": {
+              "type": "string",
+              "description": "specifies the target language runtime for this artifact that is used to configure debug support. Should be one of `go`, `nodejs`, `jvm`, `python` or `netcore`. If unspecified the language runtime is inferred from common heuristics for the list of supported runtimes.",
+              "x-intellij-html-description": "specifies the target language runtime for this artifact that is used to configure debug support. Should be one of <code>go</code>, <code>nodejs</code>, <code>jvm</code>, <code>python</code> or <code>netcore</code>. If unspecified the language runtime is inferred from common heuristics for the list of supported runtimes."
+            },
             "sync": {
               "$ref": "#/definitions/Sync",
               "description": "*beta* local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
@@ -467,6 +508,7 @@
             "requires",
             "hooks",
             "platforms",
+            "runtimeType",
             "buildpacks"
           ],
           "additionalProperties": false
@@ -514,6 +556,11 @@
               "description": "describes build artifacts that this artifact depends on.",
               "x-intellij-html-description": "describes build artifacts that this artifact depends on."
             },
+            "runtimeType": {
+              "type": "string",
+              "description": "specifies the target language runtime for this artifact that is used to configure debug support. Should be one of `go`, `nodejs`, `jvm`, `python` or `netcore`. If unspecified the language runtime is inferred from common heuristics for the list of supported runtimes.",
+              "x-intellij-html-description": "specifies the target language runtime for this artifact that is used to configure debug support. Should be one of <code>go</code>, <code>nodejs</code>, <code>jvm</code>, <code>python</code> or <code>netcore</code>. If unspecified the language runtime is inferred from common heuristics for the list of supported runtimes."
+            },
             "sync": {
               "$ref": "#/definitions/Sync",
               "description": "*beta* local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
@@ -528,6 +575,7 @@
             "requires",
             "hooks",
             "platforms",
+            "runtimeType",
             "custom"
           ],
           "additionalProperties": false

--- a/pkg/skaffold/build/builder_mux.go
+++ b/pkg/skaffold/build/builder_mux.go
@@ -117,8 +117,9 @@ func (b *BuilderMux) Build(ctx context.Context, out io.Writer, tags tag.ImageTag
 		}
 
 		if err := b.cache.AddArtifact(ctx, graph.Artifact{
-			ImageName: artifact.ImageName,
-			Tag:       built,
+			ImageName:   artifact.ImageName,
+			Tag:         built,
+			RuntimeType: artifact.RuntimeType,
 		}); err != nil {
 			log.Entry(ctx).Warnf("error adding artifact to cache; caching may not work as expected: %v", err)
 		}

--- a/pkg/skaffold/build/cache/retrieve.go
+++ b/pkg/skaffold/build/cache/retrieve.go
@@ -136,8 +136,9 @@ func (c *cache) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, ar
 		}
 		c.artifactStore.Record(artifact, uniqueTag)
 		alreadyBuilt = append(alreadyBuilt, graph.Artifact{
-			ImageName: artifact.ImageName,
-			Tag:       uniqueTag,
+			ImageName:   artifact.ImageName,
+			Tag:         uniqueTag,
+			RuntimeType: artifact.RuntimeType,
 		})
 	}
 

--- a/pkg/skaffold/build/result.go
+++ b/pkg/skaffold/build/result.go
@@ -172,7 +172,7 @@ func (ba *artifactStoreImpl) GetArtifacts(s []*latest.Artifact) ([]graph.Artifac
 		if !found {
 			return nil, fmt.Errorf("failed to retrieve build result for image %s", a.ImageName)
 		}
-		builds = append(builds, graph.Artifact{ImageName: a.ImageName, Tag: t})
+		builds = append(builds, graph.Artifact{ImageName: a.ImageName, Tag: t, RuntimeType: a.RuntimeType})
 	}
 	return builds, nil
 }

--- a/pkg/skaffold/debug/apply_transforms.go
+++ b/pkg/skaffold/debug/apply_transforms.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/debug/types"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/output/log"
@@ -72,13 +73,14 @@ func RetrieveImageConfiguration(ctx context.Context, artifact *graph.Artifact, i
 	log.Entry(ctx).Debugf("Retrieved local image configuration for %v: %v", artifact.Tag, config)
 	// need to duplicate slices as apiClient caches requests
 	return ImageConfiguration{
-		Artifact:   artifact.ImageName,
-		Author:     manifest.Author,
-		Env:        envAsMap(config.Env),
-		Entrypoint: dupArray(config.Entrypoint),
-		Arguments:  dupArray(config.Cmd),
-		Labels:     dupMap(config.Labels),
-		WorkingDir: config.WorkingDir,
+		Artifact:    artifact.ImageName,
+		RuntimeType: types.ToRuntime(artifact.RuntimeType),
+		Author:      manifest.Author,
+		Env:         envAsMap(config.Env),
+		Entrypoint:  dupArray(config.Entrypoint),
+		Arguments:   dupArray(config.Cmd),
+		Labels:      dupMap(config.Labels),
+		WorkingDir:  config.WorkingDir,
 	}, nil
 }
 

--- a/pkg/skaffold/debug/transform.go
+++ b/pkg/skaffold/debug/transform.go
@@ -71,14 +71,14 @@ type ConfigurationRetriever func(string) (ImageConfiguration, error)
 // It also includes a "artifact", usually containing the corresponding artifact's' image name from `skaffold.yaml`.
 type ImageConfiguration struct {
 	// Artifact is the corresponding Artifact's image name (`pkg/skaffold/build.Artifact.ImageName`)
-	Artifact string
-
-	Author     string
-	Labels     map[string]string
-	Env        map[string]string
-	Entrypoint []string
-	Arguments  []string
-	WorkingDir string
+	Artifact    string
+	RuntimeType types.Runtime
+	Author      string
+	Labels      map[string]string
+	Env         map[string]string
+	Entrypoint  []string
+	Arguments   []string
+	WorkingDir  string
 }
 
 const (

--- a/pkg/skaffold/debug/transform_go.go
+++ b/pkg/skaffold/debug/transform_go.go
@@ -64,6 +64,10 @@ func isLaunchingDlv(args []string) bool {
 }
 
 func (t dlvTransformer) IsApplicable(config ImageConfiguration) bool {
+	if config.RuntimeType == types.Runtimes.Go {
+		log.Entry(context.TODO()).Infof("Artifact %q has Go runtime: specified by user in skaffold config", config.Artifact)
+		return true
+	}
 	for _, name := range []string{"GODEBUG", "GOGC", "GOMAXPROCS", "GOTRACEBACK", "KO_DATA_PATH"} {
 		if _, found := config.Env[name]; found {
 			log.Entry(context.TODO()).Infof("Artifact %q has Go runtime: has env %q", config.Artifact, name)

--- a/pkg/skaffold/debug/transform_go_test.go
+++ b/pkg/skaffold/debug/transform_go_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/debug/types"
 	"github.com/GoogleContainerTools/skaffold/v2/testutil"
 )
 
@@ -66,6 +67,11 @@ func TestDlvTransformer_IsApplicable(t *testing.T) {
 		launcher    string
 		result      bool
 	}{
+		{
+			description: "user specified",
+			source:      ImageConfiguration{RuntimeType: types.Runtimes.Go},
+			result:      true,
+		},
 		{
 			description: "GOMAXPROCS",
 			source:      ImageConfiguration{Env: map[string]string{"GOMAXPROCS": "2"}},

--- a/pkg/skaffold/debug/transform_jvm.go
+++ b/pkg/skaffold/debug/transform_jvm.go
@@ -43,6 +43,10 @@ const (
 )
 
 func (t jdwpTransformer) IsApplicable(config ImageConfiguration) bool {
+	if config.RuntimeType == types.Runtimes.JVM {
+		log.Entry(context.TODO()).Infof("Artifact %q has JVM runtime: specified by user in skaffold config", config.Artifact)
+		return true
+	}
 	if _, found := config.Env["JAVA_TOOL_OPTIONS"]; found {
 		return true
 	}

--- a/pkg/skaffold/debug/transform_jvm_test.go
+++ b/pkg/skaffold/debug/transform_jvm_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/debug/types"
 	"github.com/GoogleContainerTools/skaffold/v2/testutil"
 )
 
@@ -31,6 +32,11 @@ func TestJdwpTransformer_IsApplicable(t *testing.T) {
 		launcher    string
 		result      bool
 	}{
+		{
+			description: "user specified",
+			source:      ImageConfiguration{RuntimeType: types.Runtimes.JVM},
+			result:      true,
+		},
 		{
 			description: "JAVA_TOOL_OPTIONS",
 			source:      ImageConfiguration{Env: map[string]string{"JAVA_TOOL_OPTIONS": "-agent:jdwp"}},

--- a/pkg/skaffold/debug/transform_netcore.go
+++ b/pkg/skaffold/debug/transform_netcore.go
@@ -53,6 +53,10 @@ func isLaunchingNetcore(args []string) bool {
 }
 
 func (t netcoreTransformer) IsApplicable(config ImageConfiguration) bool {
+	if config.RuntimeType == types.Runtimes.NetCore {
+		log.Entry(context.TODO()).Infof("Artifact %q has netcore runtime: specified by user in skaffold config", config.Artifact)
+		return true
+	}
 	// Some official base images (eg: dotnet/core/runtime-deps) contain the following env vars
 	for _, v := range []string{"ASPNETCORE_URLS", "DOTNET_RUNNING_IN_CONTAINER", "DOTNET_SYSTEM_GLOBALIZATION_INVARIANT"} {
 		if _, found := config.Env[v]; found {

--- a/pkg/skaffold/debug/transform_netcore_test.go
+++ b/pkg/skaffold/debug/transform_netcore_test.go
@@ -19,6 +19,7 @@ package debug
 import (
 	"testing"
 
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/debug/types"
 	"github.com/GoogleContainerTools/skaffold/v2/testutil"
 )
 
@@ -29,6 +30,11 @@ func TestNetcoreTransformer_IsApplicable(t *testing.T) {
 		launcher    string
 		result      bool
 	}{
+		{
+			description: "user specified",
+			source:      ImageConfiguration{RuntimeType: types.Runtimes.NetCore},
+			result:      true,
+		},
 		{
 			description: "ASPNETCORE_URLS",
 			source:      ImageConfiguration{Env: map[string]string{"ASPNETCORE_URLS": "http://+:80"}},

--- a/pkg/skaffold/debug/transform_nodejs.go
+++ b/pkg/skaffold/debug/transform_nodejs.go
@@ -64,6 +64,11 @@ func isLaunchingNpm(args []string) bool {
 }
 
 func (t nodeTransformer) IsApplicable(config ImageConfiguration) bool {
+	if config.RuntimeType == types.Runtimes.NodeJS {
+		log.Entry(context.TODO()).Infof("Artifact %q has nodejs runtime: specified by user in skaffold config", config.Artifact)
+		return true
+	}
+
 	// NODE_VERSION defined in Official Docker `node` image
 	// NODEJS_VERSION defined in RedHat's node base image
 	// NODE_ENV is a common var found to toggle debug and production

--- a/pkg/skaffold/debug/transform_nodejs_test.go
+++ b/pkg/skaffold/debug/transform_nodejs_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/debug/types"
 	"github.com/GoogleContainerTools/skaffold/v2/testutil"
 )
 
@@ -62,6 +63,12 @@ func TestNodeTransformer_IsApplicable(t *testing.T) {
 		launcher    string
 		result      bool
 	}{
+
+		{
+			description: "user specified",
+			source:      ImageConfiguration{RuntimeType: types.Runtimes.NodeJS},
+			result:      true,
+		},
 		{
 			description: "NODE_VERSION",
 			source:      ImageConfiguration{Env: map[string]string{"NODE_VERSION": "10"}},

--- a/pkg/skaffold/debug/transform_python.go
+++ b/pkg/skaffold/debug/transform_python.go
@@ -99,6 +99,10 @@ func hasCommonPythonEnvVars(env map[string]string) bool {
 }
 
 func (t pythonTransformer) IsApplicable(config ImageConfiguration) bool {
+	if config.RuntimeType == types.Runtimes.Python {
+		log.Entry(context.TODO()).Infof("Artifact %q has python runtime: specified by user in skaffold config", config.Artifact)
+		return true
+	}
 	if hasCommonPythonEnvVars(config.Env) {
 		return true
 	}

--- a/pkg/skaffold/debug/transform_python_test.go
+++ b/pkg/skaffold/debug/transform_python_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/debug/types"
 	"github.com/GoogleContainerTools/skaffold/v2/testutil"
 )
 
@@ -66,6 +67,12 @@ func TestPythonTransformer_IsApplicable(t *testing.T) {
 		launcher    string
 		result      bool
 	}{
+
+		{
+			description: "user specified",
+			source:      ImageConfiguration{RuntimeType: types.Runtimes.Python},
+			result:      true,
+		},
 		{
 			description: "PYTHON_VERSION",
 			source:      ImageConfiguration{Env: map[string]string{"PYTHON_VERSION": "2.7"}},

--- a/pkg/skaffold/debug/types/types.go
+++ b/pkg/skaffold/debug/types/types.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package types
 
+import (
+	"strings"
+)
+
 const (
 	// DebugConfig is the name of the podspec annotation that records debugging configuration information.
 	// The annotation should be a JSON-encoded map of container-name to a `ContainerDebugConfiguration` object.
@@ -69,4 +73,40 @@ type ContainerPort struct {
 type ContainerEnv struct {
 	Order []string
 	Env   map[string]string
+}
+
+// Runtime specifies the target language runtime for this artifact that is used to configure debug support
+type Runtime string
+
+var Runtimes = struct {
+	Go      Runtime
+	NodeJS  Runtime
+	JVM     Runtime
+	Python  Runtime
+	NetCore Runtime
+	Unknown Runtime
+}{
+	Go:      "go",
+	NodeJS:  "nodejs",
+	JVM:     "jvm",
+	Python:  "python",
+	NetCore: "netcore",
+	Unknown: "unknown",
+}
+
+func ToRuntime(r string) Runtime {
+	switch strings.ToLower(r) {
+	case "go", "golang":
+		return Runtimes.Go
+	case "nodejs", "node", "npm":
+		return Runtimes.NodeJS
+	case "jvm", "java":
+		return Runtimes.JVM
+	case "python":
+		return Runtimes.Python
+	case "netcore", ".net", "dotnet":
+		return Runtimes.NetCore
+	default:
+		return Runtimes.Unknown
+	}
 }

--- a/pkg/skaffold/deploy/helm/helm.go
+++ b/pkg/skaffold/deploy/helm/helm.go
@@ -158,7 +158,8 @@ func NewDeployer(ctx context.Context, cfg Config, labeller *label.DefaultLabelle
 	var ogImages []graph.Artifact
 	for _, artifact := range artifacts {
 		ogImages = append(ogImages, graph.Artifact{
-			ImageName: artifact.ImageName,
+			ImageName:   artifact.ImageName,
+			RuntimeType: artifact.RuntimeType,
 		})
 	}
 	return &Deployer{

--- a/pkg/skaffold/deploy/kubectl/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl.go
@@ -116,7 +116,8 @@ func NewDeployer(cfg Config, labeller *label.DefaultLabeller, d *latest.KubectlD
 	var ogImages []graph.Artifact
 	for _, artifact := range artifacts {
 		ogImages = append(ogImages, graph.Artifact{
-			ImageName: artifact.ImageName,
+			ImageName:   artifact.ImageName,
+			RuntimeType: artifact.RuntimeType,
 		})
 	}
 

--- a/pkg/skaffold/graph/artifact_graph.go
+++ b/pkg/skaffold/graph/artifact_graph.go
@@ -16,12 +16,15 @@ limitations under the License.
 
 package graph
 
-import "github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/latest"
+import (
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/latest"
+)
 
 // Artifact is the result corresponding to each successful build.
 type Artifact struct {
-	ImageName string `json:"imageName"`
-	Tag       string `json:"tag"`
+	ImageName   string `json:"imageName"`
+	Tag         string `json:"tag"`
+	RuntimeType string `json:"-"`
 }
 
 // ArtifactGraph is a map of [artifact image : artifact definition]

--- a/pkg/skaffold/runner/build.go
+++ b/pkg/skaffold/runner/build.go
@@ -139,8 +139,9 @@ func artifactsWithTags(tags tag.ImageTags, artifacts []*latest.Artifact) []graph
 	var bRes []graph.Artifact
 	for _, artifact := range artifacts {
 		bRes = append(bRes, graph.Artifact{
-			ImageName: artifact.ImageName,
-			Tag:       tags[artifact.ImageName],
+			ImageName:   artifact.ImageName,
+			Tag:         tags[artifact.ImageName],
+			RuntimeType: artifact.RuntimeType,
 		})
 	}
 

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -985,6 +985,9 @@ type Artifact struct {
 	// Each platform is of the format `os[/arch[/variant]]`, e.g., `linux/amd64`.
 	// Example: `["linux/amd64", "linux/arm64"]`.
 	Platforms []string `yaml:"platforms,omitempty"`
+
+	// RuntimeType specifies the target language runtime for this artifact that is used to configure debug support. Should be one of `go`, `nodejs`, `jvm`, `python` or `netcore`. If unspecified the language runtime is inferred from common heuristics for the list of supported runtimes.
+	RuntimeType string `yaml:"runtimeType,omitempty"`
 }
 
 // Sync *beta* specifies what files to sync into the container.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #2203 <!-- tracking issues that this PR will close -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Allow specifying the debug runtime for artifacts in `skaffold.yaml`.

**Testing instructions**
In the `integration/examples/getting-started` project:
1. Modify the Dockerfile by deleting line 12 ( `ENV GOTRACEBACK=single`).
2. Run `skaffold debug -v DEBUG`. 
3. Search the output for the text `Image "getting-started" not configured for debugging: unable to determine runtime`. This implies that Skaffold couldn't identify the language runtime for this artifact for debug.
4. Now modify the `skaffold.yaml` file to:
  ```
  apiVersion: skaffold/v4beta1
  kind: Config
  build:
    artifacts:
    - image: skaffold-example
      runtimeType: go     # added runtime type explicitly
  manifests:
    rawYaml:
    - k8s-pod.yaml
  ```
5. Run `skaffold debug -v DEBUG` again. 
6. Search the output for the text `Artifact "skaffold-example" has Go runtime: specified by user in skaffold config`. This implies that Skaffold was able to identify Golang as the language runtime for this artifact for debug.

