### PR TITLE
fix: use new URL format for Google Cloud Build log

### DIFF
--- a/pkg/skaffold/build/gcb/cloud_build.go
+++ b/pkg/skaffold/build/gcb/cloud_build.go
@@ -165,7 +165,7 @@ func (b *Builder) buildArtifactWithCloudBuild(ctx context.Context, out io.Writer
 		return "", err
 	}
 	logsObject := fmt.Sprintf("log-%s.txt", remoteID)
-	output.Default.Fprintf(out, "Logs are available at \nhttps://console.cloud.google.com/m/cloudstorage/b/%s/o/%s\n", cbBucket, logsObject)
+	output.Default.Fprintf(out, "Logs are available at \nhttps://storage.cloud.google.com/%s/%s\n", cbBucket, logsObject)
 
 	var digest string
 	offset := int64(0)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #8322 <!-- tracking issues that this PR will close -->
**Related**: N/A
**Merge before/after**: N/A

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
As written in #8322, URL format `https://console.cloud.google.com/m/cloudstorage/b/<bucket-name>/o/<object-name>` has been deprecated so we need to use the new format `https://storage.cloud.google.com/<bucket-name>/<object-name>` instead.

**User facing changes**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->
This will replace the invalid deprecated log URL with the valid log URL.

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
