### PR TITLE
feat: support deploying to multiple clusters

### DIFF
--- a/pkg/skaffold/deploy/kubectl/cli.go
+++ b/pkg/skaffold/deploy/kubectl/cli.go
@@ -61,6 +61,7 @@ type Config interface {
 	GetNamespace() string
 	DefaultPipeline() latest.Pipeline
 	Tail() bool
+	IsMultiCluster() bool
 	PipelineForImage(imageName string) (latest.Pipeline, bool)
 	JSONParseConfig() latest.JSONParseConfig
 	EnablePlatformNodeAffinityInRenderedManifests() bool

--- a/pkg/skaffold/kubernetes/logger/log.go
+++ b/pkg/skaffold/kubernetes/logger/log.go
@@ -61,6 +61,7 @@ type LogAggregator struct {
 
 type Config interface {
 	Tail() bool
+	IsMultiCluster() bool
 	PipelineForImage(imageName string) (latest.Pipeline, bool)
 	DefaultPipeline() latest.Pipeline
 	JSONParseConfig() latest.JSONParseConfig
@@ -80,7 +81,7 @@ func NewLogAggregator(cli *kubectl.CLI, podSelector kubernetes.PodSelector, name
 	}
 	a.formatter = func(p v1.Pod, c v1.ContainerStatus, isMuted func() bool) log.Formatter {
 		pod := p
-		return newKubernetesLogFormatter(config, a.colorPicker, isMuted, &pod, c)
+		return newKubernetesLogFormatter(config, a.colorPicker, isMuted, cli.KubeContext, &pod, c)
 	}
 	return a
 }

--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -84,6 +84,22 @@ func (ps Pipelines) IsMultiPipeline() bool {
 	return len(ps.pipelines) > 1
 }
 
+// IsMultiPipeline returns true if there are more than one target kubernetes clusters.
+func (ps Pipelines) IsMultiCluster() bool {
+	var k string
+	for _, p := range ps.pipelines {
+		if p.Deploy.KubeContext == "" {
+			continue
+		}
+		if k == "" {
+			k = p.Deploy.KubeContext
+		} else if k != p.Deploy.KubeContext {
+			return true
+		}
+	}
+	return false
+}
+
 func (ps Pipelines) PortForwardResources() []*latest.PortForwardResource {
 	var pf []*latest.PortForwardResource
 	for _, p := range ps.pipelines {
@@ -284,9 +300,11 @@ func (rc *RunContext) GetNamespace() string {
 	}
 	return strings.Trim(string(b), "'")
 }
-func (rc *RunContext) AutoBuild() bool                               { return rc.Opts.AutoBuild }
-func (rc *RunContext) DisableMultiPlatformBuild() bool               { return rc.Opts.DisableMultiPlatformBuild }
-func (rc *RunContext) CheckClusterNodePlatforms() bool               { return rc.Opts.CheckClusterNodePlatforms }
+func (rc *RunContext) AutoBuild() bool                 { return rc.Opts.AutoBuild }
+func (rc *RunContext) DisableMultiPlatformBuild() bool { return rc.Opts.DisableMultiPlatformBuild }
+func (rc *RunContext) CheckClusterNodePlatforms() bool {
+	return rc.Opts.CheckClusterNodePlatforms && !rc.IsMultiCluster()
+}
 func (rc *RunContext) AutoDeploy() bool                              { return rc.Opts.AutoDeploy }
 func (rc *RunContext) AutoSync() bool                                { return rc.Opts.AutoSync }
 func (rc *RunContext) ContainerDebugging() bool                      { return rc.Opts.ContainerDebugging }
@@ -297,6 +315,7 @@ func (rc *RunContext) CustomLabels() []string                        { return rc
 func (rc *RunContext) CustomTag() string                             { return rc.Opts.CustomTag }
 func (rc *RunContext) DefaultRepo() *string                          { return rc.Cluster.DefaultRepo.Value() }
 func (rc *RunContext) MultiLevelRepo() *bool                         { return rc.Opts.MultiLevelRepo }
+func (rc *RunContext) IsMultiCluster() bool                          { return rc.Pipelines.IsMultiCluster() }
 func (rc *RunContext) Mode() config.RunMode                          { return rc.Opts.Mode() }
 func (rc *RunContext) DryRun() bool                                  { return rc.Opts.DryRun }
 func (rc *RunContext) ForceDeploy() bool                             { return rc.Opts.Force }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #915 <!-- tracking issues that this PR will close -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
This PR fixes some issues around deploying to multiple kubernetes clusters using multi module skaffold configurations.

* Skaffold commands `dev`, `run` and `debug` support deploying to multiple kubernetes clusters using multiple skaffold configurations. For example, in the `examples/getting-started` project we can modify the `skaffold.yaml` file:
  ```
  apiVersion: skaffold/v4beta2
  kind: Config
  build:
    artifacts:
    - image: skaffold-example
  manifests:
    rawYaml:
    - k8s-pod.yaml
  deploy:
    kubectl: {}
    kubeContext: my-cluster-1
  ---
  apiVersion: skaffold/v4beta2
  kind: Config
  manifests:
    rawYaml:
    - k8s-pod.yaml
  deploy:
    kubectl: {}
    kubeContext: my-cluster-2
  ```
* This will deploy the `skaffold-example` image to both clusters `my-cluster-1` and `my-cluster-2`.
  ```
  $ skaffold run  --tail
  ...
  Starting deploy...
   - pod/getting-started configured
  Waiting for deployments to stabilize...
   - pods is ready.
  Deployments stabilized in 2.659 seconds
   - pod/getting-started configured
  Waiting for deployments to stabilize...
   - pods is ready.
  Deployments stabilized in 2.61 seconds
  Press Ctrl+C to exit
  [my-cluster-1][getting-started] Hello world!
  [my-cluster-2][getting-started] Hello world!
  ```
* The container logs are prefixed with the cluster name when there is more than one cluster.
