### PR TITLE
feat: add ingore-path kaniko flag support

### DIFF
--- a/docs-v2/content/en/schemas/v4beta2.json
+++ b/docs-v2/content/en/schemas/v4beta2.json
@@ -2523,6 +2523,15 @@
           "x-intellij-html-description": "building outside of a container.",
           "default": "false"
         },
+        "ignorePaths": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "a list of ignored paths when making an image snapshot.",
+          "x-intellij-html-description": "a list of ignored paths when making an image snapshot.",
+          "default": "[]"
+        },
         "image": {
           "type": "string",
           "description": "Docker image used by the Kaniko pod. Defaults to the latest released version of `gcr.io/kaniko-project/executor`.",
@@ -2729,7 +2738,8 @@
         "label",
         "buildArgs",
         "volumeMounts",
-        "contextSubPath"
+        "contextSubPath",
+        "ignorePaths"
       ],
       "additionalProperties": false,
       "type": "object",

--- a/pkg/skaffold/build/gcb/kaniko_test.go
+++ b/pkg/skaffold/build/gcb/kaniko_test.go
@@ -397,6 +397,17 @@ func TestKanikoBuildSpec(t *testing.T) {
 				kaniko.LabelFlag, "label2",
 			},
 		},
+		{
+			description: "with IgnorePaths",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				IgnorePaths:    []string{"/var", "/tmp"},
+			},
+			expectedArgs: []string{
+				kaniko.IgnorePathFlag, "/var",
+				kaniko.IgnorePathFlag, "/tmp",
+			},
+		},
 	}
 	store := mockArtifactStore{
 		"img2": "img2:tag",

--- a/pkg/skaffold/build/kaniko/args.go
+++ b/pkg/skaffold/build/kaniko/args.go
@@ -174,6 +174,12 @@ func Args(artifact *latest.KanikoArtifact, tag, context string) ([]string, error
 	}
 	args = append(args, sRegArgs...)
 
+	var ignPathArgs []string
+	for _, r := range artifact.IgnorePaths {
+		ignPathArgs = append(ignPathArgs, IgnorePathFlag, r)
+	}
+	args = append(args, ignPathArgs...)
+
 	registryCertificate, err := util.MapToFlag(artifact.RegistryCertificate, RegistryCertificateFlag)
 	if err != nil {
 		return args, err

--- a/pkg/skaffold/build/kaniko/args_test.go
+++ b/pkg/skaffold/build/kaniko/args_test.go
@@ -407,6 +407,18 @@ func TestArgs(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			description: "with IgnorePaths",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "dir/Dockerfile",
+				IgnorePaths:    []string{"/tmp", "/proc"},
+			},
+			expectedArgs: []string{
+				IgnorePathFlag, "/tmp",
+				IgnorePathFlag, "/proc",
+			},
+			wantErr: false,
+		},
 	}
 
 	defaultExpectedArgs := []string{

--- a/pkg/skaffold/build/kaniko/types.go
+++ b/pkg/skaffold/build/kaniko/types.go
@@ -107,4 +107,6 @@ const (
 	DefaultDockerConfigPath = "/kaniko/.docker"
 	// DefaultSecretMountPath for kaniko pod
 	DefaultSecretMountPath = "/secret"
+	// IgnorePath additional flag
+	IgnorePathFlag = "--ignore-path"
 )

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -1387,6 +1387,9 @@ type KanikoArtifact struct {
 
 	// ContextSubPath is to specify a sub path within the context.
 	ContextSubPath string `yaml:"contextSubPath,omitempty" skaffold:"filepath"`
+
+	// IgnorePaths is a list of ignored paths when making an image snapshot.
+	IgnorePaths []string `yaml:"ignorePaths,omitempty"`
 }
 
 // DockerArtifact describes an artifact built from a Dockerfile,


### PR DESCRIPTION
**Related**:  https://github.com/GoogleContainerTools/kaniko/issues/2164

**Description**
For local development we are using skaffold. Also, as we are from Ukraine and there could be no elictricty or no internet we need to be able to working offline. For such purposes we  have created a script which ups the kind cluster and we can continue working on.
On mac based systems we don't have any issues with kind and kaniko. 
But unfortunately on linux machines we have a similar issue as in linked kaniko issue.
So we need to add such flag to kaniko.

**User facing changes**

Ability to add an ingore paths for kaniko.
