### PR TITLE
feat: read firelog API key from embedded file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,6 @@ SKAFFOLD_TEST_PACKAGES = ./pkg/skaffold/... ./cmd/... ./hack/... ./pkg/webhook/.
 GO_FILES = $(shell find . -type f -name '*.go' -not -path "./pkg/diag/*")
 
 VERSION_PACKAGE = $(REPOPATH)/v2/pkg/skaffold/version
-FIRELOG_PACKAGE = $(REPOPATH)/v2/pkg/skaffold/instrumentation/firelog
 COMMIT = $(shell git rev-parse HEAD)
 
 ifeq "$(strip $(VERSION))" ""
@@ -58,9 +57,6 @@ endif
 GO_LDFLAGS = -X $(VERSION_PACKAGE).version=$(VERSION)
 GO_LDFLAGS += -X $(VERSION_PACKAGE).buildDate=$(BUILD_DATE)
 GO_LDFLAGS += -X $(VERSION_PACKAGE).gitCommit=$(COMMIT)
-ifdef FIRELOG_API_KEY
-    GO_LDFLAGS += -X $(VERSION_PACKAGE).APIKey=$(FIRELOG_API_KEY)
-endif
 GO_LDFLAGS += -s -w
 
 GO_BUILD_TAGS = timetzdata

--- a/hack/generate-embedded-files.sh
+++ b/hack/generate-embedded-files.sh
@@ -50,4 +50,10 @@ if [[ -d ${SECRET} ]]; then
    cp -R ${SECRET} "fs/assets/secrets_generated"
 fi
 
+if [ -n "${FIRELOG_API_KEY_FILE+x}" ] && [ -f ${FIRELOG_API_KEY_FILE} ]; then
+   echo "generating embedded files for firelog API key"
+   mkdir -p "fs/assets/firelog_generated"
+   cp ${FIRELOG_API_KEY_FILE} "fs/assets/firelog_generated/key.txt"
+fi
+
 echo "Used for marking generating embedded files task complete, don't modify this." > fs/assets/check.txt

--- a/pkg/skaffold/instrumentation/export.go
+++ b/pkg/skaffold/instrumentation/export.go
@@ -55,6 +55,7 @@ import (
 
 func ExportMetrics(exitCode int) error {
 	if !ShouldExportMetrics || meter.Command == "" {
+		log.Entry(context.TODO()).Debug("exporting metrics disabled")
 		return nil
 	}
 	home, err := homedir.Dir()

--- a/pkg/skaffold/instrumentation/export_test.go
+++ b/pkg/skaffold/instrumentation/export_test.go
@@ -31,7 +31,6 @@ import (
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 
 	"github.com/GoogleContainerTools/skaffold/v2/fs"
-	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/instrumentation/firelog"
 	"github.com/GoogleContainerTools/skaffold/v2/proto/v1"
 	"github.com/GoogleContainerTools/skaffold/v2/testutil"
 )
@@ -110,6 +109,7 @@ func TestExportMetrics(t *testing.T) {
 	fakeFS := testutil.FakeFileSystem{
 		Files: map[string][]byte{
 			"assets/secrets_generated/keys.json": []byte(testKey),
+			"assets/firelog_generated/key.txt":   []byte("no-empty"),
 		},
 	}
 
@@ -169,7 +169,6 @@ func TestExportMetrics(t *testing.T) {
 
 			fs.AssetsFS = fakeFS
 			t.Override(&isOnline, test.isOnline)
-			t.Override(&firelog.APIKey, "no-empty")
 
 			if test.isOnline {
 				tmpFile, err := os.OpenFile(tmp.Path(openTelFilename), os.O_RDWR|os.O_CREATE, os.ModePerm)

--- a/pkg/skaffold/instrumentation/firelog/exporter_test.go
+++ b/pkg/skaffold/instrumentation/firelog/exporter_test.go
@@ -27,29 +27,35 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/metric"
 
+	"github.com/GoogleContainerTools/skaffold/v2/fs"
 	"github.com/GoogleContainerTools/skaffold/v2/testutil"
 )
 
 func TestNewFireLogExporter(t *testing.T) {
 	var tests = []struct {
-		name     string
-		expected metric.Exporter
-		apiKey   string
-		wantErr  bool
+		name       string
+		expected   metric.Exporter
+		fileSystem *testutil.FakeFileSystem
+		wantErr    bool
 	}{
 		{
-			name:     "no api key",
+			name: "no api key",
+			fileSystem: &testutil.FakeFileSystem{
+				Files: map[string][]byte{},
+			},
 			expected: nil,
 		},
 		{
 			name:     "has api key",
 			expected: &Exporter{},
-			apiKey:   "test key",
+			fileSystem: &testutil.FakeFileSystem{
+				Files: map[string][]byte{"assets/firelog_generated/key.txt": []byte("test key")},
+			},
 		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.name, func(t *testutil.T) {
-			APIKey = test.apiKey
+			fs.AssetsFS = test.fileSystem
 			out, err := NewFireLogExporter()
 			t.CheckError(test.wantErr, err)
 			t.CheckDeepEqual(test.expected, out)


### PR DESCRIPTION
This PR makes the change to read the firelog API key from an embedded file `FIRELOG_API_KEY_FILE`. This is required to workaround the requirement of not printing the key value to stdout when running the build (which was happening with the environment variable `FIRELOG_API_KEY`)