### PR TITLE
docs: add `minikube tunnel` command in the tutorial

### DIFF
--- a/docs-v2/content/en/docs/quickstart/_index.md
+++ b/docs-v2/content/en/docs/quickstart/_index.md
@@ -109,6 +109,13 @@ This may take several minutes.
     ```terminal
     Example app listening on port 3000!
     ```
+    
+    To browse to the web page, open a new terminal and run:
+    ```terminal
+    minikube tunnel -p custom
+    ```
+    
+    Now open your browser at `http://localhost:3000`. This displays the content of `public/index.html` file. 
 
     Skaffold is now watching for any file changes, and will rebuild your application automatically. Let's see this in action.
 


### PR DESCRIPTION

**Description**
Added `minikube tunnel` command to the tutorial. Without it, you can not access `localhost:3000` because the service of type LoadBalancer is stuck in `pending` state.


