### PR TITLE
fix: correctly rewrite /deploy/kubectl/manifests in patch upgrades

### DIFF
--- a/pkg/skaffold/schema/v2beta29/upgrade.go
+++ b/pkg/skaffold/schema/v2beta29/upgrade.go
@@ -36,7 +36,7 @@ import (
 var artifactOverridesRegexp = regexp.MustCompile("/deploy/helm/releases/[0-9]+/artifactOverrides/image")
 
 var migrations = map[string]string{
-	"/deploy/kubectl":             "/manifests/rawYaml",
+	"/deploy/kubectl/manifests":   "/manifests/rawYaml",
 	"/deploy/kustomize/paths":     "/manifests/kustomize/paths",
 	"/deploy/kustomize/buildArgs": "/manifests/kustomize/buildArgs",
 	"/deploy/helm":                "/manifests/helm",

--- a/pkg/skaffold/schema/v2beta29/upgrade_test.go
+++ b/pkg/skaffold/schema/v2beta29/upgrade_test.go
@@ -245,7 +245,9 @@ profiles:
 - name: kustomize
   patches:
   - op: remove
-    path: /deploy/kubectl
+    path: /deploy/kubectl/manifests
+  - op: remove
+    path: /deploy/kubectl/manifests/0
   - op: remove
     path: /deploy/helm
   deploy:
@@ -273,6 +275,8 @@ profiles:
   patches:
   - op: remove
     path: /manifests/rawYaml
+  - op: remove
+    path: /manifests/rawYaml/0
   - op: remove
     path: /manifests/helm
   - op: remove


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #8564 <!-- tracking issues that this PR will close -->

**Description**
This looks like a fairly simple fix to me. https://github.com/GoogleContainerTools/skaffold/pull/7800 added functionality to rewrite yaml paths in patches during v2->v3 upgrades. Only `/deploy/kubectl/manifests` should be rewritten to `/manifests/rawYaml` though, not all of `/deploy/kubectl`.
