### PR TITLE
fix: deploy to multiple namespaces

### DIFF
--- a/integration/testdata/helm-multi-namespaces/Dockerfile
+++ b/integration/testdata/helm-multi-namespaces/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.18 as builder
+WORKDIR /code
+COPY main.go .
+COPY go.mod .
+# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
+ARG SKAFFOLD_GO_GCFLAGS
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app main.go
+
+FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
+CMD ["./app"]
+COPY --from=builder /app .

--- a/integration/testdata/helm-multi-namespaces/charts/Chart.yaml
+++ b/integration/testdata/helm-multi-namespaces/charts/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: Skaffold example with Helm
+name: skaffold-helm
+version: 0.1.0

--- a/integration/testdata/helm-multi-namespaces/charts/templates/deployment.yaml
+++ b/integration/testdata/helm-multi-namespaces/charts/templates/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Chart.Name }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Chart.Name }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: {{ .Values.image }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: configmap
+  namespace: namespace2
+data:
+  foo: bar

--- a/integration/testdata/helm-multi-namespaces/charts/values.yaml
+++ b/integration/testdata/helm-multi-namespaces/charts/values.yaml
@@ -1,0 +1,5 @@
+# Default values for skaffold-helm.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 2
+image: skaffold-helm:latest

--- a/integration/testdata/helm-multi-namespaces/go.mod
+++ b/integration/testdata/helm-multi-namespaces/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/examples/helm-deployment
+
+go 1.18

--- a/integration/testdata/helm-multi-namespaces/main.go
+++ b/integration/testdata/helm-multi-namespaces/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+	for counter := 0; ; counter++ {
+		fmt.Println("Hello world!", counter)
+
+		time.Sleep(time.Second * 1)
+	}
+}

--- a/integration/testdata/helm-multi-namespaces/skaffold.yaml
+++ b/integration/testdata/helm-multi-namespaces/skaffold.yaml
@@ -1,0 +1,12 @@
+apiVersion: skaffold/v4beta4
+kind: Config
+build:
+  artifacts:
+  - image: skaffold-helm
+manifests:
+  helm:
+    releases:
+    - name: skaffold-helm
+      chartPath: charts
+      namespace: namespace1
+

--- a/pkg/skaffold/kubectl/cli.go
+++ b/pkg/skaffold/kubectl/cli.go
@@ -58,13 +58,19 @@ func NewCLI(cfg Config, defaultNamespace string) *CLI {
 
 // Command creates the underlying exec.CommandContext. This allows low-level control of the executed command.
 func (c *CLI) Command(ctx context.Context, command string, arg ...string) *exec.Cmd {
-	args := c.args(command, "", arg...)
+	args := c.args(command, util.Ptr(""), arg...)
 	return exec.CommandContext(ctx, "kubectl", args...)
 }
 
 // Command creates the underlying exec.CommandContext with namespace. This allows low-level control of the executed command.
 func (c *CLI) CommandWithNamespaceArg(ctx context.Context, command string, namespace string, arg ...string) *exec.Cmd {
-	args := c.args(command, namespace, arg...)
+	args := c.args(command, util.Ptr(namespace), arg...)
+	return exec.CommandContext(ctx, "kubectl", args...)
+}
+
+// Command creates the underlying exec.CommandContext without a namespace. This allows low-level control of the executed command.
+func (c *CLI) CommandWithoutNamespaceArg(ctx context.Context, command string, arg ...string) *exec.Cmd {
+	args := c.args(command, nil, arg...)
 	return exec.CommandContext(ctx, "kubectl", args...)
 }
 
@@ -86,6 +92,12 @@ func (c *CLI) RunInNamespace(ctx context.Context, in io.Reader, out io.Writer, c
 	return util.RunCmd(ctx, cmd)
 }
 
+// RunInNamespace shells out kubectl CLI with given namespace
+func (c *CLI) RunOutWithoutNamespace(ctx context.Context, command string, arg ...string) ([]byte, error) {
+	cmd := c.CommandWithoutNamespaceArg(ctx, command, arg...)
+	return util.RunCmdOut(ctx, cmd)
+}
+
 // RunOut shells out kubectl CLI.
 func (c *CLI) RunOut(ctx context.Context, command string, arg ...string) ([]byte, error) {
 	cmd := c.Command(ctx, command, arg...)
@@ -101,7 +113,7 @@ func (c *CLI) RunOutInput(ctx context.Context, in io.Reader, command string, arg
 
 // CommandWithStrictCancellation ensures for windows OS that all child process get terminated on cancellation
 func (c *CLI) CommandWithStrictCancellation(ctx context.Context, command string, arg ...string) *Cmd {
-	args := c.args(command, "", arg...)
+	args := c.args(command, util.Ptr(""), arg...)
 	return CommandContext(ctx, "kubectl", args...)
 }
 
@@ -112,14 +124,16 @@ func (c *CLI) Kustomize(ctx context.Context, args []string) ([]byte, error) {
 
 // args builds an argument list for calling kubectl and consistently
 // adds the `--context` and `--namespace` flags.
-func (c *CLI) args(command string, namespace string, arg ...string) []string {
+func (c *CLI) args(command string, namespace *string, arg ...string) []string {
 	args := []string{}
 	if c.KubeContext != "" {
 		args = append(args, "--context", c.KubeContext)
 	}
-	namespace = c.resolveNamespace(namespace)
-	if namespace != "" {
-		args = append(args, "--namespace", namespace)
+	if namespace != nil {
+		ns := c.resolveNamespace(*namespace)
+		if ns != "" {
+			args = append(args, "--namespace", ns)
+		}
 	}
 	if c.KubeConfig != "" {
 		args = append(args, "--kubeconfig", c.KubeConfig)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: b/266719200 <!-- tracking issues that this PR will close -->

**Description**
If the rendered manifest has multiple namespaces, retry `kubectl create` `dry-run` command without a namespace flag.

**Testing instruction**
See the added integration test.


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
