### PR TITLE
chore: upgrade docker and make integration-in-docker to use docker dependencies from pr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,10 +212,10 @@ build_deps:
 
 skaffold-builder-ci:
 	docker build \
-		--cache-from gcr.io/$(GCP_PROJECT)/build_deps
+		--cache-from gcr.io/$(GCP_PROJECT)/build_deps \
 		-f deploy/skaffold/Dockerfile.deps \
 		-t gcr.io/$(GCP_PROJECT)/build_deps \
-		. &&
+		.
 	time docker build \
 		-f deploy/skaffold/Dockerfile \
 		--target builder \

--- a/Makefile
+++ b/Makefile
@@ -210,6 +210,17 @@ build_deps:
 		deploy/skaffold
 	docker push gcr.io/$(GCP_PROJECT)/build_deps:$(DEPS_DIGEST)
 
+skaffold-builder-ci:
+	docker build \
+		--cache-from gcr.io/$(GCP_PROJECT)/build_deps
+		-f deploy/skaffold/Dockerfile.deps \
+		-t gcr.io/$(GCP_PROJECT)/build_deps &&
+	time docker build \
+		-f deploy/skaffold/Dockerfile \
+		--target builder \
+		-t gcr.io/$(GCP_PROJECT)/skaffold-builder \
+		.
+
 .PHONY: skaffold-builder
 skaffold-builder:
 	time docker build \
@@ -272,7 +283,7 @@ integration-in-k3d: skaffold-builder
 		'
 
 .PHONY: integration-in-docker
-integration-in-docker: skaffold-builder
+integration-in-docker: skaffold-builder-ci
 	docker run --rm \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $(HOME)/.config/gcloud:/root/.config/gcloud \

--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,8 @@ skaffold-builder-ci:
 	docker build \
 		--cache-from gcr.io/$(GCP_PROJECT)/build_deps
 		-f deploy/skaffold/Dockerfile.deps \
-		-t gcr.io/$(GCP_PROJECT)/build_deps &&
+		-t gcr.io/$(GCP_PROJECT)/build_deps \
+		. &&
 	time docker build \
 		-f deploy/skaffold/Dockerfile \
 		--target builder \

--- a/deploy/skaffold/Dockerfile.deps
+++ b/deploy/skaffold/Dockerfile.deps
@@ -122,7 +122,9 @@ RUN apt-get update && \
     git python unzip && \
     rm -rf /var/lib/apt/lists/*
 
-COPY --from=docker:19.03.13 /usr/local/bin/docker /usr/local/bin/
+COPY --from=docker:23.0.1 /usr/local/bin/docker /usr/local/bin/
+# From Docker Engine version 23.0.0, Buildx is distributed in a separate package: docker-buildx-plugin. In earlier versions, Buildx was included in the docker-ce-cli package
+COPY --from=docker/buildx-bin:0.10.4 /buildx /usr/libexec/docker/cli-plugins/docker-buildx
 COPY --from=download-kubectl kubectl /usr/local/bin/
 COPY --from=download-helm helm /usr/local/bin/
 COPY --from=download-kustomize kustomize /usr/local/bin/


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #8578 <!-- tracking issues that this PR will close -->
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
 - This pr upgrades docker bin in skaffold image as the old one is not working when running some kpt images. 
 - Adds buildx into skaffold image, as after 23.0.0 the buildx is not bundled with docker directly, we need to add it separately 
 - Also, change the kokoro presubmit pipeline to pick up changes in the pr while still taking advantages of the docker deps
cache
**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->

**Follow-up Work (remove if N/A)**
<!-- Mention any related follow up work to this PR. -->


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
