### PR TITLE
feat: logic to create a new ActionsRunner

### DIFF
--- a/pkg/skaffold/actions/docker/exec_env.go
+++ b/pkg/skaffold/actions/docker/exec_env.go
@@ -64,7 +64,9 @@ type ExecEnv struct {
 	envVars []string
 }
 
-func NewExecEnv(ctx context.Context, cfg dockerutil.Config, labeller *label.DefaultLabeller, resources []*latest.PortForwardResource, network string, envMap map[string]string, acs []latest.Action) (*ExecEnv, error) {
+var NewExecEnv = newExecEnv
+
+func newExecEnv(ctx context.Context, cfg dockerutil.Config, labeller *label.DefaultLabeller, resources []*latest.PortForwardResource, network string, envMap map[string]string, acs []latest.Action) (*ExecEnv, error) {
 	tracker := tracker.NewContainerTracker()
 	l, err := logger.NewLogger(ctx, tracker, cfg)
 	if err != nil {

--- a/pkg/skaffold/actions/runner.go
+++ b/pkg/skaffold/actions/runner.go
@@ -27,10 +27,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/output/log"
-	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/runner"
 )
-
-var _ runner.ActionsRunner = Runner{}
 
 type Runner struct {
 	// Map to access the associated Exec environment of a given action.

--- a/pkg/skaffold/runner/actions.go
+++ b/pkg/skaffold/runner/actions.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2023 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"context"
+	"io"
+
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/graph"
+)
+
+func (r *SkaffoldRunner) Exec(ctx context.Context, out io.Writer, artifacts []graph.Artifact, action string) error {
+	return r.actionsRunner.Exec(ctx, out, artifacts, action)
+}

--- a/pkg/skaffold/runner/actions_runner.go
+++ b/pkg/skaffold/runner/actions_runner.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Skaffold Authors
+Copyright 2023 The Skaffold Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,11 +20,95 @@ import (
 	"context"
 	"io"
 
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/actions"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/actions/docker"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/deploy/label"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/graph"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/runner/runcontext"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/util"
+	vutil "github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/verify/util"
 )
 
 // ActionsRunner defines the API used to run custom actions.
 type ActionsRunner interface {
+	// Exec triggers the execution of the given action.
 	Exec(ctx context.Context, out io.Writer, allbuilds []graph.Artifact, action string) error
+
+	// ExecAll triggers the execution of all the defined actions.
 	ExecAll(ctx context.Context, out io.Writer, allbuilds []graph.Artifact) error
+}
+
+func GetActionsRunner(ctx context.Context, runCtx *runcontext.RunContext, l *label.DefaultLabeller, dockerNetwork string, envFile string) (ActionsRunner, error) {
+	aCfgs := []latest.Action{}
+
+	for _, p := range runCtx.GetPipelines() {
+		aCfgs = append(aCfgs, p.CustomActions...)
+	}
+
+	envMap, err := loadEnvMap(envFile)
+	if err != nil {
+		return nil, err
+	}
+
+	return createActionsRunner(ctx, runCtx, l, dockerNetwork, envMap, aCfgs)
+}
+
+func createActionsRunner(ctx context.Context, runCtx *runcontext.RunContext, l *label.DefaultLabeller, dNetwork string, envMap map[string]string, aCfgs []latest.Action) (ActionsRunner, error) {
+	execEnvByAction := map[string]actions.ExecEnv{}
+	ordExecEnvs := []actions.ExecEnv{}
+	acsByExecEnv := map[actions.ExecEnv][]string{}
+
+	pF := runCtx.PortForwardResources()
+	dockerCfgs, _ := cfgsByExecMode(aCfgs)
+
+	if len(dockerCfgs) > 0 {
+		dExecEnv, err := docker.NewExecEnv(ctx, runCtx, l, pF, dNetwork, envMap, dockerCfgs)
+		if err != nil {
+			return nil, err
+		}
+
+		ordExecEnvs = append(ordExecEnvs, dExecEnv)
+		insertExecEnv(execEnvByAction, dockerCfgs, dExecEnv)
+		for _, cfg := range dockerCfgs {
+			acsByExecEnv[dExecEnv] = append(acsByExecEnv[dExecEnv], cfg.Name)
+		}
+	}
+
+	return actions.NewRunner(execEnvByAction, ordExecEnvs, acsByExecEnv), nil
+}
+
+func cfgsByExecMode(aCfgs []latest.Action) (dockerCfgs []latest.Action, k8sCfgs []latest.Action) {
+	for _, cfg := range aCfgs {
+		setDefaultConfigValues(&cfg)
+		if cfg.ExecutionModeConfig.KubernetesClusterExecutionMode != nil {
+			k8sCfgs = append(k8sCfgs, cfg)
+			continue
+		}
+		dockerCfgs = append(dockerCfgs, cfg)
+	}
+	return
+}
+
+func setDefaultConfigValues(cfg *latest.Action) {
+	if cfg.Config.IsFailFast == nil {
+		cfg.Config.IsFailFast = util.Ptr(true)
+	}
+
+	if cfg.Config.Timeout == nil {
+		cfg.Config.Timeout = util.Ptr(0) // No timeout
+	}
+}
+
+func insertExecEnv(execEnvByAction map[string]actions.ExecEnv, acs []latest.Action, execEnv actions.ExecEnv) {
+	for _, a := range acs {
+		execEnvByAction[a.Name] = execEnv
+	}
+}
+
+func loadEnvMap(envFile string) (map[string]string, error) {
+	if envFile == "" {
+		return nil, nil
+	}
+	return vutil.ParseEnvVariablesFromFile(envFile)
 }

--- a/pkg/skaffold/runner/actions_runner_test.go
+++ b/pkg/skaffold/runner/actions_runner_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2023 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/actions"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/actions/docker"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/deploy/label"
+	dockerutil "github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/docker"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/graph"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/runner/runcontext"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/v2/testutil"
+)
+
+type MockActionsRunner struct {
+	ExecEnvByAction map[string]actions.ExecEnv
+	OrderedExecEnvs []actions.ExecEnv
+	AcsByExecEnv    map[actions.ExecEnv][]string
+}
+
+func (mar MockActionsRunner) Exec(ctx context.Context, out io.Writer, allbuilds []graph.Artifact, action string) error {
+	return nil
+}
+
+func (mar MockActionsRunner) ExecAll(ctx context.Context, out io.Writer, allbuilds []graph.Artifact) error {
+	return nil
+}
+
+func TestActionsRunner_Creation(t *testing.T) {
+	tests := []struct {
+		description       string
+		pipelinesCfg      map[string]latest.Pipeline
+		orderedPipelines  []string
+		envFile           string
+		expectedDockerAcs []string
+		inputRunCtx       runcontext.RunContext
+		expectedAr        actions.Runner
+	}{
+		{
+			description: "default to docker when no execution mode is specified",
+			inputRunCtx: runcontext.RunContext{
+				Pipelines: runcontext.NewPipelines(map[string]latest.Pipeline{
+					"config1": {CustomActions: []latest.Action{{Name: "action1"}, {Name: "action2"}}},
+					"config2": {
+						CustomActions: []latest.Action{
+							{
+								Name: "action3",
+							},
+							{
+								Name: "action4",
+								ExecutionModeConfig: latest.ActionExecutionModeConfig{
+									VerifyExecutionModeType: latest.VerifyExecutionModeType{
+										KubernetesClusterExecutionMode: &latest.KubernetesClusterVerifier{},
+									},
+								},
+							},
+						},
+					},
+				}, []string{"config1", "config2"}),
+			},
+			expectedDockerAcs: []string{"action1", "action2", "action3"},
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			var createdDockerAcs []string
+			t.Override(&docker.NewExecEnv, func(ctx context.Context, cfg dockerutil.Config, labeller *label.DefaultLabeller, resources []*latest.PortForwardResource, network string, envMap map[string]string, acs []latest.Action) (*docker.ExecEnv, error) {
+				for _, a := range acs {
+					createdDockerAcs = append(createdDockerAcs, a.Name)
+				}
+				return &docker.ExecEnv{}, nil
+			})
+
+			_, err := GetActionsRunner(context.TODO(), &test.inputRunCtx, &label.DefaultLabeller{}, "", "")
+
+			t.CheckNoError(err)
+			t.CheckDeepEqual(test.expectedDockerAcs, createdDockerAcs)
+		})
+	}
+}

--- a/pkg/skaffold/runner/new.go
+++ b/pkg/skaffold/runner/new.go
@@ -111,6 +111,13 @@ func NewForConfig(ctx context.Context, runCtx *runcontext.RunContext) (*Skaffold
 		return nil, fmt.Errorf("creating verifier: %w", err)
 	}
 
+	var acsRunner ActionsRunner
+	acsRunner, err = GetActionsRunner(ctx, runCtx, labeller, runCtx.VerifyDockerNetwork(), runCtx.Opts.VerifyEnvFile)
+	if err != nil {
+		endTrace(instrumentation.TraceEndError(err))
+		return nil, fmt.Errorf("creating actiosn runner: %w", err)
+	}
+
 	depLister := func(ctx context.Context, artifact *latest.Artifact) ([]string, error) {
 		ctx, endTrace := instrumentation.StartTrace(ctx, "NewForConfig_depLister")
 		defer endTrace()
@@ -176,6 +183,7 @@ func NewForConfig(ctx context.Context, runCtx *runcontext.RunContext) (*Skaffold
 		intents:            intents,
 		isLocalImage:       isLocalImage,
 		verifier:           verifier,
+		actionsRunner:      acsRunner,
 	}, nil
 }
 

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -59,6 +59,8 @@ type Runner interface {
 	Test(context.Context, io.Writer, []graph.Artifact) error
 	Verify(context.Context, io.Writer, []graph.Artifact) error
 	VerifyAndLog(context.Context, io.Writer, []graph.Artifact) error
+
+	Exec(context.Context, io.Writer, []graph.Artifact, string) error
 }
 
 // SkaffoldRunner is responsible for running the skaffold build, test and deploy config.
@@ -67,11 +69,12 @@ type SkaffoldRunner struct {
 	Pruner
 	tester test.Tester
 
-	renderer renderer.Renderer
-	deployer deploy.Deployer
-	verifier verify.Verifier
-	monitor  filemon.Monitor
-	listener Listener
+	renderer      renderer.Renderer
+	deployer      deploy.Deployer
+	verifier      verify.Verifier
+	actionsRunner ActionsRunner
+	monitor       filemon.Monitor
+	listener      Listener
 
 	cache              cache.Cache
 	changeSet          ChangeSet


### PR DESCRIPTION
Fixes: #8519 

**Description**
This PR adds the logic to create a new actions runner reading the configuration from `customActions` stanza in the `skaffold.yaml` file.