### PR TITLE
fix: expand home directory for docker secrets

### DIFF
--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -46,8 +46,8 @@ import (
 	sErrors "github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/errors"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/output/log"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/latest"
-	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/util/term"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/util"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/util/term"
 )
 
 const (

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -47,6 +47,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/output/log"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/util/term"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/util"
 )
 
 const (
@@ -667,7 +668,7 @@ func ToCLIBuildArgs(a *latest.DockerArtifact, evaluatedArgs map[string]*string) 
 	for _, secret := range a.Secrets {
 		secretString := fmt.Sprintf("id=%s", secret.ID)
 		if secret.Source != "" {
-			secretString += ",src=" + secret.Source
+			secretString += ",src=" + util.ExpandHomePath(secret.Source)
 		}
 		if secret.Env != "" {
 			secretString += ",env=" + secret.Env

--- a/pkg/skaffold/docker/image_test.go
+++ b/pkg/skaffold/docker/image_test.go
@@ -19,6 +19,7 @@ package docker
 import (
 	"context"
 	"io"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -369,6 +370,15 @@ func TestGetBuildArgs(t *testing.T) {
 				},
 			},
 			want: []string{"--secret", "id=mysecret,src=foo.src"},
+		},
+		{
+			description: "secret with file source in home directory",
+			artifact: &latest.DockerArtifact{
+				Secrets: []*latest.DockerSecret{
+					{ID: "mysecret", Source: "~/foo.src"},
+				},
+			},
+			want: []string{"--secret", fmt.Sprintf("id=mysecret,src=%s", util.ExpandHomePath("~/foo.src"))},
 		},
 		{
 			description: "secret with env source",

--- a/pkg/skaffold/docker/image_test.go
+++ b/pkg/skaffold/docker/image_test.go
@@ -18,8 +18,8 @@ package docker
 
 import (
 	"context"
-	"io"
 	"fmt"
+	"io"
 	"sync"
 	"sync/atomic"
 	"testing"

--- a/pkg/skaffold/util/util.go
+++ b/pkg/skaffold/util/util.go
@@ -338,3 +338,11 @@ func ParseNamespaceFromFlags(flgs []string) string {
 	}
 	return ""
 }
+
+func ExpandHomePath(path string) string {
+	if strings.HasPrefix(path, "~/") {
+		dirname, _ := os.UserHomeDir()
+		path = filepath.Join(dirname, path[2:])
+	}
+	return path
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #8453 <!-- tracking issues that this PR will close -->
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
As mentioned in the issue, when using ~/ for secret path, this wasn't expended to home directory but was happened after current directory. This change expends the path to the realpath of home directory if starting with ~/

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->
No user facing changes other than have it working as intended

**Follow-up Work (remove if N/A)**
<!-- Mention any related follow up work to this PR. -->


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
Should we test the util function ? It's only calling Go standard package

And thanks @smaftoul for your help on this one ;) 