### PR TITLE
fix: use active gcp account

### DIFF
--- a/pkg/skaffold/gcp/auth.go
+++ b/pkg/skaffold/gcp/auth.go
@@ -81,7 +81,7 @@ func (ts tokenSource) Token() (*oauth2.Token, error) {
 	}
 	var t token
 	if err := json.Unmarshal(body.Bytes(), &t); err != nil {
-		return nil, fmt.Errorf("failed to get access token %v", err)
+		return nil, fmt.Errorf("failed to unmarshal gcould command result into access token %v", err)
 	}
 	return &oauth2.Token{AccessToken: t.AccessToken, Expiry: t.TokenExpiry}, nil
 }

--- a/pkg/skaffold/gcp/auth_test.go
+++ b/pkg/skaffold/gcp/auth_test.go
@@ -20,6 +20,8 @@ limitations under the License.
 package gcp
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	"github.com/docker/cli/cli/config/configfile"
@@ -110,4 +112,13 @@ func TestAutoConfigureGCRCredentialHelper(t *testing.T) {
 			t.CheckDeepEqual(test.expected, test.config)
 		})
 	}
+}
+
+func TestTesting(t *testing.T) {
+	credentials, err := activeUserCredentials(context.TODO())
+	if err != nil {
+		fmt.Println(err)
+		fmt.Println("err")
+	}
+	fmt.Println(credentials.TokenSource.Token())
 }

--- a/pkg/skaffold/gcp/client.go
+++ b/pkg/skaffold/gcp/client.go
@@ -31,7 +31,7 @@ func ClientOptions(ctx context.Context) []option.ClientOption {
 		option.WithUserAgent(version.UserAgent()),
 	}
 
-	creds, cErr := activeUserCredentials(ctx)
+	creds, cErr := activeUserCredentialsOnce()
 	if cErr == nil && creds != nil {
 		options = append(options, option.WithCredentials(creds))
 	}

--- a/pkg/skaffold/gcp/client.go
+++ b/pkg/skaffold/gcp/client.go
@@ -21,6 +21,7 @@ import (
 
 	"google.golang.org/api/option"
 
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/output/log"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/version"
 )
 
@@ -32,6 +33,7 @@ func ClientOptions(ctx context.Context) []option.ClientOption {
 	}
 
 	creds, cErr := activeUserCredentialsOnce()
+	log.Entry(ctx).Debug("unable to active user credentials %v", cErr)
 	if cErr == nil && creds != nil {
 		options = append(options, option.WithCredentials(creds))
 	}

--- a/pkg/skaffold/gcp/client.go
+++ b/pkg/skaffold/gcp/client.go
@@ -33,7 +33,7 @@ func ClientOptions(ctx context.Context) []option.ClientOption {
 	}
 
 	creds, cErr := activeUserCredentialsOnce()
-	log.Entry(ctx).Debug("unable to active user credentials %v", cErr)
+	log.Entry(ctx).Debug("unable to active user credentials %w", cErr)
 	if cErr == nil && creds != nil {
 		options = append(options, option.WithCredentials(creds))
 	}


### PR DESCRIPTION
<!-- Include if applicable: -->
Fixes: #6996 <!-- tracking issues that this PR will close -->
**Description**
 - update the method to `get` gcp active account credential 
 - The original method to retrieve account credential always produces error when calling credential.tokenSource.token method. This might have not been verified when it was implemented, seems a little strange to `create` credential with an access token. My understanding is that the credential is used to retrieve an access token and the token can be used to initiate other requests to other services. oauth.google package can use adc(application default credential) 
```json
 "client_id": "..."
 "client_secret" :".."
 "refresh_token":"...."
 "type": ".."
 ``` 
to construct tokenSource which is used retrieve access token , we can also implement our own token source and provide it to google.Credentials struct , then the tokenSource.token() will be called when needed to request gcp services. 

## Test Plan
 - create a service account from your project 
 - create keyfile for your account
 - run ``gcloud auth activate-service-account {account_name} --key-file={file}`` to activate your account
 - run ``skaffold build -vdebug`` in ``integration/testdata/gcb-explicit-repo`` project, the run should fail if you didn't give your service account k8s-skaffold storage access and artifact registry, this is good to prove that we're using the active account to issue request
 - example message ``creating bucket if not exists: getting bucket "k8s-skaffold_cloudbuild": googleapi: Error 403: {{service-account-name}} does not have storage.buckets.get access to the Google Cloud Storage bucket. Permission 'storage.buckets.get' denied on resource (or it may not exist)., forbidden``



