### PR TITLE
chore: remove validation for kpt version

### DIFF
--- a/pkg/skaffold/render/renderer/kpt/kpt.go
+++ b/pkg/skaffold/render/renderer/kpt/kpt.go
@@ -17,19 +17,22 @@ limitations under the License.
 package kpt
 
 import (
+	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"os/exec"
 
-	"github.com/blang/semver"
 	apimachinery "k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/kustomize/kyaml/fn/framework"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
 
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/instrumentation"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/kubernetes/manifest"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/render"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/render/generate"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/render/kptfile"
 	rUtil "github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/render/renderer/util"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/render/transform"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/render/validate"
@@ -53,15 +56,6 @@ type Kpt struct {
 	transformAllowlist map[apimachinery.GroupKind]latest.ResourceFilter
 	transformDenylist  map[apimachinery.GroupKind]latest.ResourceFilter
 }
-
-const (
-	DryFileName = "manifests.yaml"
-)
-
-var (
-	KptVersion                      = currentKptVersion
-	maxKptVersionAllowedForDeployer = "1.0.0-beta.24"
-)
 
 func New(cfg render.Config, rCfg latest.RenderConfig, hydrationDir string, labels map[string]string, configName string, ns string, manifestOverrides map[string]string) (*Kpt, error) {
 	transformAllowlist, transformDenylist, err := rUtil.ConsolidateTransformConfiguration(cfg)
@@ -117,7 +111,20 @@ func (r *Kpt) Render(ctx context.Context, out io.Writer, builds []graph.Artifact
 		cmd := exec.Command("kpt", "fn", "render", p, "-o", "unwrap")
 
 		if buf, err := util.RunCmdOut(rCtx, cmd); err == nil {
-			manifestList.Append(buf)
+			reader := kio.ByteReader{Reader: bytes.NewBuffer(buf)}
+			b := bytes.NewBuffer([]byte{})
+			writer := kio.ByteWriter{Writer: b}
+			// Kpt fn render outputs Kptfile content in result, we don't want this in our manifestList as Kptfile resource cannot be deployed to k8s cluster.
+			pipeline := kio.Pipeline{Filters: []kio.Filter{framework.ResourceMatcherFunc(func(node *yaml.RNode) bool {
+				return node.GetKind() != kptfile.KptFileKind
+			})},
+				Inputs:  []kio.Reader{&reader},
+				Outputs: []kio.Writer{writer},
+			}
+			if err := pipeline.Execute(); err != nil {
+				return ml, err
+			}
+			manifestList.Append(b.Bytes())
 		} else {
 			endTrace(instrumentation.TraceEndError(err))
 			// TODO(yuwenma): How to guide users when they face kpt error (may due to bad user config)?
@@ -155,33 +162,4 @@ func (r *Kpt) Render(ctx context.Context, out io.Writer, builds []graph.Artifact
 	ml = manifest.NewManifestListByConfig()
 	ml.Add(r.configName, manifestList)
 	return ml, err
-}
-
-func CheckIsProperBinVersion(ctx context.Context) error {
-	maxAllowedVersion := semver.MustParse(maxKptVersionAllowedForDeployer)
-	version, err := KptVersion(ctx)
-	if err != nil {
-		return err
-	}
-
-	currentVersion, err := semver.ParseTolerant(version)
-	if err != nil {
-		return err
-	}
-
-	if currentVersion.GT(maxAllowedVersion) {
-		return fmt.Errorf("max allowed verion for Kpt renderer without Kpt deployer is %v, detected version is %v", maxKptVersionAllowedForDeployer, currentVersion)
-	}
-
-	return nil
-}
-
-func currentKptVersion(ctx context.Context) (string, error) {
-	cmd := exec.Command("kpt", "version")
-	b, err := util.RunCmdOut(ctx, cmd)
-	if err != nil {
-		return "", fmt.Errorf("kpt version command failed: %w", err)
-	}
-	version := string(b)
-	return version, nil
 }

--- a/pkg/skaffold/render/renderer/kpt/kpt.go
+++ b/pkg/skaffold/render/renderer/kpt/kpt.go
@@ -114,9 +114,10 @@ func (r *Kpt) Render(ctx context.Context, out io.Writer, builds []graph.Artifact
 			reader := kio.ByteReader{Reader: bytes.NewBuffer(buf)}
 			b := bytes.NewBuffer([]byte{})
 			writer := kio.ByteWriter{Writer: b}
-			// Kpt fn render outputs Kptfile content in result, we don't want this in our manifestList as Kptfile resource cannot be deployed to k8s cluster.
+			// Kpt fn render outputs Kptfile and Config data files content in result, we don't want them in our manifestList as these cannot be deployed to k8s cluster.
 			pipeline := kio.Pipeline{Filters: []kio.Filter{framework.ResourceMatcherFunc(func(node *yaml.RNode) bool {
-				return node.GetKind() != kptfile.KptFileKind
+				meta, _ := node.GetMeta()
+				return node.GetKind() != kptfile.KptFileKind && meta.Annotations["config.kubernetes.io/local-config"] != "true"
 			})},
 				Inputs:  []kio.Reader{&reader},
 				Outputs: []kio.Writer{writer},

--- a/pkg/skaffold/schema/validation/samples_test.go
+++ b/pkg/skaffold/schema/validation/samples_test.go
@@ -18,7 +18,6 @@ package validation
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -26,7 +25,6 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/parser"
-	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/render/renderer/kpt"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/defaults"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/latest"
@@ -94,9 +92,6 @@ func checkSkaffoldConfig(t *testutil.T, yaml []byte) {
 		t.CheckNoError(err)
 		cfgs = append(cfgs, cfg)
 	}
-	t.Override(&kpt.KptVersion, func(_ context.Context) (string, error) {
-		return "1.0.0-beta.13", nil
-	})
 	err = Process(cfgs, Options{CheckDeploySource: false})
 	t.CheckNoError(err)
 }

--- a/pkg/skaffold/schema/validation/validation.go
+++ b/pkg/skaffold/schema/validation/validation.go
@@ -36,7 +36,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/output/log"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/parser"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/parser/configlocations"
-	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/render/renderer/kpt"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/util"
@@ -87,7 +86,6 @@ func ProcessToErrorWithLocation(configs parser.SkaffoldConfigSet, validateConfig
 		errs = append(errs, validateTaggingPolicy(config, config.Build)...)
 		errs = append(errs, validateCustomTest(config, config.Test)...)
 		errs = append(errs, validateGCBConfig(config, config.Build)...)
-		errs = append(errs, validateKptRendererVersion(config, config.Deploy, config.Render)...)
 	}
 	errs = append(errs, validateArtifactDependencies(configs)...)
 	if validateConfig.CheckDeploySource {
@@ -98,25 +96,6 @@ func ProcessToErrorWithLocation(configs parser.SkaffoldConfigSet, validateConfig
 		return nil
 	}
 	return errs
-}
-
-func validateKptRendererVersion(cfg *parser.SkaffoldConfigEntry, dc latest.DeployConfig, rc latest.RenderConfig) (cfgErrs []ErrorWithLocation) {
-	if dc.KptDeploy != nil {
-		return
-	}
-
-	if rc.Kpt == nil && rc.Transform == nil && rc.Validate == nil { // no kpt renderer created
-		return
-	}
-
-	if err := kpt.CheckIsProperBinVersion(context.TODO()); err != nil {
-		cfgErrs = append(cfgErrs, ErrorWithLocation{
-			Error:    err,
-			Location: cfg.YAMLInfos.LocateField(cfg, "Render"),
-		})
-	}
-
-	return
 }
 
 // Process checks if the Skaffold pipeline is valid and returns all encountered errors as a concatenated string


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #8306 <!-- tracking issues that this PR will close -->
Related: https://github.com/GoogleContainerTools/kpt/issues/3844
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
 - remove kpt version validation, the reason is in the linked issue. 
 - upgrade kpt version in skaffold image to support parameterization, the new version kpt has already been uploaded to gcs https://storage.googleapis.com/skaffold/deps/kpt/v1.0.0-beta.24/kpt_linux_amd64 
 - ``wget https://storage.googleapis.com/skaffold/deps/kpt/v1.0.0-beta.24/kpt_linux_amd64 -O kpt && shasum -a 256 -c ${skaffold_repo}deploy/skaffold/digests/kpt.amd64.sha256 ``  should output ok 
**Follow-up Work (remove if N/A)**