### PR TITLE
chore: fix transformer share config-map issues

### DIFF
--- a/pkg/skaffold/render/transform/transform.go
+++ b/pkg/skaffold/render/transform/transform.go
@@ -35,7 +35,7 @@ var (
 	allowListedTransformer = []string{"set-labels"}
 	transformerAllowlist   = map[string]kptfile.Function{
 		"set-namespace": {
-			Image:     "gcr.io/kpt-fn/set-namespace",
+			Image:     "gcr.io/kpt-fn/set-namespace:v0.4.1",
 			ConfigMap: map[string]string{},
 		},
 		"set-labels": {
@@ -135,9 +135,9 @@ func (v *Transformer) Transform(ctx context.Context, ml manifest.ManifestList) (
 		cmd.Stdin = reader
 		cmd.Stdout = buffer
 
-		err := cmd.Run()
+		err := util.RunCmd(ctx, cmd)
 		if err != nil {
-			return ml, err
+			return ml, fmt.Errorf("failed to run transfomer: %s, err: %v", transformer.Image, err)
 		}
 		ml, err = manifest.Load(buffer)
 		if err != nil {
@@ -182,6 +182,7 @@ func validateTransformers(config []latest.Transformer) ([]kptfile.Function, erro
 					},
 				})
 		}
+		newFunc = kptfile.Function{Image: newFunc.Image, ConfigMap: map[string]string{}}
 		if c.ConfigMap != nil {
 			for _, stringifiedData := range c.ConfigMap {
 				index := strings.Index(stringifiedData, ":")

--- a/pkg/skaffold/render/transform/transform_test.go
+++ b/pkg/skaffold/render/transform/transform_test.go
@@ -54,6 +54,29 @@ func TestNewTransformer(t *testing.T) {
 	}
 }
 
+func TestNewTransformerDoesNotShareConfigMap(t *testing.T) {
+	tests := []struct {
+		description string
+		config      []latest.Transformer
+	}{
+		{
+			description: "set-labels",
+			config: []latest.Transformer{
+				{Name: "set-labels", ConfigMap: []string{"owner2:skaffold-test"}},
+				{Name: "set-labels", ConfigMap: []string{"owner:skaffold-test"}},
+			},
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			transformer, err := NewTransformer(test.config)
+			t.CheckNoError(err)
+			t.CheckDeepEqual(1, len(transformer.kptFn[0].ConfigMap))
+			t.CheckDeepEqual(1, len(transformer.kptFn[1].ConfigMap))
+		})
+	}
+}
+
 func TestNewValidator_Error(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
 		_, err := NewTransformer([]latest.Transformer{


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #8580 <!-- tracking issues that this PR will close -->
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
 - kpt Transformers with the same name are currently sharing configmap which can produce unexpected behavior 
   -  uses could define create-setter, apply-setter, create-setter, apply-setter in a row in skaffold transform stanza 
      each entry should only be able to access its own datamap
  - kpt set-namespace image doesn't have a latest version, we need to specify the version, so added one. 
  - change cmd run to use util cmd run to make debugging life easier
