### PR TITLE
ci: Use Go 1.20 in GitHub Actions workflows

### DIFF
--- a/.github/workflows/integration-linux.yml
+++ b/.github/workflows/integration-linux.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.19.*
+        go-version: 1.20.*
       id: go
 
     # Retrieve build locations with `go env`

--- a/.github/workflows/linters-checks.yml
+++ b/.github/workflows/linters-checks.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19.*
+          go-version: 1.20.*
         id: go
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/performance-comparison.yml
+++ b/.github/workflows/performance-comparison.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.19.*
+        go-version: 1.20.*
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/unit-tests-darwin.yml
+++ b/.github/workflows/unit-tests-darwin.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.19.*
+        go-version: 1.20.*
       id: go
 
     # Retrieve build locations with `go env`

--- a/.github/workflows/unit-tests-linux.yml
+++ b/.github/workflows/unit-tests-linux.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.19.*
+        go-version: 1.20.*
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/unit-tests-windows.yml
+++ b/.github/workflows/unit-tests-windows.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.19.*
+        go-version: 1.20.*
       id: go
 
     # Retrieve build locations with `go env`

--- a/.github/workflows/verify-examples.yml
+++ b/.github/workflows/verify-examples.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.19.*
+        go-version: 1.20.*
       id: go
 
     # Skip changes not affecting examples or integration/examples

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -18,7 +18,7 @@ set -e -o pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 BIN=${DIR}/bin
-VERSION=1.49.0
+VERSION=1.52.2
 
 function install_linter() {
   echo "Installing GolangCI-Lint"

--- a/pkg/diag/diag_test.go
+++ b/pkg/diag/diag_test.go
@@ -34,9 +34,7 @@ type mockValidator struct {
 	listOptions metav1.ListOptions
 }
 
-type mockErrValidator struct {
-	*mockValidator
-}
+type mockErrValidator struct{}
 
 func (m *mockValidator) Validate(_ context.Context, ns string, opts metav1.ListOptions) ([]validator.Resource, error) {
 	m.ns = append(m.ns, ns)


### PR DESCRIPTION
This also required upgrading GolangCI-Lint, which in turn found an unused field that appears to have previously gone undetected.

Related: #8558
