### PR TITLE
chore: update cloudbuild config to publish distroless-skaffold image to artifact registry for vulns scanning

### DIFF
--- a/deploy/cloudbuild-release-lts.yaml
+++ b/deploy/cloudbuild-release-lts.yaml
@@ -31,6 +31,18 @@ steps:
     - 'deploy/skaffold/Dockerfile'
     - '.'
 
+# Build and tag distroless-skaffold image for scanning
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '--build-arg'
+      - 'PROJECT_ID=$PROJECT_ID'
+      - '-t'
+      - 'us-east1-docker.pkg.dev/$PROJECT_ID/scanning/skaffold:$TAG_NAME-lts'
+      - '-f'
+      - 'deploy/skaffold/Dockerfile.skaffold'
+      - '.'
+
 # Do the go build & push the results to GCS
   - name: 'gcr.io/$PROJECT_ID/skaffold-builder:latest'
     args:
@@ -48,6 +60,7 @@ steps:
 
 images:
 - 'gcr.io/$PROJECT_ID/skaffold:$TAG_NAME-lts'
+- 'us-east1-docker.pkg.dev/$PROJECT_ID/scanning/skaffold:$TAG_NAME-lts'
 
 options:
   machineType: 'N1_HIGHCPU_8'

--- a/deploy/cloudbuild.yaml
+++ b/deploy/cloudbuild.yaml
@@ -28,6 +28,18 @@ steps:
     - 'deploy/skaffold/Dockerfile'
     - '.'
 
+# Build and tag distroless-skaffold image for scanning
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '--build-arg'
+      - 'PROJECT_ID=$PROJECT_ID'
+      - '-t'
+      - 'us-east1-docker.pkg.dev/$PROJECT_ID/scanning/skaffold:edge'
+      - '-f'
+      - 'deploy/skaffold/Dockerfile.skaffold'
+      - '.'
+
 # Do the go build & push the results to GCS
   - name: 'gcr.io/$PROJECT_ID/skaffold-builder:latest'
     args:
@@ -46,6 +58,7 @@ images:
 - 'gcr.io/$PROJECT_ID/build_deps:latest'
 - 'gcr.io/$PROJECT_ID/skaffold:edge'
 - 'gcr.io/$PROJECT_ID/skaffold:$COMMIT_SHA'
+- 'us-east1-docker.pkg.dev/$PROJECT_ID/scanning/skaffold:edge'
 
 options:
   machineType: 'N1_HIGHCPU_8'

--- a/deploy/skaffold/Dockerfile.skaffold
+++ b/deploy/skaffold/Dockerfile.skaffold
@@ -1,0 +1,5 @@
+ARG PROJECT_ID
+FROM gcr.io/$PROJECT_ID/skaffold-builder:latest as builder
+
+FROM gcr.io/distroless/static-debian11
+COPY --from=builder /usr/bin/skaffold /usr/bin/skaffold


### PR DESCRIPTION
<!-- Include if applicable: -->
Fixes: #nnn <!-- tracking issues that this PR will close -->
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
 - This pr adds a step to build and publish distroless-skaffold image in main new commit and lts builds, 
 - skaffold binaries built from latest commits and from lts commits cut will be wrapped with distroless images and then published to artifact registry 
 - These images will be used for vulnerability-scanning to identify any vulns in skaffold binary
 - The actual scanning script and related config will be added in a separate pr.
**Test Plan**
 - create ``cloudbuild.yaml`` file with the following content in your skaffold repo root dir
 ```yaml
steps:
  # Build and tag skaffold builder
  - name: 'gcr.io/cloud-builders/docker'
    args:
      - 'build'
      - '-t'
      - 'gcr.io/$PROJECT_ID/skaffold-builder:latest'
      - '-f'
      - 'deploy/skaffold/Dockerfile'
      - '.'

  - name: 'gcr.io/cloud-builders/docker'
    args:
      - 'build'
      - '--build-arg'
      - 'PROJECT_ID=$PROJECT_ID'
      - '-t'
      - 'us-east1-docker.pkg.dev/$PROJECT_ID/scanning/skaffold:edge'
      - '-f'
      - 'deploy/skaffold/Dockerfile.skaffold'
      - '.'
images:
  - 'us-east1-docker.pkg.dev/$PROJECT_ID/scanning/skaffold:edge'
```
 -  switch your project to ``k8s-skaffold`` ,by running``gcloud config set project k8s-skaffold``
 - in the repo root dir, run `` gcloud builds submit --config=cloudbuild.yaml`` to submit the build, 
 - The build should succeed, and image is pushed to artifact registry
 - example build: https://pantheon.corp.google.com/cloud-build/builds;region=global/72128d61-dde5-49ec-b9f7-91cb7b6f95c1;step=1?e=13802955&jsmode=O&mods=logs_tg_staging&project=k8s-skaffold 
 - image: us-east1-docker.pkg.dev/k8s-skaffold/scanning/skaffold:edge