### PR TITLE
fix: create new docker network only when the --docker-network flag is not set

### DIFF
--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -675,7 +675,7 @@ The build result from a previous 'skaffold build --file-output' run can be used 
 	{
 		Name:          "docker-network",
 		Shorthand:     "",
-		Usage:         "Run verify tests in the specified docker network",
+		Usage:         "Name of an existing docker network to use when running the verify tests. If not specified, Skaffold will create a new network to use of the form 'skaffold-network-<uuid>'",
 		Value:         &opts.VerifyDockerNetwork,
 		DefValue:      "",
 		FlagAddMethod: "StringVar",

--- a/docs-v2/content/en/docs/references/cli/_index.md
+++ b/docs-v2/content/en/docs/references/cli/_index.md
@@ -1355,7 +1355,7 @@ Options:
 }
 The build result from a previous 'skaffold build --file-output' run can be used here
   -d, --default-repo='': Default repository value (overrides global config)
-      --docker-network='': Run verify tests in the specified docker network
+      --docker-network='': Name of an existing docker network to use when running the verify tests. If not specified, Skaffold will create a new network to use of the form 'skaffold-network-<uuid>'
       --env-file='': File containing env var key-value pairs that will be set in all verify container envs
   -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
   -m, --module=[]: Filter Skaffold configs to only the provided named modules

--- a/integration/verify_test.go
+++ b/integration/verify_test.go
@@ -56,6 +56,14 @@ func TestLocalVerifyPassingTestsWithEnvVar(t *testing.T) {
 	// TODO(aaron-prindle) verify that SUCCEEDED event is found where expected
 }
 
+func TestVerifyWithNotCreatedNetwork(t *testing.T) {
+	MarkIntegrationTest(t, CanRunWithoutGcp)
+	// `--default-repo=` is used to cancel the default repo that is set by default.
+	logs, err := skaffold.Verify("--default-repo=", "--env-file", "verify.env", "--docker-network", "not-created-network").InDir("testdata/verify-succeed").RunWithCombinedOutput(t)
+	testutil.CheckError(t, true, err)
+	testutil.CheckContains(t, "network not-created-network not found", string(logs))
+}
+
 func TestLocalVerifyOneTestFailsWithEnvVar(t *testing.T) {
 	MarkIntegrationTest(t, CanRunWithoutGcp)
 	tmp := t.TempDir()

--- a/pkg/skaffold/verify/docker/verify.go
+++ b/pkg/skaffold/verify/docker/verify.go
@@ -118,11 +118,14 @@ func (v *Verifier) TrackContainerFromBuild(artifact graph.Artifact, container tr
 // from each specified image, executing them, and waiting for execution to complete.
 func (v *Verifier) Verify(ctx context.Context, out io.Writer, allbuilds []graph.Artifact) error {
 	var err error
-	v.once.Do(func() {
-		err = v.client.NetworkCreate(ctx, v.network)
-	})
-	if err != nil {
-		return fmt.Errorf("creating skaffold network %s: %w", v.network, err)
+
+	if !v.networkFlagPassed {
+		v.once.Do(func() {
+			err = v.client.NetworkCreate(ctx, v.network)
+		})
+		if err != nil {
+			return fmt.Errorf("creating skaffold network %s: %w", v.network, err)
+		}
 	}
 
 	builds := []graph.Artifact{}


### PR DESCRIPTION
**Description**
Change behaviour so we don't create a new docker network when `skaffold verify` is run with the `--docker-network` flag, instead we assume the docker network with the given name already exists.