### PR TITLE
feat: add timeout for copying build context on kaniko

### DIFF
--- a/pkg/skaffold/build/cluster/kaniko.go
+++ b/pkg/skaffold/build/cluster/kaniko.go
@@ -112,7 +112,7 @@ func (b *Builder) buildWithKaniko(ctx context.Context, out io.Writer, workspace 
 	return docker.RemoteDigest(tag, b.cfg, nil)
 }
 
-func (b *Builder) copyKanikoBuildContext(ctx context.Context, workspace string, artifactName string, artifact *latest.KanikoArtifact, pods corev1.PodInterface, podName string) error {
+func (b *Builder) copyKanikoBuildContext(ctx context.Context, workspace string, artifactName string, artifact *latest.KanikoArtifact, podName string) error {
 	ctx, cancel := context.WithTimeout(ctx, copyTimeout)
 	defer cancel()
 	errs := make(chan error, 1)
@@ -153,7 +153,7 @@ func (b *Builder) setupKanikoBuildContext(ctx context.Context, workspace string,
 	// total attempts is `uploadMaxRetries + 1`
 	attempt := 1
 	err := wait.Poll(time.Second, copyTimeout*(copyMaxRetries+1), func() (bool, error) {
-		if err := b.copyKanikoBuildContext(ctx, workspace, artifactName, artifact, pods, podName); err != nil {
+		if err := b.copyKanikoBuildContext(ctx, workspace, artifactName, artifact, podName); err != nil {
 			log.Entry(ctx).Warnf("uploading build context failed, retrying (%d/%d): %v", attempt, copyMaxRetries, err)
 			if attempt == copyMaxRetries {
 				return false, err

--- a/pkg/skaffold/build/cluster/kaniko.go
+++ b/pkg/skaffold/build/cluster/kaniko.go
@@ -40,6 +40,10 @@ import (
 
 const (
 	initContainer = "kaniko-init-container"
+	// copyMaxRetries is the number of times to retry copy build contexts to a cluster if it fails.
+	copyMaxRetries = 3
+	// copyTimeout is the timeout for copying build contexts to a cluster.
+	copyTimeout = 5 * time.Minute
 )
 
 func (b *Builder) buildWithKaniko(ctx context.Context, out io.Writer, workspace string, artifactName string, artifact *latest.KanikoArtifact, tag string, requiredImages map[string]*string, platforms platform.Matcher) (string, error) {
@@ -87,7 +91,7 @@ func (b *Builder) buildWithKaniko(ctx context.Context, out io.Writer, workspace 
 		}
 	}()
 
-	if err := b.copyKanikoBuildContext(ctx, workspace, artifactName, artifact, pods, pod.Name); err != nil {
+	if err := b.setupKanikoBuildContext(ctx, workspace, artifactName, artifact, pods, pod.Name); err != nil {
 		return "", fmt.Errorf("copying sources: %w", err)
 	}
 
@@ -108,14 +112,9 @@ func (b *Builder) buildWithKaniko(ctx context.Context, out io.Writer, workspace 
 	return docker.RemoteDigest(tag, b.cfg, nil)
 }
 
-// first copy over the buildcontext tarball into the init container tmp dir via kubectl cp
-// Via kubectl exec, we extract the tarball to the empty dir
-// Then, via kubectl exec, create the /tmp/complete file via kubectl exec to complete the init container
 func (b *Builder) copyKanikoBuildContext(ctx context.Context, workspace string, artifactName string, artifact *latest.KanikoArtifact, pods corev1.PodInterface, podName string) error {
-	if err := kubernetes.WaitForPodInitialized(ctx, pods, podName); err != nil {
-		return fmt.Errorf("waiting for pod to initialize: %w", err)
-	}
-
+	ctx, cancel := context.WithTimeout(ctx, copyTimeout)
+	defer cancel()
 	errs := make(chan error, 1)
 	buildCtx, buildCtxWriter := io.Pipe()
 	go func() {
@@ -132,24 +131,41 @@ func (b *Builder) copyKanikoBuildContext(ctx context.Context, workspace string, 
 	// Send context by piping into `tar`.
 	// In case of an error, retry and print the command's output. (The `err` itself is useless: exit status 1).
 	var out bytes.Buffer
-	var errRun error
-
-	// poll up to 10 seconds
-	err := wait.Poll(100*time.Millisecond, 10*time.Second, func() (bool, error) {
-		if err := b.kubectlcli.Run(ctx, buildCtx, &out, "exec", "-i", podName, "-c", initContainer, "-n", b.Namespace, "--", "tar", "-xf", "-", "-C", kaniko.DefaultEmptyDirMountPath); err != nil {
-			return false, err
-		}
-		return true, nil
-	})
-	if err != nil {
-		errRun = fmt.Errorf("uploading build context: %s", out.String())
+	if err := b.kubectlcli.Run(ctx, buildCtx, &out, "exec", "-i", podName, "-c", initContainer, "-n", b.Namespace, "--", "tar", "-xf", "-", "-C", kaniko.DefaultEmptyDirMountPath); err != nil {
+		errRun := fmt.Errorf("uploading build context: %s", out.String())
 		errTar := <-errs
 		if errTar != nil {
 			errRun = fmt.Errorf("%v\ntar errors: %w", errRun, errTar)
 		}
 		return errRun
 	}
+	return nil
+}
 
+// first copy over the buildcontext tarball into the init container tmp dir via kubectl cp
+// Via kubectl exec, we extract the tarball to the empty dir
+// Then, via kubectl exec, create the /tmp/complete file via kubectl exec to complete the init container
+func (b *Builder) setupKanikoBuildContext(ctx context.Context, workspace string, artifactName string, artifact *latest.KanikoArtifact, pods corev1.PodInterface, podName string) error {
+	if err := kubernetes.WaitForPodInitialized(ctx, pods, podName); err != nil {
+		return fmt.Errorf("waiting for pod to initialize: %w", err)
+	}
+	// Retry uploading the build context in case of an error.
+	// total attempts is `uploadMaxRetries + 1`
+	attempt := 1
+	err := wait.Poll(time.Second, copyTimeout*(copyMaxRetries+1), func() (bool, error) {
+		if err := b.copyKanikoBuildContext(ctx, workspace, artifactName, artifact, pods, podName); err != nil {
+			log.Entry(ctx).Warnf("uploading build context failed, retrying (%d/%d): %v", attempt, copyMaxRetries, err)
+			if attempt == copyMaxRetries {
+				return false, err
+			}
+			attempt++
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("uploading build context: %w", err)
+	}
 	// Generate a file to successfully terminate the init container.
 	if out, err := b.kubectlcli.RunOut(ctx, "exec", podName, "-c", initContainer, "-n", b.Namespace, "--", "touch", "/tmp/complete"); err != nil {
 		return fmt.Errorf("finishing upload of the build context: %s", out)

--- a/pkg/skaffold/docker/context.go
+++ b/pkg/skaffold/docker/context.go
@@ -36,7 +36,7 @@ func CreateDockerTarContext(ctx context.Context, w io.Writer, buildCfg BuildConf
 		p = append(p, filepath.Join(buildCfg.workspace, path))
 	}
 
-	if err := util.CreateTar(w, buildCfg.workspace, p); err != nil {
+	if err := util.CreateTar(ctx, w, buildCfg.workspace, p); err != nil {
 		return fmt.Errorf("creating tar gz: %w", err)
 	}
 

--- a/pkg/skaffold/sources/upload.go
+++ b/pkg/skaffold/sources/upload.go
@@ -30,7 +30,7 @@ import (
 func UploadToGCS(ctx context.Context, c *cstorage.Client, a *latest.Artifact, bucket, objectName string, dependencies []string) error {
 	w := c.Bucket(bucket).Object(objectName).NewWriter(ctx)
 
-	if err := util.CreateTarGz(w, a.Workspace, dependencies); err != nil {
+	if err := util.CreateTarGz(ctx, w, a.Workspace, dependencies); err != nil {
 		return fmt.Errorf("uploading sources to google storage: %w", err)
 	}
 

--- a/pkg/skaffold/sync/docker.go
+++ b/pkg/skaffold/sync/docker.go
@@ -62,7 +62,7 @@ func (s *ContainerSyncer) deleteFileFn(ctx context.Context, containerName string
 func (s *ContainerSyncer) copyFileFn(ctx context.Context, containerName string, files syncMap) *exec.Cmd {
 	reader, writer := io.Pipe()
 	go func() {
-		if err := util.CreateMappedTar(writer, "/", files); err != nil {
+		if err := util.CreateMappedTar(ctx, writer, "/", files); err != nil {
 			writer.CloseWithError(err)
 		} else {
 			writer.Close()

--- a/pkg/skaffold/sync/kubectl.go
+++ b/pkg/skaffold/sync/kubectl.go
@@ -39,7 +39,7 @@ func (s *PodSyncer) copyFileFn(ctx context.Context, pod v1.Pod, container v1.Con
 	// Use "m" flag to touch the files as they are copied.
 	reader, writer := io.Pipe()
 	go func() {
-		if err := util.CreateMappedTar(writer, "/", files); err != nil {
+		if err := util.CreateMappedTar(ctx, writer, "/", files); err != nil {
 			writer.CloseWithError(err)
 		} else {
 			writer.Close()

--- a/pkg/skaffold/util/tar.go
+++ b/pkg/skaffold/util/tar.go
@@ -53,7 +53,6 @@ func CreateTar(ctx context.Context, w io.Writer, root string, paths []string) er
 	defer tw.Close()
 
 	for _, path := range paths {
-		log.Entry(ctx).Debugf("Adding %s to tar", path)
 		if err := addFileToTar(ctx, root, path, "", tw, nil); err != nil {
 			return err
 		}
@@ -121,7 +120,7 @@ func addFileToTar(ctx context.Context, root string, src string, dst string, tw *
 		}
 
 		if filepath.IsAbs(target) {
-			log.Entry(context.TODO()).Warnf("Skipping %s. Only relative symlinks are supported.", src)
+			log.Entry(ctx).Warnf("Skipping %s. Only relative symlinks are supported.", src)
 			return nil
 		}
 
@@ -157,7 +156,6 @@ func addFileToTar(ctx context.Context, root string, src string, dst string, tw *
 	if err := tw.WriteHeader(header); err != nil {
 		return err
 	}
-
 	if mode.IsRegular() {
 		f, err := os.Open(src)
 		if err != nil {

--- a/pkg/skaffold/util/tar_test.go
+++ b/pkg/skaffold/util/tar_test.go
@@ -296,7 +296,7 @@ func TestAddFileToTarTimeout(t *testing.T) {
 
 		var b bytes.Buffer
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Nanosecond)
-		time.Sleep(1 * time.Millisecond)
+		time.Sleep(1 * time.Second)
 		defer cancel()
 		err := CreateTar(ctx, &b, tmpDir.Root(), tmpDir.Paths(paths...))
 		t.CheckErrorContains("context deadline exceeded", err)

--- a/pkg/skaffold/util/tar_test.go
+++ b/pkg/skaffold/util/tar_test.go
@@ -20,6 +20,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"context"
 	"io"
 	"runtime"
 	"testing"
@@ -39,7 +40,7 @@ func TestCreateTar(t *testing.T) {
 		_, paths := prepareFiles(t, files)
 
 		var b bytes.Buffer
-		err := CreateTar(&b, ".", paths)
+		err := CreateTar(context.Background(), &b, ".", paths)
 		t.CheckNoError(err)
 
 		// Make sure the contents match.
@@ -72,7 +73,7 @@ func TestCreateTarWithParents(t *testing.T) {
 		_, paths := prepareFiles(t, files)
 
 		var b bytes.Buffer
-		err := CreateTarWithParents(&b, ".", paths, 10, 100, time.Now())
+		err := CreateTarWithParents(context.Background(), &b, ".", paths, 10, 100, time.Now())
 		t.CheckNoError(err)
 
 		// Make sure the contents match.
@@ -112,7 +113,7 @@ func TestCreateTarGz(t *testing.T) {
 		_, paths := prepareFiles(t, files)
 
 		var b bytes.Buffer
-		err := CreateTarGz(&b, ".", paths)
+		err := CreateTarGz(context.Background(), &b, ".", paths)
 		t.CheckNoError(err)
 
 		// Make sure the contents match.
@@ -147,7 +148,7 @@ func TestCreateTarSubDirectory(t *testing.T) {
 		_, paths := prepareFiles(t, files)
 
 		var b bytes.Buffer
-		err := CreateTar(&b, "sub", paths)
+		err := CreateTar(context.Background(), &b, "sub", paths)
 		t.CheckNoError(err)
 
 		// Make sure the contents match.
@@ -177,7 +178,7 @@ func TestCreateTarEmptyFolder(t *testing.T) {
 			Chdir()
 
 		var b bytes.Buffer
-		err := CreateTar(&b, ".", []string{"empty"})
+		err := CreateTar(context.Background(), &b, ".", []string{"empty"})
 		t.CheckNoError(err)
 
 		// Make sure the contents match.
@@ -210,7 +211,7 @@ func TestCreateTarWithAbsolutePaths(t *testing.T) {
 		tmpDir, paths := prepareFiles(t, files)
 
 		var b bytes.Buffer
-		err := CreateTar(&b, tmpDir.Root(), tmpDir.Paths(paths...))
+		err := CreateTar(context.Background(), &b, tmpDir.Root(), tmpDir.Paths(paths...))
 		t.CheckNoError(err)
 
 		// Make sure the contents match.
@@ -257,7 +258,7 @@ func TestAddFileToTarSymlinks(t *testing.T) {
 		}
 
 		var b bytes.Buffer
-		err := CreateTar(&b, tmpDir.Root(), tmpDir.Paths(paths...))
+		err := CreateTar(context.Background(), &b, tmpDir.Root(), tmpDir.Paths(paths...))
 		t.CheckNoError(err)
 
 		// Make sure the links match.
@@ -281,6 +282,24 @@ func TestAddFileToTarSymlinks(t *testing.T) {
 				t.Errorf("Link destination doesn't match. %s != %s.", link, hdr.Linkname)
 			}
 		}
+	})
+}
+
+func TestAddFileToTarTimeout(t *testing.T) {
+	testutil.Run(t, "", func(t *testutil.T) {
+		files := map[string]string{
+			"foo":     "baz1",
+			"bar/bat": "baz2",
+			"bar/baz": "baz3",
+		}
+		tmpDir, paths := prepareFiles(t, files)
+
+		var b bytes.Buffer
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+		time.Sleep(2 * time.Millisecond)
+		defer cancel()
+		err := CreateTar(ctx, &b, tmpDir.Root(), tmpDir.Paths(paths...))
+		t.CheckErrorContains("context deadline exceeded", err)
 	})
 }
 

--- a/pkg/skaffold/util/tar_test.go
+++ b/pkg/skaffold/util/tar_test.go
@@ -295,8 +295,8 @@ func TestAddFileToTarTimeout(t *testing.T) {
 		tmpDir, paths := prepareFiles(t, files)
 
 		var b bytes.Buffer
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
-		time.Sleep(2 * time.Millisecond)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Nanosecond)
+		time.Sleep(1 * time.Millisecond)
 		defer cancel()
 		err := CreateTar(ctx, &b, tmpDir.Root(), tmpDir.Paths(paths...))
 		t.CheckErrorContains("context deadline exceeded", err)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
**Related**: https://github.com/GoogleContainerTools/skaffold/pull/7887

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->

I found that uploading build context to kaniko pods sometimes stacks when copying build context on same conditions.
I inspected a pod on stack and found three things.
- initContainer keeps running
- `/kaniko/buildcontext` is empty
- `/tmp/complete` file is not created

I did not figure out exact reasons, but it supposed to be caused by creating tarball and uploading to pods.

Current implementation does not has timeout on creating tar, so I implemented this by passing `context.Context`.

**Problem**
This implementation assumes that the copying to pod must finish in 5 minutes, otherwise fail.
So We need to pass timeout duration if required.

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->

All copying steps to kaniko pod must be finished in 5 minutes.

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
