### PR TITLE
fix: resolve issue where kubectl Flags.Apply namespace flag usage would fail

### DIFF
--- a/pkg/skaffold/deploy/kubectl/cli.go
+++ b/pkg/skaffold/deploy/kubectl/cli.go
@@ -35,6 +35,7 @@ import (
 	kstatus "github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/kubernetes/status"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/output/log"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/util"
 )
 
 // CLI holds parameters to run kubectl.
@@ -208,6 +209,11 @@ func (c *CLI) ReadManifests(ctx context.Context, manifests []string) (manifest.M
 	}
 
 	args := c.args([]string{dryRun, "-oyaml"}, list...)
+
+	if ns := util.ParseNamespaceFromFlags(c.Flags.Apply); ns != "" {
+		args = append(args, "-n", ns)
+	}
+
 	if c.Flags.DisableValidation {
 		args = append(args, "--validate=false")
 	}

--- a/pkg/skaffold/inspect/namespaces/list.go
+++ b/pkg/skaffold/inspect/namespaces/list.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/inspect"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/webhook/constants"
 )
 
@@ -104,10 +105,10 @@ func PrintNamespacesList(ctx context.Context, out io.Writer, manifestFile string
 			if c.Deploy.KubectlDeploy.DefaultNamespace != nil && *c.Deploy.KubectlDeploy.DefaultNamespace != "" {
 				defaultNamespace = *c.Deploy.KubectlDeploy.DefaultNamespace
 			}
-			if namespaceVal := parseNamespaceFromFlags(c.Deploy.KubectlDeploy.Flags.Global); namespaceVal != "" {
+			if namespaceVal := util.ParseNamespaceFromFlags(c.Deploy.KubectlDeploy.Flags.Global); namespaceVal != "" {
 				flagNamespace = namespaceVal
 			}
-			if namespaceVal := parseNamespaceFromFlags(c.Deploy.KubectlDeploy.Flags.Apply); namespaceVal != "" {
+			if namespaceVal := util.ParseNamespaceFromFlags(c.Deploy.KubectlDeploy.Flags.Apply); namespaceVal != "" {
 				flagNamespace = namespaceVal
 			}
 			// NOTE: Cloud Deploy uses `skaffold apply` which always uses kubectl deployer.  As such other
@@ -129,22 +130,4 @@ func PrintNamespacesList(ctx context.Context, out io.Writer, manifestFile string
 	l := &resourceToInfoContainer{ResourceToInfoMap: resourceToInfoMap}
 
 	return formatter.Write(l)
-}
-
-func parseNamespaceFromFlags(flgs []string) string {
-	for i, s := range flgs {
-		if s == "-n" && i < len(flgs)-1 {
-			return flgs[i+1]
-		}
-		if strings.HasPrefix(s, "-n=") && len(strings.Split(s, "=")) == 2 {
-			return strings.Split(s, "=")[1]
-		}
-		if s == "--namespace" && i < len(flgs)-1 {
-			return flgs[i+1]
-		}
-		if strings.HasPrefix(s, "--namespace=") && len(strings.Split(s, "=")) == 2 {
-			return strings.Split(s, "=")[1]
-		}
-	}
-	return ""
 }

--- a/pkg/skaffold/util/util.go
+++ b/pkg/skaffold/util/util.go
@@ -320,3 +320,21 @@ func SanitizeHelmTemplateValue(s string) string {
 	// replaces commonly used image name chars that are illegal go template chars -> replaces "/", "-" and "." with "_"
 	return strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(s, ".", "_"), "-", "_"), "/", "_")
 }
+
+func ParseNamespaceFromFlags(flgs []string) string {
+	for i, s := range flgs {
+		if s == "-n" && i < len(flgs)-1 {
+			return flgs[i+1]
+		}
+		if strings.HasPrefix(s, "-n=") && len(strings.Split(s, "=")) == 2 {
+			return strings.Split(s, "=")[1]
+		}
+		if s == "--namespace" && i < len(flgs)-1 {
+			return flgs[i+1]
+		}
+		if strings.HasPrefix(s, "--namespace=") && len(strings.Split(s, "=")) == 2 {
+			return strings.Split(s, "=")[1]
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
fixes #8336 

Adding that issue text inline below:

There is currently an issue where skaffold apply uses incorrect namespace if kubectl `-n` or `--namespace` flag is provided in deploy.kubectl.flags.apply field

Repro:

`skaffold.yaml`
```
apiVersion: skaffold/v4beta1
kind: Config
build:
  tagPolicy:
    gitCommit: {}
  local: {}
manifests:
  rawYaml:
  - /workspace/source/deployment.yaml
  - /workspace/source/service.yaml
  - /workspace/source/httproute.yaml
deploy:
  kubectl:
    flags:
      apply:
      - --namespace=service-mesh
  logs:
    prefix: container
```

`manifests.yaml`
```
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: service-mesh
  name: service-mesh-deployment
spec:
  replicas: 3
  selector:
    matchLabels:
      app: service-mesh
  strategy:
    rollingUpdate:
      maxSurge: 1
      maxUnavailable: 0
    type: RollingUpdate
  template:
    metadata:
      labels:
        app: service-mesh
    spec:
      containers:
      - image: gcr.io/google-containers/nginx:latest
        imagePullPolicy: Always
        name: hello-app
```

Unexpected/Bug-indicating Error message (should work):
```
- the namespace from the provided object "default" does not match the namespace "service-mesh". You must pass '--namespace=default' to perform this operation.
```

Works with:
```
    flags:
      global:
      - --namespace=service-mesh
```

But not:
```
    flags:
      apply:
      - --namespace=service-mesh
```