### PR TITLE
fix: cant deploy with kubectl if kubectl and pod have diffrerent namespace

### DIFF
--- a/pkg/skaffold/deploy/kubectl/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os/exec"
-	"strings"
 
 	"github.com/segmentio/textio"
 	"go.opentelemetry.io/otel/trace"
@@ -86,13 +84,6 @@ type Deployer struct {
 // with the needed configuration for `kubectl apply`
 func NewDeployer(cfg Config, labeller *label.DefaultLabeller, d *latest.KubectlDeploy, artifacts []*latest.Artifact, configName string) (*Deployer, error) {
 	defaultNamespace := ""
-	b, err := util.RunCmdOutOnce(context.TODO(), exec.Command("kubectl", "config", "view", "--minify", "-o", "jsonpath='{..namespace}'"))
-	if err == nil {
-		defaultNamespace = strings.Trim(string(b), "'")
-		if defaultNamespace == "default" {
-			defaultNamespace = ""
-		}
-	}
 	if d.DefaultNamespace != nil {
 		var err error
 		defaultNamespace, err = util.ExpandEnvTemplate(*d.DefaultNamespace, nil)


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->

if kubectl context's namespace is not `default`,and its different from pod's metadata.namespace, deploy will fail.

for example: 
kubectl context's namespace is `myns`, and manifests yaml is:
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: testmodule
  namespace: podns
  labels:
    app: testmodule
  annotations:
    secrets.doppler.com/reload: 'true'
spec:
```


```
Starting deploy...
 - the namespace from the provided object "podns" does not match the namespace "myns". You must pass '--namespace=podns' to perform this operation.
 - the namespace from the provided object "podns" does not match the namespace "myns". You must pass '--namespace=podns' to perform this operation.
 - the namespace from the provided object "podns" does not match the namespace "myns". You must pass '--namespace=podns' to perform this operation.
 - the namespace from the provided object "podns" does not match the namespace "myns". You must pass '--namespace=podns' to perform this operation.
kubectl apply: exit status 1
```

So,if the the defaultNamespace of Deployer is kubectl's default namespace, then kubectl CLI  flag `--namespace=` should be removed.

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
