### PR TITLE
test: integration test for helm render with OCI repo

### DIFF
--- a/integration/skaffold/helper.go
+++ b/integration/skaffold/helper.go
@@ -47,6 +47,8 @@ type RunBuilder struct {
 	stdin      []byte
 }
 
+const DefaultRepo = "us-central1-docker.pkg.dev/k8s-skaffold/testing"
+
 // Apply runs `skaffold apply` with the given arguments.
 func Apply(args ...string) *RunBuilder {
 	return withDefaults("apply", args)
@@ -144,7 +146,7 @@ func GeneratePipeline(args ...string) *RunBuilder {
 func withDefaults(command string, args []string) *RunBuilder {
 	repo := os.Getenv("DEFAULT_REPO")
 	if repo == "" {
-		repo = "us-central1-docker.pkg.dev/k8s-skaffold/testing"
+		repo = DefaultRepo
 	}
 	return &RunBuilder{command: command, args: args, repo: repo}
 }


### PR DESCRIPTION
**Related PRs**:
- https://github.com/GoogleContainerTools/skaffold/pull/7825
- https://github.com/GoogleContainerTools/skaffold/pull/7986
- https://github.com/GoogleContainerTools/skaffold/pull/8005

**Related PR from v1**:
- https://github.com/GoogleContainerTools/skaffold/pull/8333

**Description**
This is to test the render command with a helm chart located in a OCI repository. Using skaffold with helm  >= 3.10.2, injects some corrupted data in the generated yaml file, this was already fixed, but an integration test to validate the behavior was missing. 

A helm chart was created and uploaded to `us-central1-docker.pkg.dev/k8s-skaffold/testing/skaffold-helm-chart`; to be able to run the test we need this chart.