### PR TITLE
chore: security fixes for v1.37.3

### DIFF
--- a/deploy/skaffold/Dockerfile.deps
+++ b/deploy/skaffold/Dockerfile.deps
@@ -115,7 +115,7 @@ RUN \
     sha256sum -c bazel.${ARCH}.sha256
 RUN chmod +x bazel
 
-FROM gcr.io/gcp-runtimes/ubuntu_20_0_4 as runtime_deps
+FROM ubuntu:20.04 as runtime_deps
 
 RUN apt-get update && \
     apt-get install --no-install-recommends --no-install-suggests -y \
@@ -147,6 +147,7 @@ RUN gcloud auth configure-docker && \
     gcloud components install gke-gcloud-auth-plugin
 
 FROM runtime_deps
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \
     build-essential \
     python-setuptools \
@@ -156,5 +157,5 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
     jq \
     apt-transport-https && \
     rm -rf /var/lib/apt/lists/*
-COPY --from=golang:1.17.3 /usr/local/go /usr/local/go
+COPY --from=golang:1.17.13 /usr/local/go /usr/local/go
 ENV PATH /usr/local/go/bin:/root/go/bin:$PATH

--- a/deploy/skaffold/Dockerfile.deps.lts
+++ b/deploy/skaffold/Dockerfile.deps.lts
@@ -68,7 +68,7 @@ RUN \
 RUN tar -zxf gcloud.tar.gz
 
 
-FROM gcr.io/gcp-runtimes/ubuntu_20_0_4 as runtime_deps
+FROM ubuntu:20.04 as runtime_deps
 
 RUN apt-get update && \
     apt-get install --no-install-recommends --no-install-suggests -y \
@@ -91,6 +91,7 @@ RUN gcloud auth configure-docker && \
     gcloud components install gke-gcloud-auth-plugin
 
 FROM runtime_deps
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \
     build-essential \
     python-setuptools \
@@ -100,5 +101,5 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
     jq \
     apt-transport-https && \
     rm -rf /var/lib/apt/lists/*
-COPY --from=golang:1.17.3 /usr/local/go /usr/local/go
+COPY --from=golang:1.17.13 /usr/local/go /usr/local/go
 ENV PATH /usr/local/go/bin:/root/go/bin:$PATH


### PR DESCRIPTION
Security fixes for v1.37.3 equivalent to:
 - upgrade go: 6289a4b3c1666cfbe7e5d086c0ca7f3932036b82  pr : https://github.com/GoogleContainerTools/skaffold/pull/8420
 - upgrade base image: 984765305b3d2cf447d88148cc804b3a3dce4bf1 pr: https://github.com/GoogleContainerTools/skaffold/pull/8460

Creating PR to show changes, no need to merge.