### PR TITLE
chore: Security hotfixes for v2.0.6 branch

### DIFF
--- a/deploy/skaffold/Dockerfile.deps
+++ b/deploy/skaffold/Dockerfile.deps
@@ -115,7 +115,7 @@ RUN \
     sha256sum -c bazel.${ARCH}.sha256
 RUN chmod +x bazel
 
-FROM gcr.io/gcp-runtimes/ubuntu_20_0_4 as runtime_deps
+FROM ubuntu:20.04 as runtime_deps
 
 RUN apt-get update && \
     apt-get install --no-install-recommends --no-install-suggests -y \
@@ -147,6 +147,7 @@ RUN gcloud auth configure-docker && \
     gcloud components install gke-gcloud-auth-plugin
 
 FROM runtime_deps
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \
     build-essential \
     python-setuptools \

--- a/deploy/skaffold/Dockerfile.deps
+++ b/deploy/skaffold/Dockerfile.deps
@@ -156,5 +156,5 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
     jq \
     apt-transport-https && \
     rm -rf /var/lib/apt/lists/*
-COPY --from=golang:1.19.1 /usr/local/go /usr/local/go
+COPY --from=golang:1.19.2 /usr/local/go /usr/local/go
 ENV PATH /usr/local/go/bin:/root/go/bin:$PATH

--- a/deploy/skaffold/Dockerfile.deps.lts
+++ b/deploy/skaffold/Dockerfile.deps.lts
@@ -100,5 +100,5 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
     jq \
     apt-transport-https && \
     rm -rf /var/lib/apt/lists/*
-COPY --from=golang:1.19.1 /usr/local/go /usr/local/go
+COPY --from=golang:1.19.2 /usr/local/go /usr/local/go
 ENV PATH /usr/local/go/bin:/root/go/bin:$PATH

--- a/deploy/skaffold/Dockerfile.deps.lts
+++ b/deploy/skaffold/Dockerfile.deps.lts
@@ -68,7 +68,7 @@ RUN \
 RUN tar -zxf gcloud.tar.gz
 
 
-FROM gcr.io/gcp-runtimes/ubuntu_20_0_4 as runtime_deps
+FROM ubuntu:20.04 as runtime_deps
 
 RUN apt-get update && \
     apt-get install --no-install-recommends --no-install-suggests -y \
@@ -91,6 +91,7 @@ RUN gcloud auth configure-docker && \
     gcloud components install gke-gcloud-auth-plugin
 
 FROM runtime_deps
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \
     build-essential \
     python-setuptools \

--- a/deploy/skaffold/Dockerfile.deps.slim
+++ b/deploy/skaffold/Dockerfile.deps.slim
@@ -100,5 +100,5 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
     jq \
     apt-transport-https && \
     rm -rf /var/lib/apt/lists/*
-COPY --from=golang:1.19.1 /usr/local/go /usr/local/go
+COPY --from=golang:1.19.2 /usr/local/go /usr/local/go
 ENV PATH /usr/local/go/bin:/root/go/bin:$PATH

--- a/deploy/skaffold/Dockerfile.deps.slim
+++ b/deploy/skaffold/Dockerfile.deps.slim
@@ -68,7 +68,7 @@ RUN \
 RUN tar -zxf gcloud.tar.gz
 
 
-FROM gcr.io/gcp-runtimes/ubuntu_20_0_4 as runtime_deps
+FROM ubuntu:20.04 as runtime_deps
 
 RUN apt-get update && \
     apt-get install --no-install-recommends --no-install-suggests -y \
@@ -91,6 +91,7 @@ RUN gcloud auth configure-docker && \
     gcloud components install gke-gcloud-auth-plugin
 
 FROM runtime_deps
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \
     build-essential \
     python-setuptools \


### PR DESCRIPTION
Changes here cherry-pick the following security related fixes on-top of the `v2.0.5` branch:

 - upgrade go: 6289a4b3c1666cfbe7e5d086c0ca7f3932036b82  pr : https://github.com/GoogleContainerTools/skaffold/pull/8420
 - upgrade base image: 984765305b3d2cf447d88148cc804b3a3dce4bf1 pr: https://github.com/GoogleContainerTools/skaffold/pull/8460