### PR TITLE
feat: standarize renders to inject namespace only if --namespace or render specific config is set

### DIFF
--- a/pkg/skaffold/deploy/kubectl/kubectl_test.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl_test.go
@@ -245,7 +245,7 @@ func TestKubectlV1RenderDeploy(t *testing.T) {
 				},
 			}
 
-			r, err := kubectlR.New(mockCfg, rc, map[string]string{}, configName, "", nil)
+			r, err := kubectlR.New(mockCfg, rc, map[string]string{}, configName, skaffoldNamespaceOption, nil, !test.skipSkaffoldNamespaceOption)
 			t.CheckNoError(err)
 			var b bytes.Buffer
 			m, errR := r.Render(context.Background(), &b, []graph.Artifact{{ImageName: "leeroy-web", Tag: "leeroy-web:v1"}},
@@ -340,7 +340,7 @@ func TestKubectlCleanup(t *testing.T) {
 				},
 			}
 
-			r, err := kubectlR.New(mockCfg, rc, map[string]string{}, configName, "", nil)
+			r, err := kubectlR.New(mockCfg, rc, map[string]string{}, configName, TestNamespace, nil, true)
 			t.CheckNoError(err)
 			var b bytes.Buffer
 			m, errR := r.Render(context.Background(), &b, []graph.Artifact{{ImageName: "leeroy-web", Tag: "leeroy-web:v1"}},
@@ -544,7 +544,7 @@ func TestGCSManifests(t *testing.T) {
 					}, []string{configName}),
 				},
 			}
-			r, err := kubectlR.New(mockCfg, rc, map[string]string{}, configName, "", nil)
+			r, err := kubectlR.New(mockCfg, rc, map[string]string{}, configName, TestNamespace, nil, true)
 			t.CheckNoError(err)
 			var b bytes.Buffer
 			m, errR := r.Render(context.Background(), &b, []graph.Artifact{{ImageName: "leeroy-web", Tag: "leeroy-web:v1"}},

--- a/pkg/skaffold/deploy/kubectl/kustomize_test.go
+++ b/pkg/skaffold/deploy/kubectl/kustomize_test.go
@@ -142,7 +142,7 @@ func TestKustomizeRenderDeploy(t *testing.T) {
 			mockCfg := &kubectlConfig{
 				RunContext: runcontext.RunContext{},
 			}
-			r, err := kustomize.New(mockCfg, rc, map[string]string{}, configName, "", nil)
+			r, err := kustomize.New(mockCfg, rc, map[string]string{}, configName, skaffoldNamespaceOption, nil, !test.skipSkaffoldNamespaceOption)
 			t.CheckNoError(err)
 			var b bytes.Buffer
 			m, errR := r.Render(context.Background(), &b, test.builds, true)
@@ -224,7 +224,7 @@ func TestKustomizeCleanup(t *testing.T) {
 				workingDir: tmpDir.Root(),
 				RunContext: runcontext.RunContext{},
 			}
-			r, err := kustomize.New(mockCfg, rc, map[string]string{}, configName, "", nil)
+			r, err := kustomize.New(mockCfg, rc, map[string]string{}, configName, TestNamespace, nil, true)
 			t.CheckNoError(err)
 			var b bytes.Buffer
 			m, errR := r.Render(context.Background(), &b, []graph.Artifact{{ImageName: "leeroy-web", Tag: "leeroy-web:v1"}},
@@ -446,7 +446,7 @@ func TestDependenciesForKustomization(t *testing.T) {
 			mockCfg := &kubectlConfig{
 				RunContext: runcontext.RunContext{},
 			}
-			r, err := kustomize.New(mockCfg, rc, map[string]string{}, "default", "", nil)
+			r, err := kustomize.New(mockCfg, rc, map[string]string{}, "default", "", nil, false)
 			t.CheckNoError(err)
 
 			deps, err := r.ManifestDeps()

--- a/pkg/skaffold/render/renderer/kpt/kpt.go
+++ b/pkg/skaffold/render/renderer/kpt/kpt.go
@@ -50,6 +50,7 @@ type Kpt struct {
 	hydrationDir      string
 	labels            map[string]string
 	namespace         string
+	injectNs          bool
 	pkgDir            []string
 	manifestOverrides map[string]string
 
@@ -57,7 +58,7 @@ type Kpt struct {
 	transformDenylist  map[apimachinery.GroupKind]latest.ResourceFilter
 }
 
-func New(cfg render.Config, rCfg latest.RenderConfig, hydrationDir string, labels map[string]string, configName string, ns string, manifestOverrides map[string]string) (*Kpt, error) {
+func New(cfg render.Config, rCfg latest.RenderConfig, hydrationDir string, labels map[string]string, configName string, ns string, manifestOverrides map[string]string, injectNs bool) (*Kpt, error) {
 	transformAllowlist, transformDenylist, err := rUtil.ConsolidateTransformConfiguration(cfg)
 	if err != nil {
 		return nil, err
@@ -98,6 +99,7 @@ func New(cfg render.Config, rCfg latest.RenderConfig, hydrationDir string, label
 		transformAllowlist: transformAllowlist,
 		transformDenylist:  transformDenylist,
 		namespace:          ns,
+		injectNs:           injectNs,
 	}, nil
 }
 
@@ -146,7 +148,7 @@ func (r *Kpt) Render(ctx context.Context, out io.Writer, builds []graph.Artifact
 		EnableGKEARMNodeToleration: r.cfg.EnableGKEARMNodeTolerationInRenderedManifests(),
 		Offline:                    offline,
 		KubeContext:                r.cfg.GetKubeContext(),
-		InjectNamespace:            true,
+		InjectNamespace:            r.injectNs,
 	}
 
 	manifestList, err = rUtil.BaseTransform(ctx, manifestList, builds, opts, r.labels, r.namespace)

--- a/pkg/skaffold/render/renderer/kpt/kpt_test.go
+++ b/pkg/skaffold/render/renderer/kpt/kpt_test.go
@@ -49,7 +49,6 @@ spec:
 kind: Pod
 metadata:
   name: leeroy-web
-  namespace: default
 spec:
   containers:
   - image: leeroy-web:v1
@@ -89,7 +88,7 @@ func TestRender(t *testing.T) {
 				WorkingDir: tmpDirObj.Root(),
 			}
 			test.renderConfig.Kpt = []string{filepath.Join(tmpDirObj.Root(), constants.DefaultHydrationDir)}
-			r, err := New(mockCfg, test.renderConfig, filepath.Join(tmpDirObj.Root(), constants.DefaultHydrationDir), map[string]string{}, "default", "", nil)
+			r, err := New(mockCfg, test.renderConfig, filepath.Join(tmpDirObj.Root(), constants.DefaultHydrationDir), map[string]string{}, "default", "", nil, false)
 			t.CheckNoError(err)
 			t.Override(&util.DefaultExecCommand,
 				testutil.CmdRunOut(fmt.Sprintf("kpt fn render %v -o unwrap",

--- a/pkg/skaffold/render/renderer/kubectl/kubectl.go
+++ b/pkg/skaffold/render/renderer/kubectl/kubectl.go
@@ -44,6 +44,7 @@ type Kubectl struct {
 	rCfg               latest.RenderConfig
 	configName         string
 	namespace          string
+	injectNs           bool
 	Generator          generate.Generator
 	labels             map[string]string
 	manifestOverrides  map[string]string
@@ -53,7 +54,7 @@ type Kubectl struct {
 	transformDenylist  map[apimachinery.GroupKind]latest.ResourceFilter
 }
 
-func New(cfg render.Config, rCfg latest.RenderConfig, labels map[string]string, configName string, ns string, manifestOverrides map[string]string) (Kubectl, error) {
+func New(cfg render.Config, rCfg latest.RenderConfig, labels map[string]string, configName string, ns string, manifestOverrides map[string]string, injectNs bool) (Kubectl, error) {
 	transformAllowlist, transformDenylist, err := rUtil.ConsolidateTransformConfiguration(cfg)
 	generator := generate.NewGenerator(cfg.GetWorkingDir(), rCfg.Generate, "")
 	if err != nil {
@@ -88,6 +89,7 @@ func New(cfg render.Config, rCfg latest.RenderConfig, labels map[string]string, 
 		configName:         configName,
 		rCfg:               rCfg,
 		namespace:          ns,
+		injectNs:           injectNs,
 		Generator:          generator,
 		labels:             labels,
 		manifestOverrides:  manifestOverrides,
@@ -123,7 +125,7 @@ func (r Kubectl) Render(ctx context.Context, out io.Writer, builds []graph.Artif
 		EnableGKEARMNodeToleration: r.cfg.EnableGKEARMNodeTolerationInRenderedManifests(),
 		Offline:                    offline,
 		KubeContext:                r.cfg.GetKubeContext(),
-		InjectNamespace:            true,
+		InjectNamespace:            r.injectNs,
 	}
 	manifests, err = rUtil.BaseTransform(ctx, manifests, builds, opts, r.labels, r.namespace)
 

--- a/pkg/skaffold/render/renderer/kustomize/kustomize.go
+++ b/pkg/skaffold/render/renderer/kustomize/kustomize.go
@@ -52,6 +52,7 @@ type Kustomize struct {
 
 	configName string
 	namespace  string
+	injectNs   bool
 
 	labels            map[string]string
 	manifestOverrides map[string]string
@@ -85,11 +86,11 @@ func (k Kustomize) Render(ctx context.Context, out io.Writer, builds []graph.Art
 		EnableGKEARMNodeToleration: k.cfg.EnableGKEARMNodeTolerationInRenderedManifests(),
 		Offline:                    offline,
 		KubeContext:                k.cfg.GetKubeContext(),
-		InjectNamespace:            false, // This is to keep backwards compatibility with Skaffold v1.
+		InjectNamespace:            k.injectNs,
 	}
 
 	ns := k.namespace
-	if k.cfg.GetKubeNamespace() != "" {
+	if k.injectNs {
 		ns = k.cfg.GetKubeNamespace()
 	}
 	manifests, err := util.BaseTransform(ctx, manifests, builds, opts, k.labels, ns)
@@ -205,7 +206,7 @@ func (k Kustomize) mirror(kusDir string, fs TmpFS) error {
 	return nil
 }
 
-func New(cfg render.Config, rCfg latest.RenderConfig, labels map[string]string, configName string, ns string, manifestOverrides map[string]string) (Kustomize, error) {
+func New(cfg render.Config, rCfg latest.RenderConfig, labels map[string]string, configName string, ns string, manifestOverrides map[string]string, injectNs bool) (Kustomize, error) {
 	transformAllowlist, transformDenylist, err := util.ConsolidateTransformConfiguration(cfg)
 	if err != nil {
 		return Kustomize{}, err
@@ -238,6 +239,7 @@ func New(cfg render.Config, rCfg latest.RenderConfig, labels map[string]string, 
 		cfg:               cfg,
 		configName:        configName,
 		namespace:         ns,
+		injectNs:          injectNs,
 		labels:            labels,
 		rCfg:              rCfg,
 		manifestOverrides: manifestOverrides,

--- a/pkg/skaffold/render/renderer/renderer.go
+++ b/pkg/skaffold/render/renderer/renderer.go
@@ -43,9 +43,10 @@ type Renderer interface {
 func New(ctx context.Context, cfg render.Config, renderCfg latest.RenderConfig, hydrationDir string, labels map[string]string, configName string, manifestOverrides map[string]string) (GroupRenderer, error) {
 	var rs GroupRenderer
 	rs.HookRunners = []hooks.Runner{hooks.NewRenderRunner(renderCfg.Generate.LifecycleHooks, &[]string{cfg.GetNamespace()}, hooks.NewRenderEnvOpts(cfg.GetKubeContext(), []string{cfg.GetNamespace()}))}
+	injectNs := cfg.GetKubeNamespace() != ""
 
 	if renderCfg.Kpt != nil {
-		r, err := kpt.New(cfg, renderCfg, hydrationDir, labels, configName, cfg.GetNamespace(), manifestOverrides)
+		r, err := kpt.New(cfg, renderCfg, hydrationDir, labels, configName, cfg.GetNamespace(), manifestOverrides, injectNs)
 		if err != nil {
 			return GroupRenderer{}, err
 		}
@@ -54,14 +55,14 @@ func New(ctx context.Context, cfg render.Config, renderCfg latest.RenderConfig, 
 	}
 
 	if renderCfg.RawK8s != nil || renderCfg.RemoteManifests != nil {
-		r, err := kubectl.New(cfg, renderCfg, labels, configName, cfg.GetNamespace(), manifestOverrides)
+		r, err := kubectl.New(cfg, renderCfg, labels, configName, cfg.GetNamespace(), manifestOverrides, injectNs)
 		if err != nil {
 			return GroupRenderer{}, err
 		}
 		rs.Renderers = append(rs.Renderers, r)
 	}
 	if renderCfg.Kustomize != nil {
-		r, err := kustomize.New(cfg, renderCfg, labels, configName, cfg.GetNamespace(), manifestOverrides)
+		r, err := kustomize.New(cfg, renderCfg, labels, configName, cfg.GetNamespace(), manifestOverrides, injectNs)
 		if err != nil {
 			return GroupRenderer{}, err
 		}

--- a/pkg/skaffold/render/renderer/renderer.go
+++ b/pkg/skaffold/render/renderer/renderer.go
@@ -21,7 +21,6 @@ import (
 	"io"
 
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/hooks"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/kubernetes/manifest"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/output/log"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/render"
@@ -42,7 +41,6 @@ type Renderer interface {
 // New creates a new Renderer object from the latestV2 API schema.
 func New(ctx context.Context, cfg render.Config, renderCfg latest.RenderConfig, hydrationDir string, labels map[string]string, configName string, manifestOverrides map[string]string) (GroupRenderer, error) {
 	var rs GroupRenderer
-	rs.HookRunners = []hooks.Runner{hooks.NewRenderRunner(renderCfg.Generate.LifecycleHooks, &[]string{cfg.GetNamespace()}, hooks.NewRenderEnvOpts(cfg.GetKubeContext(), []string{cfg.GetNamespace()}))}
 	injectNs := cfg.GetKubeNamespace() != ""
 
 	if renderCfg.Kpt != nil {


### PR DESCRIPTION
Fixes: #8318

**Description**
This PR will make the existing renderers to only inject a `metadata.namespace` field if a `--namespace` flag is set or if the render itself is configured for that.

**Pending**
Validate helm behavior