### PR TITLE
fix: skaffold render namespace regression in v2

### DIFF
--- a/pkg/skaffold/runner/renderer.go
+++ b/pkg/skaffold/runner/renderer.go
@@ -47,14 +47,14 @@ func GetRenderer(ctx context.Context, runCtx *runcontext.RunContext, hydrationDi
 	if usingLegacyHelmDeploy && runCtx.Opts.Command == "render" {
 		for _, configName := range configNames {
 			p := runCtx.Pipelines.GetForConfigName(configName)
-
-			if p.Deploy.LegacyHelmDeploy == nil {
+			legacyHelmReleases := filterDuplicates(p.Deploy.LegacyHelmDeploy, p.Render.Helm)
+			if len(legacyHelmReleases) == 0 {
 				continue
 			}
 			rCfg := latest.RenderConfig{
 				Generate: latest.Generate{
 					Helm: &latest.Helm{
-						Releases: p.Deploy.LegacyHelmDeploy.Releases,
+						Releases: legacyHelmReleases,
 					},
 				},
 			}
@@ -66,4 +66,28 @@ func GetRenderer(ctx context.Context, runCtx *runcontext.RunContext, hydrationDi
 		}
 	}
 	return renderer.NewRenderMux(gr), nil
+}
+
+// filterDuplicates removes duplicate releases defined in the legacy helm deployer
+func filterDuplicates(l *latest.LegacyHelmDeploy, h *latest.Helm) []latest.HelmRelease {
+	if l == nil {
+		return nil
+	}
+	if h == nil {
+		return l.Releases
+	}
+	var rs []latest.HelmRelease
+	for i := range l.Releases {
+		isDup := false
+		for _, r := range h.Releases {
+			if r.Name == l.Releases[i].Name {
+				isDup = true
+				break
+			}
+		}
+		if !isDup {
+			rs = append(rs, l.Releases[i])
+		}
+	}
+	return rs
 }

--- a/pkg/skaffold/schema/v2beta29/upgrade_test.go
+++ b/pkg/skaffold/schema/v2beta29/upgrade_test.go
@@ -161,7 +161,10 @@ manifests:
         chartPath: charts
 deploy:
   kubectl: {}
-  helm: {}
+  helm:
+    releases:
+    - name: skaffold-helm
+      chartPath: charts
 portForward:
   - resourceType: deployment
     resourceName: leeroy-app
@@ -261,8 +264,10 @@ manifests:
    releases:
    - name: test
 deploy:
-    helm: {}
-    kubectl: {}
+  kubectl: {}
+  helm:
+    releases:
+    - name: test
 profiles:
 - name: kustomize
   patches:
@@ -270,6 +275,8 @@ profiles:
     path: /manifests/rawYaml
   - op: remove
     path: /manifests/helm
+  - op: remove
+    path: /deploy/helm
   manifests:
     kustomize:
       paths:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: b/265799040 <!-- tracking issues that this PR will close -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
From https://github.com/helm/helm/issues/3553 `helm template` command run with the `--namespace` flag doesn't set the `metadata.namespace` in the rendered manifests but only sets `{{.Release.Namespace}}` templates. In Skaffold v1, the `deploy.helm.releases[i].namespace` property was also being passed as the `--namespace` flag for a `skaffold apply` command. To preserve this behavior in v2 when upgrading from an old config, the upgrade logic is changed to duplicate the `deploy.helm.releases` to `manifests.helm.releases`. So we can use the helm release namespace values again in the `skaffold apply` command.
