### PR TITLE
feat: add support for remote docker over ssh

### DIFF
--- a/pkg/skaffold/docker/client.go
+++ b/pkg/skaffold/docker/client.go
@@ -21,11 +21,13 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
 
+	"github.com/docker/cli/cli/connhelper"
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/tlsconfig"
 
@@ -92,7 +94,22 @@ func newAPIClient(ctx context.Context, kubeContext string, minikubeProfile strin
 // It will "negotiate" the highest possible API version supported by both the client
 // and the server if there is a mismatch.
 func newEnvAPIClient() ([]string, client.CommonAPIClient, error) {
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithHTTPHeaders(getUserAgentHeader()))
+	var opts = []client.Opt{client.WithHTTPHeaders(getUserAgentHeader())}
+	if host := os.Getenv("DOCKER_HOST"); host != "" {
+		helper, err := connhelper.GetConnectionHelper(host)
+		if err == nil && helper != nil {
+			httpClient := &http.Client{
+				Transport: &http.Transport{
+					DialContext: helper.Dialer,
+				},
+			}
+			opts = append(opts, client.WithHTTPClient(httpClient), client.WithHost(helper.Host))
+		} else {
+			opts = append(opts, client.FromEnv)
+		}
+	}
+
+	cli, err := client.NewClientWithOpts(opts...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error getting docker client: %s", err)
 	}

--- a/pkg/skaffold/docker/client_test.go
+++ b/pkg/skaffold/docker/client_test.go
@@ -53,7 +53,7 @@ func TestNewEnvClient(t *testing.T) {
 			envs: map[string]string{
 				"DOCKER_HOST": "ssh://127.0.0.1",
 			},
-			shouldErr: true,
+			shouldErr: false,
 		},
 	}
 	for _, test := range tests {

--- a/pkg/skaffold/docker/client_test.go
+++ b/pkg/skaffold/docker/client_test.go
@@ -48,6 +48,13 @@ func TestNewEnvClient(t *testing.T) {
 			},
 			shouldErr: true,
 		},
+		{
+			description: "ssh",
+			envs: map[string]string{
+				"DOCKER_HOST": "ssh://127.0.0.1",
+			},
+			shouldErr: true,
+		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #5703

**Description**
this pr adds support for remote docker over ssh using [connhelper package](https://github.com/docker/cli/tree/master/cli/connhelper), the feat was introduced by docker cli by this commit:  https://github.com/docker/cli/pull/1014
 

### TestCase

open google cloud shell: 

https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/catusax/skaffold&cloudshell_git_branch=docker-ssh-support&cloudshell_open_in_editor=examples/cross-platform-builds/skaffold.yaml


```shell

# setup ssh
ssh-keygen
cat ~/.ssh/id_rsa.pub > ~/.ssh/authorized_keys
chmod 640 ~/.ssh/authorized_keys
sudo service ssh restart
ssh-copy-id 127.0.0.1
export DOCKER_HOST=ssh://127.0.0.1

# setup docker
export DOCKER_USER=<your dockerhub userid>
docker login -u $DOCKER_USER

export ROOT=$PWD && export PROJECT=$ROOT/examples/cross-platform-builds
cd $PROJECT

sed -i 's/skaffold-example/${DOCKER_USER}\/skaffold-example/g' skaffold.yaml
skaffold build # this will fail
# Cannot connect to the Docker daemon at ssh://127.0.0.1. Is the docker daemon running?. Docker build ran into internal error. Please retry.
# If this keeps happening, please open an issue..

# build new patch
cd $ROOT && LOCAL=true make 
sudo cp out/skaffold /usr/bin/skaffold

# build with ssh support
cd $PROJECT
skaffold build # success

# without ssh
unset DOCKER_HOST
skaffold build # success

```


