### PR TITLE
docs: Upgrade hugo and docsy versions to enable collapsible nav

### DIFF
--- a/deploy/webhook-v2/Dockerfile
+++ b/deploy/webhook-v2/Dockerfile
@@ -14,7 +14,8 @@
 
 # Download Docsy theme for Hugo
 FROM alpine:3.10 as download-docsy
-ENV DOCSY_VERSION 3c4280bae0db96cb272ddc4b4959b2beef9299af
+# v0.3.0
+ENV DOCSY_VERSION 9f55cf34808d720bcfff9398c9f9bb7fd8fce4ec
 ENV DOCSY_URL https://github.com/google/docsy.git
 RUN apk add --no-cache git
 WORKDIR /docsy
@@ -25,7 +26,7 @@ RUN git clone "${DOCSY_URL}" . && \
 
 # Download Hugo
 FROM alpine:3.10 as download-hugo
-ENV HUGO_VERSION 0.67.1
+ENV HUGO_VERSION 0.99.1
 ENV HUGO_URL https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz
 RUN wget -O- "${HUGO_URL}" | tar xz
 

--- a/deploy/webhook/Dockerfile
+++ b/deploy/webhook/Dockerfile
@@ -14,7 +14,8 @@
 
 # Download Docsy theme for Hugo
 FROM alpine:3.10 as download-docsy
-ENV DOCSY_VERSION 3c4280bae0db96cb272ddc4b4959b2beef9299af
+# v0.3.0
+ENV DOCSY_VERSION 9f55cf34808d720bcfff9398c9f9bb7fd8fce4ec
 ENV DOCSY_URL https://github.com/google/docsy.git
 RUN apk add --no-cache git
 WORKDIR /docsy
@@ -25,7 +26,7 @@ RUN git clone "${DOCSY_URL}" . && \
 
 # Download Hugo
 FROM alpine:3.10 as download-hugo
-ENV HUGO_VERSION 0.67.1
+ENV HUGO_VERSION 0.99.1
 ENV HUGO_URL https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz
 RUN wget -O- "${HUGO_URL}" | tar xz
 

--- a/docs-v1/config.toml
+++ b/docs-v1/config.toml
@@ -103,6 +103,8 @@ version_menu = "Versions"
 sidebar_menu_compact = false
 #  Set to true to disable breadcrumb navigation.
 breadcrumb_disable = false
+# Allow users to expand and collapse nav menu options
+sidebar_menu_foldable = true
 
 [params.links]
 # Developer relevant links. These will show up on right side of footer.

--- a/docs-v2/config.toml
+++ b/docs-v2/config.toml
@@ -99,6 +99,8 @@ version_menu = "Versions"
 sidebar_menu_compact = false
 #  Set to true to disable breadcrumb navigation.
 breadcrumb_disable = false
+# Allow users to expand and collapse nav menu options
+sidebar_menu_foldable = true
 
 [params.links]
 # Developer relevant links. These will show up on right side of footer.


### PR DESCRIPTION
Fixes: https://github.com/GoogleContainerTools/skaffold/issues/8389

**Description**

Docsy now supports collapsing/expanding menu options (https://www.docsy.dev/docs/adding-content/navigation/#section-menu-options), which improves the navigability of skaffold.dev documentation. (See https://kubernetes.io/docs/home/ nav as an example.)

Before breaking up the Builders page into sub-pages (https://github.com/GoogleContainerTools/skaffold/issues/8382), I wanted to ensure that sections were collapsible because the Build nav menu already has many sub-pages. 😄 

This PR:
1. Updates the hugo and docsy versions. (Note that these are not the latest releases, as updating to the latest versions introduced some errors to the build that it would be easier to address separately before upgrading.)
2. Adds `sidebar_menu_foldable = true` to config.toml.

**User facing changes**

Before:

![3vU7TYBSk5jiPF5](https://user-images.githubusercontent.com/15936279/216168979-6fd4616d-e61a-4ac4-bf36-1a0dae7ccdb6.png)

After:

![6Sk3nhMMqp5XktF](https://user-images.githubusercontent.com/15936279/216168147-ece2c0ce-b056-46c7-b634-5a0fd9ad8534.png)
