### PR TITLE
docs: add tooltip with yaml path in Skaffold yaml reference page

### DIFF
--- a/docs-v2/content/en/docs/references/yaml/main.css
+++ b/docs-v2/content/en/docs/references/yaml/main.css
@@ -4,6 +4,7 @@
 
 .key {
     color: #811f3f;
+    position: relative;
 }
 
 .key.required {
@@ -86,4 +87,39 @@ a.anchor{
     a.anchor {
         top: -10px;
     }
+}
+
+.stooltip {
+    background-color: #555;
+    border-radius: 5px;
+    color: #fff;
+    display: inline-block;
+    font-size: 9px;
+    font-weight: 100;
+    left: 0;
+    opacity: 0;
+    padding: 5px 6px;
+    position: absolute;
+    top: -15px;
+    transform: translateY(-50%);
+    transition: opacity 0.3s;
+    visibility: hidden;
+}
+
+.stooltip::before {
+    background-color: #555;
+    border-radius: 1px;
+    bottom: -3px;
+    content: '';
+    display: block;
+    height: 10px;
+    left: 9px;
+    position: absolute;
+    transform: rotate(45deg);
+    width: 10px;
+}
+
+.stooltip__anchor:hover ~ .stooltip {
+    opacity: 1;
+    visibility: visible;
 }


### PR DESCRIPTION
**Description**
This change adds a new on hover tooltip in the Skaffold yaml reference indicating the full structure where the key is located in the file:

<img width="759" alt="image" src="https://user-images.githubusercontent.com/10214389/221224344-0a092c15-4a8e-42cb-b839-fb5b6e79816e.png">

**Known issue**
The tooltip for the first property in the yaml file, `apiVersion`, is not visible, we'll need to check better the CSS to remove the `overflow-x: auto` from the table without breaking the styles.