### PR TITLE
chore: upgrade docker version in skaffold image

### DIFF
--- a/deploy/skaffold/Dockerfile.deps
+++ b/deploy/skaffold/Dockerfile.deps
@@ -122,7 +122,7 @@ RUN apt-get update && \
     git python unzip && \
     rm -rf /var/lib/apt/lists/*
 
-COPY --from=docker:19.03.13 /usr/local/bin/docker /usr/local/bin/
+COPY --from=docker:23.0.1 /usr/local/bin/docker /usr/local/bin/
 COPY --from=download-kubectl kubectl /usr/local/bin/
 COPY --from=download-helm helm /usr/local/bin/
 COPY --from=download-kustomize kustomize /usr/local/bin/


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #8578 <!-- tracking issues that this PR will close -->
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Test Plan**
 - Tested by building the image and run test plan provided in #8578  
-  output
```yaml
apiVersion: v1
kind: Namespace
metadata:
  name: skaffold-clouddeploy-test
---
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: kpt
  name: kpt
  namespace: skaffold-clouddeploy-test
spec:
  replicas: 1
  selector:
    matchLabels:
      app: kpt
  template:
    metadata:
      labels:
        app: kpt
    spec:
      containers:
        - image: gcr.io/google-samples/hello-app:2.0@sha256:c4b0d869bd22cb3d1207848b385c389f7a4ab7a481184476ee7b98e7876ee594
          imagePullPolicy: Always
          name: hello
          ports:
            - containerPort: 8080
          resources:
            limits:
              cpu: 100m
            requests:
              cpu: 100m
---
apiVersion: v1
kind: Service
metadata:
  labels:
    app: kpt
  name: kpt
  namespace: skaffold-clouddeploy-test
spec:
  ports:
    - name: http
      port: 80
      targetPort: 8080
  selector:
    app: kpt
  type: LoadBalancer
```
 - check docker version shows 
 ```bash
Client:
 Version:           23.0.1
 API version:       1.41 (downgraded from 1.42)
 Go version:        go1.19.5
 Git commit:        a5ee5b1
 Built:             Thu Feb  9 19:45:43 2023
 OS/Arch:           linux/amd64
 Context:           default
```
 