### PR TITLE
fix: don't apply basepath when looking up image names for re-tagging multi-arch images

### DIFF
--- a/pkg/skaffold/build/cache/details.go
+++ b/pkg/skaffold/build/cache/details.go
@@ -19,7 +19,6 @@ package cache
 import (
 	"context"
 	"io"
-	"path/filepath"
 	"strings"
 
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/docker"
@@ -88,8 +87,8 @@ func (d needsRemoteTagging) Hash() string {
 }
 
 func (d needsRemoteTagging) Tag(ctx context.Context, c *cache, platforms platform.Resolver) error {
-	fqn := d.tag + "@" + d.digest // Tag is not important. We just need the registry and the digest to locate the image.
-	matched := platforms.GetPlatforms(strings.Split(filepath.Base(d.tag), ":")[0])
+	fqn := d.tag + "@" + d.digest
+	matched := platforms.GetPlatforms(strings.Split(d.tag, ":")[0])
 	return docker.AddRemoteTag(fqn, d.tag, c.cfg, matched.Platforms)
 }
 


### PR DESCRIPTION
Fixes: #8380

**Description**

Addresses the issue described in #8380 where re-tagging multi-arch builds with e.g. a `cache` tag, re-tags the first manifest returned by the registry instead of re-tagging the multi-arch manifest.

Further details are described in [this issue comment](https://github.com/GoogleContainerTools/skaffold/issues/8380#issuecomment-1452132087).

**User facing changes (remove if N/A)**

Before: running `skaffold build --tag xy` for an already existing multi-arch image would re-tag e.g. the `*_amd64` image version instead of the multi-arch manifest (no suffix).
This results in errors when trying to pull the `xy` image tag on a non-matching arch, e.g. `arm64`.

After: running `skaffold build --tag xy` for an already existing multi-arch image adds a tag `xy` to the multi-arch manifest.