### PR TITLE
fix: `kubectl create` with `dry-run` shouldn't pass the namespace flag

### DIFF
--- a/pkg/skaffold/deploy/kubectl/cli.go
+++ b/pkg/skaffold/deploy/kubectl/cli.go
@@ -35,7 +35,6 @@ import (
 	kstatus "github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/kubernetes/status"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/output/log"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/latest"
-	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/util"
 )
 
 // CLI holds parameters to run kubectl.
@@ -211,15 +210,11 @@ func (c *CLI) ReadManifests(ctx context.Context, manifests []string) (manifest.M
 
 	args := c.args([]string{dryRun, "-oyaml"}, list...)
 
-	if ns := util.ParseNamespaceFromFlags(c.Flags.Apply); ns != "" {
-		args = append(args, "-n", ns)
-	}
-
 	if c.Flags.DisableValidation {
 		args = append(args, "--validate=false")
 	}
 
-	buf, err := c.RunOut(ctx, "create", args...)
+	buf, err := c.RunOutWithoutNamespace(ctx, "create", args...)
 	if err != nil {
 		return nil, readManifestErr(fmt.Errorf("kubectl create: %w", err))
 	}

--- a/pkg/skaffold/kubectl/cli.go
+++ b/pkg/skaffold/kubectl/cli.go
@@ -58,13 +58,19 @@ func NewCLI(cfg Config, defaultNamespace string) *CLI {
 
 // Command creates the underlying exec.CommandContext. This allows low-level control of the executed command.
 func (c *CLI) Command(ctx context.Context, command string, arg ...string) *exec.Cmd {
-	args := c.args(command, "", arg...)
+	args := c.args(command, util.Ptr(""), arg...)
 	return exec.CommandContext(ctx, "kubectl", args...)
 }
 
 // Command creates the underlying exec.CommandContext with namespace. This allows low-level control of the executed command.
 func (c *CLI) CommandWithNamespaceArg(ctx context.Context, command string, namespace string, arg ...string) *exec.Cmd {
-	args := c.args(command, namespace, arg...)
+	args := c.args(command, util.Ptr(namespace), arg...)
+	return exec.CommandContext(ctx, "kubectl", args...)
+}
+
+// Command creates the underlying exec.CommandContext without a namespace. This allows low-level control of the executed command.
+func (c *CLI) CommandWithoutNamespaceArg(ctx context.Context, command string, arg ...string) *exec.Cmd {
+	args := c.args(command, nil, arg...)
 	return exec.CommandContext(ctx, "kubectl", args...)
 }
 
@@ -86,6 +92,12 @@ func (c *CLI) RunInNamespace(ctx context.Context, in io.Reader, out io.Writer, c
 	return util.RunCmd(ctx, cmd)
 }
 
+// RunInNamespace shells out kubectl CLI with given namespace
+func (c *CLI) RunOutWithoutNamespace(ctx context.Context, command string, arg ...string) ([]byte, error) {
+	cmd := c.CommandWithoutNamespaceArg(ctx, command, arg...)
+	return util.RunCmdOut(ctx, cmd)
+}
+
 // RunOut shells out kubectl CLI.
 func (c *CLI) RunOut(ctx context.Context, command string, arg ...string) ([]byte, error) {
 	cmd := c.Command(ctx, command, arg...)
@@ -101,7 +113,7 @@ func (c *CLI) RunOutInput(ctx context.Context, in io.Reader, command string, arg
 
 // CommandWithStrictCancellation ensures for windows OS that all child process get terminated on cancellation
 func (c *CLI) CommandWithStrictCancellation(ctx context.Context, command string, arg ...string) *Cmd {
-	args := c.args(command, "", arg...)
+	args := c.args(command, util.Ptr(""), arg...)
 	return CommandContext(ctx, "kubectl", args...)
 }
 
@@ -112,14 +124,16 @@ func (c *CLI) Kustomize(ctx context.Context, args []string) ([]byte, error) {
 
 // args builds an argument list for calling kubectl and consistently
 // adds the `--context` and `--namespace` flags.
-func (c *CLI) args(command string, namespace string, arg ...string) []string {
+func (c *CLI) args(command string, namespace *string, arg ...string) []string {
 	args := []string{}
 	if c.KubeContext != "" {
 		args = append(args, "--context", c.KubeContext)
 	}
-	namespace = c.resolveNamespace(namespace)
-	if namespace != "" {
-		args = append(args, "--namespace", namespace)
+	if namespace != nil {
+		ns := c.resolveNamespace(*namespace)
+		if ns != "" {
+			args = append(args, "--namespace", ns)
+		}
 	}
 	if c.KubeConfig != "" {
 		args = append(args, "--kubeconfig", c.KubeConfig)


### PR DESCRIPTION
Skaffold runs `kubectl create --dry-run ... --namespace=foo` when reading a manifest in: https://github.com/GoogleContainerTools/skaffold/blob/e74ef33d0c6c88fc24a901dab7f0044dc41116eb/pkg/skaffold/deploy/kubectl/cli.go#L197

This can be run without the `--namespace` flag as Skaffold sets the namespace as a post-render step anyways. 