### PR TITLE
feat: define `skaffold.env` file for loading environment variables

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/joho/godotenv"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/kubectl/pkg/util/templates"
@@ -208,6 +209,7 @@ func NewSkaffoldCommand(out, errOut io.Writer) *cobra.Command {
 	rootCmd.PersistentFlags().BoolVar(&timestamps, "timestamps", false, "Print timestamps in logs")
 	rootCmd.PersistentFlags().MarkHidden("force-colors")
 
+	setEnvVariablesFromFile()
 	setFlagsFromEnvVariables(rootCmd)
 
 	return rootCmd
@@ -223,6 +225,18 @@ func NewCmdOptions() *cobra.Command {
 	templates.UseOptionsTemplates(cmd)
 
 	return cmd
+}
+
+// setEnvVariablesFromFile will read the `skaffold.env` file and load them into ENV for this process.
+func setEnvVariablesFromFile() {
+	if _, err := os.Stat(constants.SkaffoldEnvFile); os.IsNotExist(err) {
+		log.Entry(context.TODO()).Debugf("Skipped loading environment variables from file %q: %s", constants.SkaffoldEnvFile, err)
+		return
+	}
+	err := godotenv.Load(constants.SkaffoldEnvFile)
+	if err != nil {
+		log.Entry(context.TODO()).Warnf("Failed to load environment variables from file %q: %s", constants.SkaffoldEnvFile, err)
+	}
 }
 
 // Each flag can also be set with an env variable whose name starts with `SKAFFOLD_`.

--- a/docs-v2/content/en/docs/environment/_index.md
+++ b/docs-v2/content/en/docs/environment/_index.md
@@ -8,6 +8,7 @@ no_list: true
 
 | Environment Management with Skaffold | |
 |----------|---|
+| [Environment Variables File]({{< relref "env-file.md" >}}) | Loading environment variables from a file |
 | [Image Registry Handling]({{< relref "image-registries.md" >}}) | Controlling where your images are pushed |
 | [kube-context]({{< relref "kube-context.md" >}}) | Managing the active Kubernetes context for your cluster |
 | [Local Cluster]({{< relref "local-cluster.md" >}}) | Offline development with Skaffold and Minikube |

--- a/docs-v2/content/en/docs/environment/env-file.md
+++ b/docs-v2/content/en/docs/environment/env-file.md
@@ -1,0 +1,38 @@
+---
+title: "Load environment variables from a file"
+linkTitle: "Load ENV from a file"
+weight: 50
+aliases: [/docs/concepts/env_file]
+---
+
+In Skaffold, a `skaffold.env` file can be defined in the project root directory to specify environment variables that Skaffold will load into the process. This provides a more organized and manageable way of setting environment variables, rather than passing them as command line arguments.
+
+The `skaffold.env` file should be in the format of `KEY=value` pairs, with one pair per line. Skaffold will automatically load these variables into the environment before running any commands.
+
+Here is an example `skaffold.env` file:
+
+```txt
+ENV_VAR_1=value1
+ENV_VAR_2=value2
+```
+
+{{< alert title="Note" >}}
+Values set in a `skaffold.env` file will not overwrite existing environment variables in the process.
+{{< /alert >}}
+
+### Setting Skaffold Flags with Environment Variables
+
+In addition to loading environment variables from the `skaffold.env` file, Skaffold also allows users to set flags using environment variables. To set a flag using an environment variable, use the `SKAFFOLD_` prefix and convert the flag name to uppercase.
+
+For example, to set the `--cache-artifacts` flag to `true`, the equivalent environment variable would be `SKAFFOLD_CACHE_ARTIFACTS=true`.
+
+Here is an example usage in the `skaffold.env` file:
+
+```txt
+SKAFFOLD_CACHE_ARTIFACTS=true
+SKAFFOLD_NAMESPACE=mynamespace
+```
+
+{{< alert title="Note" >}}
+If a flag is set both in the `skaffold.env` file and as a command line argument, the value specified in the command line argument will take precedence.
+{{< /alert >}}

--- a/go.mod
+++ b/go.mod
@@ -209,6 +209,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/joho/godotenv v1.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1463,6 +1463,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfC
 github.com/jmoiron/sqlx v1.2.1-0.20190826204134-d7d95172beb5/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/joefitzgerald/rainbow-reporter v0.1.0/go.mod h1:481CNgqmVHQZzdIbN52CupLJyoVwB10FQ/IQlF1pdL8=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
+github.com/joho/godotenv v1.4.0 h1:3l4+N6zfMWnkbPEXKng2o2/MR5mSwTrBih4ZEkkz1lg=
+github.com/joho/godotenv v1.4.0/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=

--- a/integration/examples/README.md
+++ b/integration/examples/README.md
@@ -22,10 +22,11 @@ When deploying to a [local cluster](https://skaffold.dev/docs/environment/local-
 
 ## Deploying to a remote cluster
 
-When deploying to a remote cluster you have to point Skaffold to your default image repository in one of the four ways:
+When deploying to a remote cluster you have to point Skaffold to your default image repository in one of the five ways:
 
 * flag: `skaffold dev --default-repo <myrepo>`
 * env var: `SKAFFOLD_DEFAULT_REPO=<myrepo> skaffold dev`
+* env var file: create a file `skaffold.env` in the project root, with the line `SKAFFOLD_DEFAULT_REPO=<myrepo>`
 * global skaffold config (one time): `skaffold config set --global default-repo <myrepo>`
 * skaffold config for current kubectl context: `skaffold config set default-repo <myrepo>`
 

--- a/pkg/skaffold/constants/constants.go
+++ b/pkg/skaffold/constants/constants.go
@@ -57,6 +57,9 @@ const (
 	DefaultCacheFile   = "cache"
 	DefaultMetricFile  = "metrics"
 
+	// SkaffoldEnvFile is the file that is parsed to set environment variables in the process
+	SkaffoldEnvFile = "skaffold.env"
+
 	DefaultPortForwardAddress = "127.0.0.1"
 
 	DefaultProjectDescriptor = "project.toml"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #1545, #7913 <!-- tracking issues that this PR will close -->
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
In Skaffold, a `skaffold.env` file can be defined in the project root directory to specify environment variables that Skaffold will load into the process. This provides a more organized and manageable way of setting environment variables, rather than passing them as command line arguments.

The `skaffold.env` file should be in the format of `KEY=value` pairs, with one pair per line. Skaffold will automatically load these variables into the environment before running any commands.

Here is an example `skaffold.env` file:

```txt
ENV_VAR_1=value1
ENV_VAR_2=value2
```

### Setting Skaffold Flags with Environment Variables

In addition to loading environment variables from the `skaffold.env` file, Skaffold also allows users to set flags using environment variables. To set a flag using an environment variable, use the `SKAFFOLD_` prefix and convert the flag name to uppercase.

For example, to set the `--cache-artifacts` flag to `true`, the equivalent environment variable would be `SKAFFOLD_CACHE_ARTIFACTS=true`.

Here is an example usage in the `skaffold.env` file:

```txt
SKAFFOLD_CACHE_ARTIFACTS=true
SKAFFOLD_NAMESPACE=mynamespace
```