### PR TITLE
fix: not inject `metadata.namespace` in manifests rendered with kustomize

### DIFF
--- a/pkg/skaffold/render/renderer/kpt/kpt.go
+++ b/pkg/skaffold/render/renderer/kpt/kpt.go
@@ -138,6 +138,7 @@ func (r *Kpt) Render(ctx context.Context, out io.Writer, builds []graph.Artifact
 		EnableGKEARMNodeToleration: r.cfg.EnableGKEARMNodeTolerationInRenderedManifests(),
 		Offline:                    offline,
 		KubeContext:                r.cfg.GetKubeContext(),
+		InjectNamespace:            true,
 	}
 
 	manifestList, err = rUtil.BaseTransform(ctx, manifestList, builds, opts, r.labels, r.namespace)

--- a/pkg/skaffold/render/renderer/kubectl/kubectl.go
+++ b/pkg/skaffold/render/renderer/kubectl/kubectl.go
@@ -123,6 +123,7 @@ func (r Kubectl) Render(ctx context.Context, out io.Writer, builds []graph.Artif
 		EnableGKEARMNodeToleration: r.cfg.EnableGKEARMNodeTolerationInRenderedManifests(),
 		Offline:                    offline,
 		KubeContext:                r.cfg.GetKubeContext(),
+		InjectNamespace:            true,
 	}
 	manifests, err = rUtil.BaseTransform(ctx, manifests, builds, opts, r.labels, r.namespace)
 

--- a/pkg/skaffold/render/renderer/kustomize/kustomize.go
+++ b/pkg/skaffold/render/renderer/kustomize/kustomize.go
@@ -85,6 +85,7 @@ func (k Kustomize) Render(ctx context.Context, out io.Writer, builds []graph.Art
 		EnableGKEARMNodeToleration: k.cfg.EnableGKEARMNodeTolerationInRenderedManifests(),
 		Offline:                    offline,
 		KubeContext:                k.cfg.GetKubeContext(),
+		InjectNamespace:            false, // This is to keep backwards compatibility with Skaffold v1.
 	}
 
 	ns := k.namespace

--- a/pkg/skaffold/render/renderer/util/util.go
+++ b/pkg/skaffold/render/renderer/util/util.go
@@ -56,7 +56,7 @@ func BaseTransform(ctx context.Context, manifests manifest.ManifestList, builds 
 		return manifests, err
 	}
 
-	if !opts.Offline {
+	if !opts.Offline && opts.InjectNamespace {
 		if manifests, err = manifests.SetNamespace(ns, rs); err != nil {
 			return manifests, err
 		}

--- a/pkg/skaffold/render/renderer/util/util.go
+++ b/pkg/skaffold/render/renderer/util/util.go
@@ -18,7 +18,6 @@ package util
 
 import (
 	"context"
-	"io"
 	"os"
 	"strings"
 
@@ -28,7 +27,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/instrumentation"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/kubernetes/manifest"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/render"
-	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/render/generate"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/yaml"
 )
@@ -40,18 +38,7 @@ type GenerateHydratedManifestsOptions struct {
 	EnableGKEARMNodeToleration bool
 	Offline                    bool
 	KubeContext                string
-}
-
-func GenerateHydratedManifests(ctx context.Context, out io.Writer, builds []graph.Artifact, g generate.Generator, labels map[string]string, ns string, opts GenerateHydratedManifestsOptions) (manifest.ManifestList, error) {
-	// Generate manifests.
-	rCtx, endTrace := instrumentation.StartTrace(ctx, "Render_generateManifest")
-	manifests, err := g.Generate(rCtx, out)
-	if err != nil {
-		return nil, err
-	}
-	endTrace()
-
-	return BaseTransform(ctx, manifests, builds, opts, labels, ns)
+	InjectNamespace            bool
 }
 
 // BaseTransform skaffold controlled manifests fields


### PR DESCRIPTION
Fixes: #8403

**Description**
This is to to fix a v1 regression: manifests rendered with kustomize shouldn't have a `metadata.namespace` field injected by skaffold.

A new `InjectNamespace` property is added to decide if Skaffold should inject a namespace by itself or not. For [8318](https://github.com/GoogleContainerTools/skaffold/issues/8318) we can use this new property, reading its value from a flag or configuration.

**Follow-up Work**
[8318](https://github.com/GoogleContainerTools/skaffold/issues/8318)