### PR TITLE
docs: add more detail to Cloud Run deployer page

### DIFF
--- a/docs-v2/content/en/docs/pipeline-stages/deployers/cloudrun.md
+++ b/docs-v2/content/en/docs/pipeline-stages/deployers/cloudrun.md
@@ -9,23 +9,143 @@ featureId: deploy.cloudrun
 This feature is currently experimental and subject to change. Not all Skaffold features are supported, for example `debug` is currently not supported in Cloud Run (but is on our roadmap).
 {{< /alert >}}
 
-Cloud Run is a managed compute platform on Google Cloud that allows you to run containers on Google's infrastructure.
+[Cloud Run](https://cloud.google.com/run) is a managed compute platform on Google Cloud that allows you to run containers on Google's infrastructure. With Skaffold, now you are able to configure your dev loop to build, test, sync and use Cloud Run as deployer for your images.
 
 
 ## Deploying applications to Cloud Run
-
-Skaffold can deploy services to Cloud Run. If this deployer is used, all provided manifests must be valid Cloud Run services, using the serving.knative.dev/v1 schema.
+Skaffold can deploy services and jobs to Cloud Run. If this deployer is used, all provided manifests must be valid Cloud Run services, using the `serving.knative.dev/v1` schema, or valid Cloud Run jobs.
 See the [Cloud Run YAML reference](https://cloud.google.com/run/docs/reference/yaml/v1) for supported fields.
 
-This deployer will use the [application default credentials](https://cloud.google.com/docs/authentication/production#automatically) to deploy.  You can configure this to use your user credentials by running `gcloud auth application-default login`.
+### Environment setup
+In order to use this deployer you'll need to configure some tools first.
 
-# Features
-- As of Skaffold `v2.1.0`, Skaffold's Cloud Run Deployer now supports log streaming from the deployed Cloud Run Service(s)/Job(s).  NOTE: this requires installing the following `gcloud components`: `alpha`, `beta`, `cloud-run-proxy`, and `log-streaming`
-- Supports deploying Cloud Run `Service` and `Job` objects
+The deployer uses `gcloud` CLI to perform its tasks, so be sure it is installed in your environment. It will use the [application default credentials](https://cloud.google.com/docs/authentication/production#automatically) to deploy.  You can configure this to use your user credentials by running:
+```bash
+gcloud auth application-default login
+```
+
+To enable [Log streaming]({{< relref "#log-streaming" >}}) and [Port forwarding]({{< relref "#port-forwarding" >}}) some extra components are needed from `gcloud`. To install them run the following comand in your terminal:
+```bash
+gcloud components install --quiet \
+    alpha \
+    beta \
+    log-streaming \
+    cloud-run-proxy
+```
+
+From the previous command, `alpha` and `log-streaming` components are needed for [Log streaming]({{< relref "#log-streaming" >}}), `beta` and `cloud-run-proxy` components are needed for [Port forwarding]({{< relref "#port-forwarding" >}}).
+
+## Features
+
+### Cloud Run Services and Jobs deployment
+With Skaffold you can deploy Cloud Run [Services](https://cloud.google.com/run/docs/overview/what-is-cloud-run#services) and [Jobs](https://cloud.google.com/run/docs/overview/what-is-cloud-run#jobs) just referencing them from the `skaffold.yaml` file. The following example ilustrates a project using the Cloud Run deployer:
+
+With the following project folder structure:
+```yaml
+resources/
+  cloud-run-service.yaml
+  cloud-run-job.yaml
+skaffold.yaml
+```
+
+`cloud-run-service.yaml` content:
+```yaml
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: cloud-run-service-name
+spec:
+  template:
+    spec:
+      containers:
+      - image: gcr.io/cloudrun/hello
+```
+
+`cloud-run-job.yaml` content:
+```yaml
+apiVersion: run.googleapis.com/v1
+kind: Job
+metadata:
+  name: cloud-run-job-name
+  annotations:
+    run.googleapis.com/launch-stage: BETA
+spec:
+  template:
+    spec:
+      template:
+        spec:
+          containers:
+          - image: us-docker.pkg.dev/cloudrun/container/job
+```
+
+`skaffold.yaml` content:
+{{% readfile file="samples/deployers/cloud-run/simple-service-job-deployment.yaml" %}}
+
+Running `skaffold run` will deploy one Cloud Run service, and one Cloud Run job in the `YOUR-GCP-PROJECT` project, inside the given `GCP-REGION`.
+
+**Note:** the previous example will deploy a Cloud Run job, however, it will not trigger an execution for that job. To read more about jobs execution you can check the [Cloud Run docs](https://cloud.google.com/run/docs/execute/jobs).
+
+### Port forwarding {#port-forwarding}
+
+Skaffold will manage automatically the necessary configuration to open the deployed Cloud Run services URLs locally, even if they are private services, using the [Cloud Run proxy](https://cloud.google.com/sdk/gcloud/reference/beta/run/services/proxy) and Skaffold's Port Forwarding. To enable this, you will have to either add the `--port-forward` flag running Skaffold, or add a `portForward` stanza in your `skaffold.yaml` file. From the previous example, running `skaffold dev --port-forward` will result in the following output:
+
+```
+...
+Deploying Cloud Run service:
+         cloud-run-job-name
+Deploying Cloud Run service:
+         cloud-run-service-name
+Cloud Run Job cloud-run-job-name finished: Job started. 1/2 deployment(s) still pending
+cloud-run-service-name: Service starting: Deploying Revision. Waiting on revision cloud-run-service-name-2246v.
+cloud-run-service-name: Service starting: Deploying Revision. Waiting on revision cloud-run-service-name-2246v.
+Cloud Run Service cloud-run-service-name finished: Service started. 0/2 deployment(s) still pending
+Forwarding service projects/<YOUR-GCP-PROJECT>/locations/<GCP-REGION>/services/cloud-run-service-name to local port 8080
+...
+```
+
+Here you'll see the port to use to access the deployed Cloud Run service, in this case you can access it through `localhost:8080`. If you need to change the local port used, you'll need to add a `portForward` stanza:
+
+Using the previous example, changing `skaffold.yaml` to:
+{{% readfile file="samples/deployers/cloud-run/service-port-forward.yaml" %}}
+
+Running `skaffold dev --port-forward`, will result in:
+
+```
+...
+Forwarding service projects/<YOUR-GCP-PROJECT>/locations/<GCP-REGION>/services/cloud-run-service-name to local port 9001
+...
+```
+
+Now you will be able to access the deployed service through `localhost:9001`.
+
+
+### Log streaming {#log-streaming}
+
+On [active development]({{< relref "docs/workflows/dev">}}), Skaffold will log stream to your console the output from the Cloud Run services deployed. From the previous example, running `skaffold dev --port-forward` or `skaffold run --tail --port-forward` in your terminal, you will see the following output:
+
+```
+...
+Cloud Run Service cloud-run-service-name finished: Service started. 0/2 deployment(s) still pending
+Forwarding service projects/<YOUR-GCP-PROJECT>/locations/<GCP-REGION>/services/cloud-run-service-name to local port 9001
+No artifacts found to watch
+Press Ctrl+C to exit
+Watching for changes...
+[cloud-run-service-name] streaming logs from <YOUR-GCP-PROJECT>
+...
+```
+
+Now Skaffold is log streaming the output from the service. If you access it through `localhost:9001`, you'll see the logs:
+
+```
+...
+[cloud-run-service-name] streaming logs from renzo-friction-log-cloud-run
+[cloud-run-service-name] 2023-01-27 00:52:22 2023/01/27 00:52:22 Hello from Cloud Run! The container started successfully and is listening for HTTP requests on $PORT
+[cloud-run-service-name] 2023-01-27 00:52:22 GET 200 https://cloud-run-service-name-6u2evvstna-uc.a.run.app/
+```
 
 ## Configuring Cloud Run
 
-To deploy to Cloud Run, use the `cloudrun` type in the `deploy` section of `skaffold.yaml`.
+To deploy to Cloud Run, use the `cloudrun` type in the `deploy` section, together with `manifests.rawYaml` stanza of `skaffold.yaml`.
 
 The `cloudrun` type offers the following options:
 
@@ -34,10 +154,9 @@ The `cloudrun` type offers the following options:
 
 ### Example
 
-The following `deploy` section instructs Skaffold to deploy
-artifacts to Cloud Run:
+The following `deploy` section instructs Skaffold to deploy the artifacts under `manifests.rawYaml` to Cloud Run:
 
-{{% readfile file="samples/deployers/cloudrun.yaml" %}}
+{{% readfile file="samples/deployers/cloud-run/cloud-run.yaml" %}}
 
 {{< alert title="Note" >}}
 Images listed to be deployed with the Cloud Run deployer must be present in Google Artifact

--- a/docs-v2/content/en/docs/pipeline-stages/deployers/cloudrun.md
+++ b/docs-v2/content/en/docs/pipeline-stages/deployers/cloudrun.md
@@ -9,17 +9,17 @@ featureId: deploy.cloudrun
 This feature is currently experimental and subject to change. Not all Skaffold features are supported, for example `debug` is currently not supported in Cloud Run (but is on our roadmap).
 {{< /alert >}}
 
-[Cloud Run](https://cloud.google.com/run) is a managed compute platform on Google Cloud that allows you to run containers on Google's infrastructure. With Skaffold, now you are able to configure your dev loop to build, test, sync and use Cloud Run as deployer for your images.
+[Cloud Run](https://cloud.google.com/run) is a managed compute platform on Google Cloud that allows you to run containers on Google's infrastructure. With Skaffold, now you are able to configure your dev loop to build, test, sync and use Cloud Run as the deployer for your images.
 
 
 ## Deploying applications to Cloud Run
-Skaffold can deploy services and jobs to Cloud Run. If this deployer is used, all provided manifests must be valid Cloud Run services, using the `serving.knative.dev/v1` schema, or valid Cloud Run jobs.
+Skaffold can deploy [Services](https://cloud.google.com/run/docs/reference/rest/v1/namespaces.services#resource:-service) and [Jobs](https://cloud.google.com/run/docs/reference/rest/v1/namespaces.jobs#resource:-job) to Cloud Run. If this deployer is used, all provided manifests must be valid Cloud Run services, using the `serving.knative.dev/v1` schema, or valid Cloud Run jobs.
 See the [Cloud Run YAML reference](https://cloud.google.com/run/docs/reference/yaml/v1) for supported fields.
 
 ### Environment setup
 In order to use this deployer you'll need to configure some tools first.
 
-The deployer uses `gcloud` CLI to perform its tasks, so be sure it is installed in your environment. It will use the [application default credentials](https://cloud.google.com/docs/authentication/production#automatically) to deploy.  You can configure this to use your user credentials by running:
+The deployer uses the `gcloud` CLI to perform its tasks, so be sure it is installed in your environment. It will use the [application default credentials](https://cloud.google.com/docs/authentication/production#automatically) to deploy.  You can configure this to use your user credentials by running:
 ```bash
 gcloud auth application-default login
 ```
@@ -121,7 +121,7 @@ Now you will be able to access the deployed service through `localhost:9001`.
 
 ### Log streaming {#log-streaming}
 
-On [active development]({{< relref "docs/workflows/dev">}}), Skaffold will log stream to your console the output from the Cloud Run services deployed. From the previous example, running `skaffold dev --port-forward` or `skaffold run --tail --port-forward` in your terminal, you will see the following output:
+When doing [local development]({{< relref "docs/workflows/dev">}}), Skaffold will log stream to your console the output from the Cloud Run services deployed. From the previous example, running `skaffold dev --port-forward` or `skaffold run --tail --port-forward` in your terminal, you will see the following output:
 
 ```
 ...

--- a/docs-v2/content/en/docs/pipeline-stages/deployers/cloudrun.md
+++ b/docs-v2/content/en/docs/pipeline-stages/deployers/cloudrun.md
@@ -53,7 +53,7 @@ skaffold.yaml
 apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
-  name: cloud-run-service-name
+  name: cloud-run-service-name # this service will be created in Cloud Run via Skaffold
 spec:
   template:
     spec:
@@ -66,7 +66,7 @@ spec:
 apiVersion: run.googleapis.com/v1
 kind: Job
 metadata:
-  name: cloud-run-job-name
+  name: cloud-run-job-name # this job will be created in Cloud Run via Skaffold
   annotations:
     run.googleapis.com/launch-stage: BETA
 spec:
@@ -83,7 +83,9 @@ spec:
 
 Running `skaffold run` will deploy one Cloud Run service, and one Cloud Run job in the `YOUR-GCP-PROJECT` project, inside the given `GCP-REGION`.
 
-**Note:** the previous example will deploy a Cloud Run job, however, it will not trigger an execution for that job. To read more about jobs execution you can check the [Cloud Run docs](https://cloud.google.com/run/docs/execute/jobs).
+{{< alert title="Note" >}}
+The previous example will deploy a Cloud Run job, however, it will not trigger an execution for that job. To read more about jobs execution you can check the [Cloud Run docs](https://cloud.google.com/run/docs/execute/jobs).
+{{< /alert >}}
 
 ### Port forwarding {#port-forwarding}
 

--- a/docs-v2/content/en/samples/deployers/cloud-run/cloud-run.yaml
+++ b/docs-v2/content/en/samples/deployers/cloud-run/cloud-run.yaml
@@ -1,0 +1,8 @@
+manifests:
+  rawYaml: # Here should be the list of all the Cloud Run Services and Jobs to deploy
+    - cloud-run-service.yaml 
+
+deploy:
+  cloudrun:
+    projectid: my-gcp-project
+    region: us-central1

--- a/docs-v2/content/en/samples/deployers/cloud-run/service-port-forward.yaml
+++ b/docs-v2/content/en/samples/deployers/cloud-run/service-port-forward.yaml
@@ -1,0 +1,17 @@
+apiVersion: skaffold/v4beta2
+kind: Config
+
+manifests:
+  rawYaml:
+    - resources/*
+
+deploy:
+  cloudrun:
+    projectid: YOUR-GCP-PROJECT
+    region: GCP-REGION
+
+# Added to change local port used
+portForward:
+  - resourceType: service
+    resourceName: cloud-run-service-name
+    localPort: 9001

--- a/docs-v2/content/en/samples/deployers/cloud-run/simple-service-job-deployment.yaml
+++ b/docs-v2/content/en/samples/deployers/cloud-run/simple-service-job-deployment.yaml
@@ -1,0 +1,11 @@
+apiVersion: skaffold/v4beta2
+kind: Config
+
+manifests:
+  rawYaml:
+    - resources/*
+
+deploy:
+  cloudrun:
+    projectid: YOUR-GCP-PROJECT
+    region: GCP-REGION

--- a/docs-v2/data/maturity.json
+++ b/docs-v2/data/maturity.json
@@ -274,7 +274,7 @@
     "run": "x",
     "area": "Deploy",
     "feature": "Cloud Run Deployer",
-    "maturity": "alpha",
+    "maturity": "beta",
     "description": "Deploy applications to Google Cloud Run"
   },
   "deploy.docker": {


### PR DESCRIPTION
<!-- Include if applicable: -->
Fixes: #8320

**Description**
This PR adds more details for the [Cloud Run deployer](https://skaffold.dev/docs/pipeline-stages/deployers/cloudrun/) page.

- http://35.226.237.45:1313/docs/pipeline-stages/deployers/cloudrun/
