### PR TITLE
docs: restructure builders docs

### DIFF
--- a/docs-v2/content/en/docs/environment/templating.md
+++ b/docs-v2/content/en/docs/environment/templating.md
@@ -16,7 +16,7 @@ will be `gcr.io/k8s-skaffold/example:v1`.
 List of fields that support templating:
 
 * `build.artifacts.[].docker.buildArgs` (see [builders]({{< relref "/docs/pipeline-stages/builders" >}}))
-* `build.artifacts.[].ko.{env,flags,labels,ldflags}` (see [`ko` builder]({{< relref "/docs/pipeline-stages/builders/ko" >}}))
+* `build.artifacts.[].ko.{env,flags,labels,ldflags}` (see [`ko` builder]({{< relref "/docs/pipeline-stages/builders/builder-types/ko" >}}))
 * `build.tagPolicy.envTemplate.template` (see [envTemplate tagger]({{< relref "/docs/pipeline-stages/taggers#envtemplate-using-values-of-environment-variables-as-tags)" >}}))
 * `deploy.helm.releases.setValueTemplates` (see [Deploying with helm]({{< relref "/docs/pipeline-stages/deployers#deploying-with-helm)" >}}))
 * `deploy.helm.releases.name` (see [Deploying with helm]({{< relref "/docs/pipeline-stages/deployers#deploying-with-helm)" >}}))

--- a/docs-v2/content/en/docs/pipeline-stages/builders/_index.md
+++ b/docs-v2/content/en/docs/pipeline-stages/builders/_index.md
@@ -7,18 +7,18 @@ aliases: [/docs/how-tos/builders]
 no_list: true
 ---
 
-Skaffold supports different tools for building images:
+Skaffold supports different [tools]({{< relref "/docs/pipeline-stages/builders/builder-types" >}}) for building images across different [build environments]({{< relref "/docs/pipeline-stages/builders/build-environments" >}}).
 
 |    | Local Build | In Cluster Build | Remote on Google Cloud Build |
 |----|:-----------:|:----------------:|:----------------------------:|
-| **Dockerfile** | [Yes]({{< relref "/docs/pipeline-stages/builders/docker#dockerfile-locally" >}}) | [Yes]({{< relref "/docs/pipeline-stages/builders/docker#dockerfile-in-cluster-with-kaniko" >}}) | [Yes]({{< relref "/docs/pipeline-stages/builders/docker#dockerfile-remotely-with-google-cloud-build" >}}) |
-| **Jib Maven and Gradle** | [Yes]({{< relref "/docs/pipeline-stages/builders/jib#jib-maven-and-gradle-locally" >}}) | - | [Yes]({{< relref "/docs/pipeline-stages/builders/jib#remotely-with-google-cloud-build" >}}) |
-| **Cloud Native Buildpacks** | [Yes]({{< relref "/docs/pipeline-stages/builders/buildpacks" >}}) | - | [Yes]({{< relref "/docs/pipeline-stages/builders/buildpacks" >}}) |
-| **Bazel** | [Yes]({{< relref "/docs/pipeline-stages/builders/bazel" >}}) | - | - |
-| **ko** | [Yes]({{< relref "/docs/pipeline-stages/builders/ko" >}}) | - | [Yes]({{< relref "/docs/pipeline-stages/builders/ko#remote-builds" >}}) |
-| **Custom Script** | [Yes]({{<relref "/docs/pipeline-stages/builders/custom#custom-build-script-locally" >}}) | [Yes]({{<relref "/docs/pipeline-stages/builders/custom#custom-build-script-in-cluster" >}}) | - |
+| **Dockerfile** | [Yes]({{< relref "/docs/pipeline-stages/builders/builder-types/docker#dockerfile-locally" >}}) | [Yes]({{< relref "/docs/pipeline-stages/builders/builder-types/docker#dockerfile-in-cluster-with-kaniko" >}}) | [Yes]({{< relref "/docs/pipeline-stages/builders/builder-types/docker#dockerfile-remotely-with-google-cloud-build" >}}) |
+| **Jib Maven and Gradle** | [Yes]({{< relref "/docs/pipeline-stages/builders/builder-types/jib#jib-maven-and-gradle-locally" >}}) | - | [Yes]({{< relref "/docs/pipeline-stages/builders/builder-types/jib#remotely-with-google-cloud-build" >}}) |
+| **Cloud Native Buildpacks** | [Yes]({{< relref "/docs/pipeline-stages/builders/builder-types/buildpacks" >}}) | - | [Yes]({{< relref "/docs/pipeline-stages/builders/builder-types/buildpacks" >}}) |
+| **Bazel** | [Yes]({{< relref "/docs/pipeline-stages/builders/builder-types/bazel" >}}) | - | - |
+| **ko** | [Yes]({{< relref "/docs/pipeline-stages/builders/builder-types/ko" >}}) | - | [Yes]({{< relref "/docs/pipeline-stages/builders/builder-types/ko#remote-builds" >}}) |
+| **Custom Script** | [Yes]({{<relref "/docs/pipeline-stages/builders/builder-types/custom#custom-build-script-locally" >}}) | [Yes]({{<relref "/docs/pipeline-stages/builders/builder-types/custom#custom-build-script-in-cluster" >}}) | - |
 
-**Configuration**
+## Configuration
 
 The `build` section in the Skaffold configuration file, `skaffold.yaml`,
 controls how artifacts are built. To use a specific tool for building
@@ -27,170 +27,3 @@ to the `build` section.
 
 For detailed per-builder [Skaffold Configuration]({{< relref "/docs/design/config.md" >}}) options,
 see [skaffold.yaml References]({{< relref "/docs/references/yaml" >}}).
-
-## Local Build
-Local build execution is the default execution context.
-Skaffold will use your locally-installed build tools (such as Docker, Bazel, Maven or Gradle) to execute the build.
-
-**Configuration**
-
-To configure the local execution explicitly, add build type `local` to the build section of `skaffold.yaml`
-
-```yaml
-build:
-  local: {}
-```
-
-The following options can optionally be configured:
-
-{{< schema root="LocalBuild" >}}
-
-### Faster builds
-
-There are a few options for achieving faster local builds.
-
-#### Avoiding pushes
-
-When deploying to a [local cluster]({{<relref "/docs/environment/local-cluster" >}}), 
-Skaffold defaults `push` to `false` to speed up builds.  The `push`
-setting can be set from the command-line with `--push`.
-
-#### Parallel builds
-
-The `concurrency` controls the number of image builds that are run in parallel.
-Skaffold disables concurrency by default for local builds as several
-image builder types (`custom`, `jib`) may change files on disk and
-result in side-effects.
-`concurrency` can be set to `0` to enable full parallelism, though
-this may consume significant resources.
-The concurrency setting can be set from the command-line with the
-`--build-concurrency` flag.
-
-When artifacts are built in parallel, the build logs are still printed in sequence to make them easier to read.
-
-#### Build avoidance with `tryImportMissing`
-
-`tryImportMissing: true` causes Skaffold to avoid building an image when
-the tagged image already exists in the destination.  This setting can be
-useful for images that are expensive to build.
-
-`tryImportMissing` is disabled by default to avoid the risk from importing
-a _stale image_, where the imported image is different from the image
-that would have been built from the artifact source.
-`tryImportMissing` is best used with a
-[tagging policy]({{<relref "/docs/pipeline-stages/taggers" >}}) such as
-`imageDigest` or `gitCommit`'s `TreeSha` or `AbbrevTreeSha` variants,
-where the tag is computed using the artifact's contents.
-
-
-## In Cluster Build
-
-Skaffold supports building in cluster via [Kaniko]({{< relref "/docs/pipeline-stages/builders/docker#dockerfile-in-cluster-with-kaniko" >}}) 
-or [Custom Build Script]({{<relref "/docs/pipeline-stages/builders/custom#custom-build-script-in-cluster" >}}).
-
-**Configuration**
-
-To configure in-cluster Build, add build type `cluster` to the build section of `skaffold.yaml`. 
-
-```yaml
-build:
-  cluster: {}
-```
-
-The following options can optionally be configured:
-
-{{< schema root="ClusterDetails" >}}
-
-**Faster builds**
-
-Skaffold can build multiple artifacts in parallel, by settings a value higher than `1` to `concurrency`.
-For in-cluster builds, the default is to build all the artifacts in parallel. If your cluster is too
-small, you might want to reduce the `concurrency`. Setting `concurrency` to `1` will cause artifacts to be built sequentially.
-
-{{<alert title="Note">}}
-When artifacts are built in parallel, the build logs are still printed in sequence to make them easier to read.
-{{</alert>}}
-
-## Remotely on Google Cloud Build
-
-Skaffold supports building remotely with Google Cloud Build.
-
-[Google Cloud Build](https://cloud.google.com/cloud-build/) is a
-[Google Cloud Platform](https://cloud.google.com) service that executes
-your builds using Google infrastructure. To get started with Google
-Build, see [Cloud Build Quickstart](https://cloud.google.com/cloud-build/docs/quickstart-docker).
-
-Skaffold can automatically connect to Cloud Build, and run your builds
-with it. After Cloud Build finishes building your artifacts, they will
-be saved to the specified remote registry, such as
-[Google Container Registry](https://cloud.google.com/container-registry/).
-
-Skaffold Google Cloud Build process differs from the gcloud command
-`gcloud builds submit`. Skaffold will create a list of dependent files
-and submit a tar file to GCB. It will then generate a single step `cloudbuild.yaml`
-and will start the building process. Skaffold does not honor `.gitignore` or `.gcloudignore`
-exclusions. If you need to ignore files use `.dockerignore`. Any `cloudbuild.yaml` found will not
-be used in the build process.
-
-**Configuration**
-
-To use Cloud Build, add build type `googleCloudBuild` to the `build`
-section of `skaffold.yaml`. 
-
-```yaml
-build:
-  googleCloudBuild: {}
-```
-
-The following options can optionally be configured:
-
-{{< schema root="GoogleCloudBuild" >}}
-
-**Faster builds**
-
-Skaffold can build multiple artifacts in parallel, by settings a value higher than `1` to `concurrency`.
-For Google Cloud Build, the default is to build all the artifacts in parallel. If you hit a quota restriction,
-you might want to reduce  the `concurrency`.
-
-{{<alert title="Note">}}
-When artifacts are built in parallel, the build logs are still printed in sequence to make them easier to read.
-{{</alert>}}
-
-**Restrictions**
-
-Skaffold currently supports [Docker]({{<relref "/docs/pipeline-stages/builders/docker#dockerfile-remotely-with-google-cloud-build">}}),
-[Jib]({{<relref "/docs/pipeline-stages/builders/jib#remotely-with-google-cloud-build">}})
-on Google Cloud Build.
-
-## Cross-platform and Multi-platform build support
-
-Skaffold selectively supports building for an architecture that is different than the development machine architecture (`cross-platform` build) or building for multiple architectures (`multiple-platform` build). The target platforms for an artifact can be specified in one of the following ways:
-
-- The pipeline's `platforms` property in the `skaffold.yaml` file.
-{{% readfile file="samples/builders/platforms/pipeline-constraints.yaml" %}}
-
-- The artifact's `platforms` constraints in the `skaffold.yaml` file. This overrides the value specified in the pipeline's `platforms` property.
-{{% readfile file="samples/builders/platforms/artifact-constraints.yaml" %}}
-
-- The CLI flag `--platform` which overrides the values set in both the previous ways.
-
-```cmd
-skaffold build --platform=linux/arm64,linux/amd64
-```
-
-Additionally, for `skaffold dev`, `skaffold debug` and `skaffold run` commands, where the build output gets deployed immediately, skaffold checks the platform for the kubernetes cluster nodes and attempts to build artifacts for that target platform.
-
-The final list of target platforms need to ultimately be supported by the target builder, otherwise it'll fail the build. The cross-platform build support for the various builders can be summarized in the following table:
-
-|    | Local Build | In Cluster Build | Remote on Google Cloud Build |
-|----|:-----------:|:----------------:|:----------------------------:|
-| **Dockerfile** | Cross-platform and multi-platform supported | Cross-platform supported but platform should match cluster node running the pod. | Cross-platform and multi-platform supported |
-| **Jib Maven and Gradle** | Cross-platform and multi-platform supported | - | Cross-platform and multi-platform supported |
-| **Cloud Native Buildpacks** | Only supports `linux/amd64` | - | Only supports `linux/amd64` |
-| **Bazel** | Cross-platform supported but requires explicit platform specific rules. Not yet implemented | - | - |
-| **ko** | Cross-platform and multi-platform supported | - | Cross-platform and multi-platform supported |
-| **Custom Script** | Cross-platform and multi-platform supported but requires user to implement it in the build script | Cross-platform and multi-platform supported but requires user to implement it in the build script | - |
-
-{{< alert title="Note" >}}
-Skaffold supports multi-platform image builds natively for the [jib builder]({{<relref "/docs/pipeline-stages/builders/jib" >}}), the [ko builder]({{<relref "/docs/pipeline-stages/builders/ko">}}) and the [custom builder]({{<relref "/docs/pipeline-stages/builders/custom" >}}). For other builders that support building cross-architecture images, Skaffold will iteratively build a single platform image for each target architecture and stitch them together into a multi-platform image, and push it to the registry.
-{{< /alert >}}

--- a/docs-v2/content/en/docs/pipeline-stages/builders/build-environments/_index.md
+++ b/docs-v2/content/en/docs/pipeline-stages/builders/build-environments/_index.md
@@ -1,0 +1,13 @@
+---
+title: "Build environments"
+linkTitle: "Environments"
+weight: 20
+no_list: true
+---
+
+Skaffold supports the following build environments:
+* [Local build]({{< relref "/docs/pipeline-stages/builders/build-environments/local" >}})
+* [In cluster build]({{< relref "/docs/pipeline-stages/builders/build-environments/in-cluster" >}})
+* [Remotely on Google Cloud Build]({{< relref "/docs/pipeline-stages/builders/build-environments/cloud-build" >}})
+
+Skaffold also supports [Cross-platform and multi-platform builds]({{< relref "/docs/pipeline-stages/builders/build-environments/cross-platform" >}})

--- a/docs-v2/content/en/docs/pipeline-stages/builders/build-environments/cloud-build.md
+++ b/docs-v2/content/en/docs/pipeline-stages/builders/build-environments/cloud-build.md
@@ -1,0 +1,54 @@
+---
+title: "Google Cloud Build"
+linkTitle: "Google Cloud Build"
+weight: 30
+---
+
+Skaffold supports building remotely with Google Cloud Build.
+
+[Google Cloud Build](https://cloud.google.com/cloud-build/) is a
+[Google Cloud Platform](https://cloud.google.com) service that executes
+your builds using Google infrastructure. To get started with Google
+Build, see [Cloud Build Quickstart](https://cloud.google.com/cloud-build/docs/quickstart-docker).
+
+Skaffold can automatically connect to Cloud Build, and run your builds
+with it. After Cloud Build finishes building your artifacts, they will
+be saved to the specified remote registry, such as
+[Google Container Registry](https://cloud.google.com/container-registry/).
+
+Skaffold Google Cloud Build process differs from the gcloud command
+`gcloud builds submit`. Skaffold will create a list of dependent files
+and submit a tar file to GCB. It will then generate a single step `cloudbuild.yaml`
+and will start the building process. Skaffold does not honor `.gitignore` or `.gcloudignore`
+exclusions. If you need to ignore files use `.dockerignore`. Any `cloudbuild.yaml` found will not
+be used in the build process.
+
+## Configuration
+
+To use Cloud Build, add build type `googleCloudBuild` to the `build`
+section of `skaffold.yaml`. 
+
+```yaml
+build:
+  googleCloudBuild: {}
+```
+
+The following options can optionally be configured:
+
+{{< schema root="GoogleCloudBuild" >}}
+
+## Faster builds
+
+Skaffold can build multiple artifacts in parallel, by settings a value higher than `1` to `concurrency`.
+For Google Cloud Build, the default is to build all the artifacts in parallel. If you hit a quota restriction,
+you might want to reduce  the `concurrency`.
+
+{{<alert title="Note">}}
+When artifacts are built in parallel, the build logs are still printed in sequence to make them easier to read.
+{{</alert>}}
+
+## Restrictions
+
+Skaffold currently supports [Docker]({{<relref "/docs/pipeline-stages/builders/builder-types/docker#dockerfile-remotely-with-google-cloud-build">}}),
+[Jib]({{<relref "/docs/pipeline-stages/builders/builder-types/jib#remotely-with-google-cloud-build">}})
+on Google Cloud Build.

--- a/docs-v2/content/en/docs/pipeline-stages/builders/build-environments/cross-platform.md
+++ b/docs-v2/content/en/docs/pipeline-stages/builders/build-environments/cross-platform.md
@@ -1,0 +1,36 @@
+---
+title: "Cross-platform and multi-platform build support"
+linkTitle: "Cross/multi-platform"
+weight: 40
+---
+
+Skaffold selectively supports building for an architecture that is different than the development machine architecture (`cross-platform` build) or building for multiple architectures (`multiple-platform` build). The target platforms for an artifact can be specified in one of the following ways:
+
+- The pipeline's `platforms` property in the `skaffold.yaml` file.
+{{% readfile file="samples/builders/platforms/pipeline-constraints.yaml" %}}
+
+- The artifact's `platforms` constraints in the `skaffold.yaml` file. This overrides the value specified in the pipeline's `platforms` property.
+{{% readfile file="samples/builders/platforms/artifact-constraints.yaml" %}}
+
+- The CLI flag `--platform` which overrides the values set in both the previous ways.
+
+```cmd
+skaffold build --platform=linux/arm64,linux/amd64
+```
+
+Additionally, for `skaffold dev`, `skaffold debug` and `skaffold run` commands, where the build output gets deployed immediately, skaffold checks the platform for the kubernetes cluster nodes and attempts to build artifacts for that target platform.
+
+The final list of target platforms need to ultimately be supported by the target builder, otherwise it'll fail the build. The cross-platform build support for the various builders can be summarized in the following table:
+
+|    | Local Build | In Cluster Build | Remote on Google Cloud Build |
+|----|:-----------:|:----------------:|:----------------------------:|
+| **Dockerfile** | Cross-platform and multi-platform supported | Cross-platform supported but platform should match cluster node running the pod. | Cross-platform and multi-platform supported |
+| **Jib Maven and Gradle** | Cross-platform and multi-platform supported | - | Cross-platform and multi-platform supported |
+| **Cloud Native Buildpacks** | Only supports `linux/amd64` | - | Only supports `linux/amd64` |
+| **Bazel** | Cross-platform supported but requires explicit platform specific rules. Not yet implemented | - | - |
+| **ko** | Cross-platform and multi-platform supported | - | Cross-platform and multi-platform supported |
+| **Custom Script** | Cross-platform and multi-platform supported but requires user to implement it in the build script | Cross-platform and multi-platform supported but requires user to implement it in the build script | - |
+
+{{< alert title="Note" >}}
+Skaffold supports multi-platform image builds natively for the [jib builder]({{<relref "/docs/pipeline-stages/builders/builder-types/jib" >}}), the [ko builder]({{<relref "/docs/pipeline-stages/builders/builder-types/ko">}}) and the [custom builder]({{<relref "/docs/pipeline-stages/builders/builder-types/custom" >}}). For other builders that support building cross-architecture images, Skaffold will iteratively build a single platform image for each target architecture and stitch them together into a multi-platform image, and push it to the registry.
+{{< /alert >}}

--- a/docs-v2/content/en/docs/pipeline-stages/builders/build-environments/in-cluster.md
+++ b/docs-v2/content/en/docs/pipeline-stages/builders/build-environments/in-cluster.md
@@ -1,0 +1,31 @@
+---
+title: "In cluster build"
+linkTitle: "In cluster"
+weight: 20
+---
+
+Skaffold supports building in cluster via [Kaniko]({{< relref "/docs/pipeline-stages/builders/builder-types/docker#dockerfile-in-cluster-with-kaniko" >}}) 
+or [Custom Build Script]({{<relref "/docs/pipeline-stages/builders/builder-types/custom#custom-build-script-in-cluster" >}}).
+
+## Configuration
+
+To configure in-cluster Build, add build type `cluster` to the build section of `skaffold.yaml`. 
+
+```yaml
+build:
+  cluster: {}
+```
+
+The following options can optionally be configured:
+
+{{< schema root="ClusterDetails" >}}
+
+## Faster builds
+
+Skaffold can build multiple artifacts in parallel, by settings a value higher than `1` to `concurrency`.
+For in-cluster builds, the default is to build all the artifacts in parallel. If your cluster is too
+small, you might want to reduce the `concurrency`. Setting `concurrency` to `1` will cause artifacts to be built sequentially.
+
+{{<alert title="Note">}}
+When artifacts are built in parallel, the build logs are still printed in sequence to make them easier to read.
+{{</alert>}}

--- a/docs-v2/content/en/docs/pipeline-stages/builders/build-environments/local.md
+++ b/docs-v2/content/en/docs/pipeline-stages/builders/build-environments/local.md
@@ -1,0 +1,58 @@
+---
+title: "Local build"
+linkTitle: "Local build"
+weight: 10
+---
+
+Local build execution is the default execution context.
+Skaffold will use your locally-installed build tools (such as Docker, Bazel, Maven or Gradle) to execute the build.
+
+## Configuration
+
+To configure the local execution explicitly, add build type `local` to the build section of `skaffold.yaml`
+
+```yaml
+build:
+  local: {}
+```
+
+The following options can optionally be configured:
+
+{{< schema root="LocalBuild" >}}
+
+## Faster builds
+
+There are a few options for achieving faster local builds.
+
+### Avoiding pushes
+
+When deploying to a [local cluster]({{<relref "/docs/environment/local-cluster" >}}), 
+Skaffold defaults `push` to `false` to speed up builds.  The `push`
+setting can be set from the command-line with `--push`.
+
+### Parallel builds
+
+The `concurrency` controls the number of image builds that are run in parallel.
+Skaffold disables concurrency by default for local builds as several
+image builder types (`custom`, `jib`) may change files on disk and
+result in side-effects.
+`concurrency` can be set to `0` to enable full parallelism, though
+this may consume significant resources.
+The concurrency setting can be set from the command-line with the
+`--build-concurrency` flag.
+
+When artifacts are built in parallel, the build logs are still printed in sequence to make them easier to read.
+
+### Build avoidance with `tryImportMissing`
+
+`tryImportMissing: true` causes Skaffold to avoid building an image when
+the tagged image already exists in the destination.  This setting can be
+useful for images that are expensive to build.
+
+`tryImportMissing` is disabled by default to avoid the risk from importing
+a _stale image_, where the imported image is different from the image
+that would have been built from the artifact source.
+`tryImportMissing` is best used with a
+[tagging policy]({{<relref "/docs/pipeline-stages/taggers" >}}) such as
+`imageDigest` or `gitCommit`'s `TreeSha` or `AbbrevTreeSha` variants,
+where the tag is computed using the artifact's contents.

--- a/docs-v2/content/en/docs/pipeline-stages/builders/builder-types/_index.md
+++ b/docs-v2/content/en/docs/pipeline-stages/builders/builder-types/_index.md
@@ -1,0 +1,13 @@
+---
+title: "Builder types"
+linkTitle: "Builder types"
+weight: 10
+no_list: true
+---
+
+Skaffold supports the following builder types:
+* [Docker]({{< relref "/docs/pipeline-stages/builders/builder-types/docker" >}})
+* [Jib]({{< relref "/docs/pipeline-stages/builders/builder-types/jib" >}})
+* [Bazel]({{< relref "/docs/pipeline-stages/builders/builder-types/bazel" >}})
+* [Custom build script]({{< relref "/docs/pipeline-stages/builders/builder-types/custom" >}})
+* [ko]({{< relref "/docs/pipeline-stages/builders/builder-types/ko" >}})

--- a/docs-v2/content/en/docs/pipeline-stages/builders/builder-types/bazel.md
+++ b/docs-v2/content/en/docs/pipeline-stages/builders/builder-types/bazel.md
@@ -3,6 +3,7 @@ title: "Bazel"
 linkTitle: "Bazel"
 weight: 30
 featureId: build
+aliases: [/docs/builders/bazel]
 ---
 
 [Bazel](https://bazel.build/) is a fast, scalable, multi-language, and

--- a/docs-v2/content/en/docs/pipeline-stages/builders/builder-types/buildpacks.md
+++ b/docs-v2/content/en/docs/pipeline-stages/builders/builder-types/buildpacks.md
@@ -3,7 +3,7 @@ title: "Cloud Native Buildpacks"
 linkTitle: "Buildpacks"
 weight: 50
 featureId: build.buildpacks
-aliases: [/docs/how-tos/buildpacks]
+aliases: [/docs/how-tos/buildpacks, /docs/builders/buildpacks]
 ---
 
 [Cloud Native Buildpacks](https://buildpacks.io/) enable building

--- a/docs-v2/content/en/docs/pipeline-stages/builders/builder-types/custom.md
+++ b/docs-v2/content/en/docs/pipeline-stages/builders/builder-types/custom.md
@@ -3,6 +3,7 @@ title: "Custom Build Script"
 linkTitle: "Custom"
 weight: 40
 featureId: build.custom
+aliases: [/docs/builders/custom]
 ---
 
 Custom build scripts allow Skaffold users the flexibility to build artifacts with any builder they desire. 

--- a/docs-v2/content/en/docs/pipeline-stages/builders/builder-types/docker.md
+++ b/docs-v2/content/en/docs/pipeline-stages/builders/builder-types/docker.md
@@ -3,13 +3,14 @@ title: "Docker Build"
 linkTitle: "Docker"
 weight: 10
 featureId: build
+aliases: [/docs/builders/docker]
 ---
 
 Skaffold supports building with Dockerfile
 
-1. [locally]({{< relref "/docs/pipeline-stages/builders/docker#dockerfile-with-docker-locally">}})
-2. [in cluster]({{< relref "/docs/pipeline-stages/builders/docker#dockerfile-in-cluster-with-kaniko">}})
-3. [on Google CloudBuild ]({{< relref "/docs/pipeline-stages/builders/docker#dockerfile-remotely-with-google-cloud-build">}})
+1. [locally]({{< relref "/docs/pipeline-stages/builders/builder-types/docker#dockerfile-with-docker-locally">}})
+2. [in cluster]({{< relref "/docs/pipeline-stages/builders/builder-types/docker#dockerfile-in-cluster-with-kaniko">}})
+3. [on Google CloudBuild ]({{< relref "/docs/pipeline-stages/builders/builder-types/docker#dockerfile-remotely-with-google-cloud-build">}})
 
 ## Dockerfile with Docker locally
 

--- a/docs-v2/content/en/docs/pipeline-stages/builders/builder-types/jib.md
+++ b/docs-v2/content/en/docs/pipeline-stages/builders/builder-types/jib.md
@@ -3,6 +3,7 @@ title: "Jib Build"
 linkTitle: "Jib"
 weight: 20
 featureId: build
+aliases: [/docs/builders/jib]
 ---
 
 [Jib](https://github.com/GoogleContainerTools/jib#jib) is a set of plugins for
@@ -18,8 +19,8 @@ Skaffold requires using Jib v1.4.0 or later.
 
 Skaffold supports building with Jib
 
-1. [locally]({{< relref "/docs/pipeline-stages/builders/jib#jib-maven-and-gradle-locally" >}}) and
-2. [remotely on Google Cloud Build]({{< relref "/docs/pipeline-stages/builders/jib#remotely-with-google-cloud-build" >}})
+1. [locally]({{< relref "/docs/pipeline-stages/builders/builder-types/jib#jib-maven-and-gradle-locally" >}}) and
+2. [remotely on Google Cloud Build]({{< relref "/docs/pipeline-stages/builders/builder-types/jib#remotely-with-google-cloud-build" >}})
 
 ## Jib Maven and Gradle locally
 **Configuration**
@@ -121,7 +122,7 @@ artifacts:
 
 ### Using the `custom` builder
 
-Some users may have more complicated builds that may be better suited to using the [`custom` builder](https://skaffold.dev/docs/pipeline-stages/builders/custom/).  For example, the `jib` builder normally invokes the `prepare-package` goal rather than `package` as Jib packages the `.class` files rather than package in the jar.  But some plugins require the `package` goal.
+Some users may have more complicated builds that may be better suited to using the [`custom` builder](https://skaffold.dev/docs/pipeline-stages/builders/builder-types/custom/).  For example, the `jib` builder normally invokes the `prepare-package` goal rather than `package` as Jib packages the `.class` files rather than package in the jar.  But some plugins require the `package` goal.
 ```
 artifacts:
 - image: jib-gradle-image

--- a/docs-v2/content/en/docs/pipeline-stages/builders/builder-types/ko.md
+++ b/docs-v2/content/en/docs/pipeline-stages/builders/builder-types/ko.md
@@ -3,6 +3,7 @@ title: "ko"
 linkTitle: "ko"
 weight: 60
 featureId: build.ko
+aliases: [/docs/builders/ko]
 ---
 
 [`ko`](https://github.com/google/ko) enables fast, standardized, reproducible,
@@ -16,28 +17,28 @@ to use the ko builder.
 
 Compared to ...
 
-- [the Cloud Native buildpacks builder]({{< relref "/docs/pipeline-stages/builders/buildpacks" >}}),
+- [the Cloud Native buildpacks builder]({{< relref "/docs/pipeline-stages/builders/builder-types/buildpacks" >}}),
   the ko builder is
   [fast](https://cloud.google.com/blog/topics/developers-practitioners/ship-your-go-applications-faster-cloud-run-ko),
   doesn't require Docker, and uses a default base image that has a small
   attack surface
   ([distroless](https://github.com/GoogleContainerTools/distroless)).
 
-- [the Docker builder]({{< relref "/docs/pipeline-stages/builders/docker" >}}),
+- [the Docker builder]({{< relref "/docs/pipeline-stages/builders/builder-types/docker" >}}),
   the ko builder standardizes builds, avoiding artisanal
   [snowflake](https://martinfowler.com/bliki/SnowflakeServer.html)
   `Dockerfile`s. It also doesn't require the Docker daemon, so builds can run
   in environments where Docker isn't available for security reasons.
 
-- [the Kaniko builder]({{< relref "/docs/pipeline-stages/builders/docker#dockerfile-in-cluster-with-kaniko" >}}),
+- [the Kaniko builder]({{< relref "/docs/pipeline-stages/builders/builder-types/docker#dockerfile-in-cluster-with-kaniko" >}}),
   the ko builder doesn't need a Kubernetes cluster, and it avoids the
   previously-mentioned artisanal `Dockerfile`s.
 
-- [the Bazel builder]({{< relref "/docs/pipeline-stages/builders/bazel" >}}),
+- [the Bazel builder]({{< relref "/docs/pipeline-stages/builders/builder-types/bazel" >}}),
   the ko builder doesn't require users to adopt Bazel. However, we recommend
   the Bazel builder for users who already use Bazel for their Go apps.
 
-- [the custom builder]({{< relref "/docs/pipeline-stages/builders/custom" >}}),
+- [the custom builder]({{< relref "/docs/pipeline-stages/builders/builder-types/custom" >}}),
   the ko builder standardizes builds, as it doesn't require running `ko` using
   custom shell scripts.
 
@@ -438,7 +439,7 @@ The `ko` builder supports remote builds on Google Cloud Build. See the
 ### Using the `custom` builder
 
 If the ko builder doesn't support your use of `ko`, you can instead use the
-[`custom` builder]({{< relref "/docs/pipeline-stages/builders/custom" >}}).
+[`custom` builder]({{< relref "/docs/pipeline-stages/builders/builder-types/custom" >}}).
 
 See the `custom` builder
 [example](https://github.com/GoogleContainerTools/skaffold/tree/main/examples/custom).

--- a/docs-v2/content/en/docs/pipeline-stages/filesync.md
+++ b/docs-v2/content/en/docs/pipeline-stages/filesync.md
@@ -86,7 +86,7 @@ files; file deletion will cause a complete rebuild.
 For multi-stage Dockerfiles, Skaffold only examines the last stage.
 Use manual sync rules to sync file copies from other stages.
 
-[Ko artifacts supports syncing static content]({{<relref "/docs/pipeline-stages/builders/ko#file-sync">}}),
+[Ko artifacts supports syncing static content]({{<relref "/docs/pipeline-stages/builders/builder-types/ko#file-sync">}}),
 and the sync rules apply to added, modified, and deleted files.
 
 ### Auto sync mode

--- a/docs-v2/content/en/docs/pipeline-stages/init.md
+++ b/docs-v2/content/en/docs/pipeline-stages/init.md
@@ -15,10 +15,10 @@ and [deploy](#deploy-config-initialization) config.
 
 `skaffold init` currently supports build detection for those builders:
 
-1. [Docker]({{<relref "/docs/pipeline-stages/builders/docker">}})
-2. [Jib]({{<relref "/docs/pipeline-stages/builders/jib">}})
-3. [Ko]({{<relref "/docs/pipeline-stages/builders/ko">}})
-4. [Buildpacks]({{<relref "/docs/pipeline-stages/builders/buildpacks">}})
+1. [Docker]({{<relref "/docs/pipeline-stages/builders/builder-types/docker">}})
+2. [Jib]({{<relref "/docs/pipeline-stages/builders/builder-types/jib">}})
+3. [Ko]({{<relref "/docs/pipeline-stages/builders/builder-types/ko">}})
+4. [Buildpacks]({{<relref "/docs/pipeline-stages/builders/builder-types/buildpacks">}})
 
 `skaffold init` walks your project directory and looks for any build configuration files such as `Dockerfile`,
 `build.gradle/pom.xml`, `package.json`, `requirements.txt` or `go.mod`. `init` skips files that are larger

--- a/docs-v2/content/en/docs/tutorials/artifact-dependencies.md
+++ b/docs-v2/content/en/docs/tutorials/artifact-dependencies.md
@@ -4,7 +4,7 @@ linkTitle: "Build Dependencies"
 weight: 100
 ---
 
-This page describes how to define dependencies between artifacts and reference them in the [docker builder]({{<relref "/docs/pipeline-stages/builders/docker" >}}).
+This page describes how to define dependencies between artifacts and reference them in the [docker builder]({{<relref "/docs/pipeline-stages/builders/builder-types/docker" >}}).
 
 ## Before you begin
 
@@ -18,7 +18,7 @@ This tutorial will be based on the [simple-artifact-dependency](https://github.c
 
 ## Adding an artifact dependency
 
-We have a `base` artifact which has a single Dockerfile that we build with the [docker builder]({{<relref "/docs/pipeline-stages/builders/docker" >}}):
+We have a `base` artifact which has a single Dockerfile that we build with the [docker builder]({{<relref "/docs/pipeline-stages/builders/builder-types/docker" >}}):
  {{% readfile file="samples/builders/artifact-dependencies/Dockerfile.base" %}}
 
 This artifact is used as the base image for the `app` artifact. We express this dependency in the `skaffold.yaml` using the `requires` expression.

--- a/docs-v2/content/en/docs/tutorials/buildpacks-override.md
+++ b/docs-v2/content/en/docs/tutorials/buildpacks-override.md
@@ -4,6 +4,6 @@ linkTitle: "Overriding the buildpacks run image"
 weight: 100
 ---
 
-This is a link to a guided Cloud Shell tutorial using skaffold's `artifact dependency` feature to override the [run image](https://buildpacks.io/docs/concepts/components/stack/) in the [buildpacks builder]({{<relref "/docs/pipeline-stages/builders/buildpacks" >}}):
+This is a link to a guided Cloud Shell tutorial using skaffold's `artifact dependency` feature to override the [run image](https://buildpacks.io/docs/concepts/components/stack/) in the [buildpacks builder]({{<relref "/docs/pipeline-stages/builders/builder-types/buildpacks" >}}):
 
 [![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.png)](https://ssh.cloud.google.com/cloudshell/open?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_working_dir=codelab/03_buildpacks-runimage-override&cloudshell_workspace=codelab/03_buildpacks-runimage-override&cloudshell_tutorial=tutorial.md)

--- a/docs-v2/content/en/docs/tutorials/custom-builder.md
+++ b/docs-v2/content/en/docs/tutorials/custom-builder.md
@@ -21,7 +21,7 @@ This tutorial will be based on the [custom example](https://github.com/GoogleCon
 ## Adding a Custom Builder to Your Skaffold Project
 
 We'll need to configure your Skaffold config to build artifacts with [ko](https://github.com/google/ko).
-To do this, we will take advantage of the [custom builder]({{<relref "/docs/pipeline-stages/builders/custom" >}}) in Skaffold.
+To do this, we will take advantage of the [custom builder]({{<relref "/docs/pipeline-stages/builders/builder-types/custom" >}}) in Skaffold.
 
 First, add a `build.sh` file which Skaffold will call to build artifacts:
 
@@ -32,7 +32,7 @@ Then, configure artifacts in your `skaffold.yaml` to build with `build.sh`:
 {{% readfile file="samples/builders/custom-buildpacks/skaffold.yaml" %}}
 
 List the file dependencies for each artifact; in the example above, Skaffold watches all files in the build context.
-For more information about listing dependencies for custom artifacts, see the documentation [here]({{<relref "/docs/pipeline-stages/builders/custom#dependencies-from-a-command" >}}).
+For more information about listing dependencies for custom artifacts, see the documentation [here]({{<relref "/docs/pipeline-stages/builders/builder-types/custom#dependencies-from-a-command" >}}).
 
 You can check custom builder is properly configured by running `skaffold build`.
 This command should build the artifacts and exit successfully.

--- a/docs-v2/content/en/docs/workflows/debug.md
+++ b/docs-v2/content/en/docs/workflows/debug.md
@@ -251,7 +251,7 @@ Go-based container images are recognized by:
 - the presence of the
   [`KO_DATA_PATH` environment variable](https://github.com/google/ko#static-assets)
   in container images built by
-  [`ko`]({{< relref "/docs/pipeline-stages/builders/ko" >}}), or
+  [`ko`]({{< relref "/docs/pipeline-stages/builders/builder-types/ko" >}}), or
 - is launching using `dlv`.
 
 Unless you built your container image using `ko`, set one of the standard Go

--- a/docs-v2/content/en/docs/workflows/handling-platforms.md
+++ b/docs-v2/content/en/docs/workflows/handling-platforms.md
@@ -11,7 +11,7 @@ Skaffold has a lot of intelligence built-in to simplify working with ARM workloa
 
 Container images are built targeting specific [Instruction Set Architectures](https://en.wikipedia.org/wiki/Instruction_set_architecture) like `amd64`, `arm64`, etc. **You must use container images that are compatible with the architecture of the node where you intend to run the workloads.** For example, to deploy to a GKE cluster running ARM nodes, the image needs to be built for `linux/arm64` platform.
 
-All image builders build for different default architecture and not all support cross-architecture builds. For instance [Docker]({{<relref "/docs/pipeline-stages/builders/docker">}}) will build the image for the same architecture as the host machine, whereas [Buildpacks]({{<relref "/docs/pipeline-stages/builders/buildpacks">}}) will always build it for `amd64`.
+All image builders build for different default architecture and not all support cross-architecture builds. For instance [Docker]({{<relref "/docs/pipeline-stages/builders/builder-types/docker">}}) will build the image for the same architecture as the host machine, whereas [Buildpacks]({{<relref "/docs/pipeline-stages/builders/builder-types/buildpacks">}}) will always build it for `amd64`.
 
 Additionally, the following combination of development machine and cluster node architectures can make it difficult to build and deploy images correctly:
 
@@ -130,7 +130,7 @@ Skaffold also supports cross-architecture builds on [Google Cloud Build](https:/
 
 A [multi-arch image](https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/) is an image that can support multiple architectures. It looks like a single image with a single tag, but is actually a list of images targeting multiple architectures organized by an [image index](https://github.com/opencontainers/image-spec/blob/main/image-index.md). When you deploy a multi-arch image to a cluster, the container runtime automatically chooses the right image that is compatible with the architecture of the node to which it is being deployed. This simplifies targeting multiple clusters of different architecture nodes, and/or mixed-architecture nodes.
 
-Skaffold supports building multi-platform images natively using the [jib builder]({{<relref "/docs/pipeline-stages/builders/jib" >}}), the [ko builder]({{<relref "/docs/pipeline-stages/builders/ko">}}) and the [custom builder]({{<relref "/docs/pipeline-stages/builders/custom" >}}). For other builders that support building cross-architecture images, Skaffold will iteratively build a single platform image for each target architecture and stitch them together into a multi-platform image, and push it to the registry.
+Skaffold supports building multi-platform images natively using the [jib builder]({{<relref "/docs/pipeline-stages/builders/builder-types/jib" >}}), the [ko builder]({{<relref "/docs/pipeline-stages/builders/builder-types/ko">}}) and the [custom builder]({{<relref "/docs/pipeline-stages/builders/builder-types/custom" >}}). For other builders that support building cross-architecture images, Skaffold will iteratively build a single platform image for each target architecture and stitch them together into a multi-platform image, and push it to the registry.
 
 ![multi-arch-flow](/images/multi-arch-flow.png)
 


### PR DESCRIPTION
Fixes: https://github.com/GoogleContainerTools/skaffold/issues/8382
Related: https://github.com/GoogleContainerTools/skaffold/issues/6659

**Description**

Restructures the builders documentation:
* Separates each build environment into a standalone page.
* Separates the builder types and build environments pages into separate subsections.

User-facing improvements:
* As reported in https://github.com/GoogleContainerTools/skaffold/issues/6659, it is currently difficult to distinguish between builder types and build environments.
* Surface each build environment as a separate page when using site search or Google search.

Analytics improvements:
* Provide independent pageview metrics for each builder type and build environment page.
