### PR TITLE
fix: backport, divide stdout and stderr from helm to not create corrupted outputs

### DIFF
--- a/pkg/skaffold/deploy/helm/deploy.go
+++ b/pkg/skaffold/deploy/helm/deploy.go
@@ -439,9 +439,19 @@ func (h *Deployer) Render(ctx context.Context, out io.Writer, builds []graph.Art
 		}
 
 		outBuffer := new(bytes.Buffer)
-		if err := h.exec(ctx, outBuffer, false, nil, args...); err != nil {
-			return userErr("std out err", fmt.Errorf(outBuffer.String()))
+		errBuffer := new(bytes.Buffer)
+
+		err = h.execWithStdoutAndStderr(ctx, outBuffer, errBuffer, false, nil, args...)
+		errorMsg := errBuffer.String()
+
+		if len(errorMsg) > 0 {
+			olog.Entry(ctx).Errorf(errorMsg)
 		}
+
+		if err != nil {
+			return userErr("std out err", fmt.Errorf(outBuffer.String(), fmt.Errorf(errorMsg)))
+		}
+
 		renderedManifests.Write(outBuffer.Bytes())
 	}
 

--- a/pkg/skaffold/deploy/helm/deploy.go
+++ b/pkg/skaffold/deploy/helm/deploy.go
@@ -445,7 +445,7 @@ func (h *Deployer) Render(ctx context.Context, out io.Writer, builds []graph.Art
 		errorMsg := errBuffer.String()
 
 		if len(errorMsg) > 0 {
-			olog.Entry(ctx).Errorf(errorMsg)
+			olog.Entry(ctx).Infof(errorMsg)
 		}
 
 		if err != nil {


### PR DESCRIPTION
Fixes: #8327

**Description**
This PR is to backport a v2 fix: using `skaffold render` with a helm deployer, with helm >= 3.10.2, pulling from an OCI registry is generating a corrupted yaml output, so here we are setting two different buffers, one for stdout and another for stderr to split the messages and differentiate between the generated yaml content and the errors.

**Related PRs from v2**
- https://github.com/GoogleContainerTools/skaffold/pull/7825
- https://github.com/GoogleContainerTools/skaffold/pull/7986
- https://github.com/GoogleContainerTools/skaffold/pull/8005
