### PR TITLE
doc: Updating installation link for Cloud Code in VSCode

### DIFF
--- a/docs-v2/content/en/docs/install/_index.md
+++ b/docs-v2/content/en/docs/install/_index.md
@@ -25,7 +25,7 @@ Your use of this software is subject to the [Google Privacy Policy](https://poli
 
 {{% tab "CLOUD CODE" %}}
 
-[Cloud Code](https://cloud.google.com/code) provides a managed experience of using Skaffold in supported IDEs. You can install the `Cloud Code` extension for [Visual Studio Code](https://cloud.google.com/code/docs/vscode/quickstart-k8s#installing) or the plugin for [JetBrains IDEs](https://cloud.google.com/code/docs/intellij/quickstart-k8s#installing_the_plugin). It manages and keeps Skaffold  up-to-date, along with other common dependencies, and works with any kubernetes cluster.
+[Cloud Code](https://cloud.google.com/code) provides a managed experience of using Skaffold in supported IDEs. You can install the `Cloud Code` extension for [Visual Studio Code]([https://cloud.google.com/code/docs/vscode/quickstart-k8s#installing](https://cloud.google.com/code/docs/vscode/install#installing)) or the plugin for [JetBrains IDEs](https://cloud.google.com/code/docs/intellij/quickstart-k8s#installing_the_plugin). It manages and keeps Skaffold  up-to-date, along with other common dependencies, and works with any kubernetes cluster.
 
 {{% /tab %}}
 


### PR DESCRIPTION
**Description**
The link to install the Cloud Code extension in VSCode seems broken. I have updated the link to the new version of documentation