### PR TITLE
fix:  envTemplate is not working with command template and output with…

### DIFF
--- a/integration/build_test.go
+++ b/integration/build_test.go
@@ -89,6 +89,12 @@ func TestBuild(t *testing.T) {
 			args:        []string{"-p", "args", "-t", "foo"},
 			expectImage: imageName + "foo",
 		},
+		{
+			description: "envTemplate command tagger",
+			dir:         "testdata/tagPolicy",
+			args:        []string{"-p", "envTemplateCmd"},
+			expectImage: imageName + "1.0.0",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {

--- a/integration/testdata/tagPolicy/skaffold.yaml
+++ b/integration/testdata/tagPolicy/skaffold.yaml
@@ -29,3 +29,8 @@ profiles:
       envTemplate:
         template: "tag"
 - name: args
+- name: envTemplateCmd
+  build:
+    tagPolicy:
+      envTemplate:
+        template: '{{cmd "bash" "-c" "echo 1.0.0"}}'

--- a/pkg/skaffold/util/env_template.go
+++ b/pkg/skaffold/util/env_template.go
@@ -166,5 +166,5 @@ func defaultFunc(dflt, value interface{}) interface{} {
 func runCmdFunc(name string, args ...string) (string, error) {
 	cmd := exec.Command(name, args...)
 	out, err := RunCmdOut(context.TODO(), cmd)
-	return string(out), err
+	return strings.TrimSpace(string(out)), err
 }


### PR DESCRIPTION
 - envTemplate is not working with command template and output with spaces
 - trim leading and tailing spaces to fix the issue 

