### PR TITLE
docs: remove `log tailing` from note of unsupported features for Cloud Run

### DIFF
--- a/docs-v2/content/en/docs/pipeline-stages/deployers/cloudrun.md
+++ b/docs-v2/content/en/docs/pipeline-stages/deployers/cloudrun.md
@@ -6,7 +6,7 @@ featureId: deploy.cloudrun
 ---
 
 {{< alert title="Note" >}}
-This feature is currently experimental and subject to change. Not all Skaffold features e.g. log tailing, debugging are supported.
+This feature is currently experimental and subject to change. Not all Skaffold features e.g. debugging are supported.
 {{< /alert >}}
 
 Cloud Run is a managed compute platform on Google Cloud that allows you to run containers on Google's infrastructure.

--- a/docs-v2/content/en/docs/pipeline-stages/deployers/cloudrun.md
+++ b/docs-v2/content/en/docs/pipeline-stages/deployers/cloudrun.md
@@ -6,7 +6,7 @@ featureId: deploy.cloudrun
 ---
 
 {{< alert title="Note" >}}
-This feature is currently experimental and subject to change. Not all Skaffold features e.g. debugging are supported.
+This feature is currently experimental and subject to change. Not all Skaffold features are supported, for example `debug` is currently not supported in Cloud Run (but is on our roadmap).
 {{< /alert >}}
 
 Cloud Run is a managed compute platform on Google Cloud that allows you to run containers on Google's infrastructure.


### PR DESCRIPTION
**Related**: https://github.com/GoogleContainerTools/skaffold/pull/8338

**Description**
Remove `log tailing` from the unsupported features for Cloud Run, we should support this now for all the cases