### PR TITLE
fix: change log level to Info so `skaffold render --output=render.yaml` produces same output as `skaffold render &> render.yaml`

### DIFF
--- a/pkg/skaffold/render/renderer/helm/helm.go
+++ b/pkg/skaffold/render/renderer/helm/helm.go
@@ -161,7 +161,7 @@ func (h Helm) generateHelmManifests(ctx context.Context, builds []graph.Artifact
 		errorMsg := errBuffer.String()
 
 		if len(errorMsg) > 0 {
-			log.Entry(ctx).Errorf(errorMsg)
+			log.Entry(ctx).Infof(errorMsg)
 		}
 
 		if err != nil {


### PR DESCRIPTION
**Related**: #8327

**Description**
Related with #8327 , this change is for v2 to have the same output when we run `skaffold render --output=render.yaml` and `skaffold render &> render.yaml`