### PR TITLE
feat: change components installed in docker images to include alpha and beta

### DIFF
--- a/deploy/skaffold/Dockerfile.deps
+++ b/deploy/skaffold/Dockerfile.deps
@@ -145,6 +145,8 @@ RUN /google-cloud-sdk/install.sh \
 ENV PATH=$PATH:/google-cloud-sdk/bin
 RUN gcloud auth configure-docker && gcloud components install --quiet \
     gke-gcloud-auth-plugin \
+    alpha \
+    beta \
     cloud-run-proxy \
     log-streaming
 

--- a/deploy/skaffold/Dockerfile.deps.lts
+++ b/deploy/skaffold/Dockerfile.deps.lts
@@ -89,6 +89,8 @@ RUN /google-cloud-sdk/install.sh \
 ENV PATH=$PATH:/google-cloud-sdk/bin
 RUN gcloud auth configure-docker && gcloud components install --quiet \
     gke-gcloud-auth-plugin \
+    alpha \
+    beta \
     cloud-run-proxy \
     log-streaming
 

--- a/deploy/skaffold/Dockerfile.deps.slim
+++ b/deploy/skaffold/Dockerfile.deps.slim
@@ -89,6 +89,8 @@ RUN /google-cloud-sdk/install.sh \
 ENV PATH=$PATH:/google-cloud-sdk/bin
 RUN gcloud auth configure-docker && gcloud components install --quiet \
     gke-gcloud-auth-plugin \
+    alpha \
+    beta \
     cloud-run-proxy \
     log-streaming
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #8110 

**Description**
Add `alpha` and `beta` gcloud components that include `logs` and `proxy` services, needed to perform Cloud Run's log streaming and port forward accordingly.

**Follow-up Work**
Check when these services move out from `alpha` and `beta` to change the code accordingly. Tracking issue #8317:
- https://github.com/GoogleContainerTools/skaffold/blob/8d655cdb2f3d1eec3ee45244b33c3f064f340b8a/pkg/skaffold/deploy/cloudrun/accessor.go#L187
- https://github.com/GoogleContainerTools/skaffold/blob/8d655cdb2f3d1eec3ee45244b33c3f064f340b8a/pkg/skaffold/deploy/cloudrun/log.go#L222
