### PR TITLE
chore: add krm functions to allowList

### DIFF
--- a/pkg/skaffold/render/transform/transform.go
+++ b/pkg/skaffold/render/transform/transform.go
@@ -54,6 +54,18 @@ var (
 			Image:     "gcr.io/kpt-fn/apply-setters:unstable",
 			ConfigMap: map[string]string{},
 		},
+		"ensure-name-substring": {
+			Image:     "gcr.io/kpt-fn/ensure-name-substring:v0.2.0",
+			ConfigMap: map[string]string{},
+		},
+		"search-replace": {
+			Image:     "gcr.io/kpt-fn/search-replace:v0.2.0",
+			ConfigMap: map[string]string{},
+		},
+		"set-enforcement-action": {
+			Image:     "gcr.io/kpt-fn/set-enforcement-action:v0.1.0",
+			ConfigMap: map[string]string{},
+		},
 	}
 
 	AllowListedTransformer = func() []string {

--- a/pkg/skaffold/render/validate/validate.go
+++ b/pkg/skaffold/render/validate/validate.go
@@ -34,6 +34,9 @@ var (
 	validatorAllowlist    = map[string]kptfile.Function{
 		"kubeval": {Image: "gcr.io/kpt-fn/kubeval:v0.1"},
 		// TODO: Add conftest validator in kpt catalog.
+		"gatekeeper": {
+			Image:     "gcr.io/kpt-fn/gatekeeper:v0.2.1",
+			ConfigMap: map[string]string{}},
 	}
 )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #8189  <!-- tracking issues that this PR will close -->

**Future Work**
 #8448 8448
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
  - Add more krm functions to kpt transformAllowList based on https://catalog.kpt.dev/ 
  - The followings are not added 
     - [fix](https://catalog.kpt.dev/fix/v0.2/?id=fix), this is for upgrading Krm file schema, it is not helpful to integrate it to skaffold render flow
     -  [list-setters](https://catalog.kpt.dev/list-setters/v0.1/?id=list-setters) , this is for seeing comments with setters, cannot be used to chain krm functions
     - [render-helm-chart](https://catalog.kpt.dev/render-helm-chart/v0.2/?id=render-helm-chart)  users should use manifests.helm stanza directly 
     - [set-image](https://catalog.kpt.dev/set-image/v0.1/?id=set-image), this will override the image field in all manifests, its not suitable for skaffold flow. 
     - [starlark](https://catalog.kpt.dev/starlark/v0.4/?id=starlark), not applicable in skaffold config
     - [upsert-resource](https://catalog.kpt.dev/upsert-resource/v0.2/?id=upsert-resource) not applicatble in skaffold config 


