### PR TITLE
feat: add wait group in docker and k8s job logger to avoid race condition

### DIFF
--- a/integration/testdata/verify-fail-k8s/skaffold.yaml
+++ b/integration/testdata/verify-fail-k8s/skaffold.yaml
@@ -15,3 +15,24 @@ verify:
       args: ["-c", "echo $FOO;exit 1"]
     executionMode:
       kubernetesCluster: {}
+
+profiles:
+  - name: no-duplicated-logs
+    verify:
+      - name: alpine-1
+        executionMode:
+          kubernetesCluster: {}
+        container:
+          name: alpine-1
+          image: alpine:3.15.4
+          command: ["/bin/sh"]
+          args: ["-c", "echo alpine-1; sleep 1; echo bye alpine-1"]
+      
+      - name: alpine-2
+        executionMode:
+          kubernetesCluster: {}
+        container:
+          name: alpine-2
+          image: alpine:3.15.4
+          command: ["/bin/sh"]
+          args: ["-c", "echo alpine-2; echo bye alpine-2; exit 1"]

--- a/integration/testdata/verify-fail/skaffold.yaml
+++ b/integration/testdata/verify-fail/skaffold.yaml
@@ -11,3 +11,20 @@ verify:
     image: alpine:3.15.4
     command: ["/bin/sh"]
     args: ["-c", "echo $FOO;exit 1"]
+
+profiles:
+  - name: no-duplicated-logs
+    verify:
+      - name: alpine-1
+        container:
+          name: alpine-1
+          image: alpine:3.15.4
+          command: ["/bin/sh"]
+          args: ["-c", "echo alpine-1; sleep 2; echo bye alpine-1"]
+      
+      - name: alpine-2
+        container:
+          name: alpine-2
+          image: alpine:3.15.4
+          command: ["/bin/sh"]
+          args: ["-c", "echo alpine-2; echo bye alpine-2; exit 1"]

--- a/integration/testdata/verify-succeed-k8s/skaffold.yaml
+++ b/integration/testdata/verify-succeed-k8s/skaffold.yaml
@@ -35,3 +35,15 @@ verify:
       args: ["-c", "echo $FOO; sleep 10; echo bye"]
     executionMode:
       kubernetesCluster: {}
+
+profiles:
+  - name: no-duplicated-logs
+    verify:
+      - name: alpine-1
+        executionMode:
+          kubernetesCluster: {}
+        container:
+          name: alpine-1
+          image: alpine:3.15.4
+          command: ["/bin/sh"]
+          args: ["-c", "echo alpine-1; sleep 1; echo bye alpine-1"]

--- a/integration/testdata/verify-succeed/skaffold.yaml
+++ b/integration/testdata/verify-succeed/skaffold.yaml
@@ -21,3 +21,13 @@ verify:
     image: alpine:3.15.4
     command: ["/bin/sh"]
     args: ["-c", "echo $FOO; sleep 10; echo bye"]
+
+profiles:
+  - name: no-duplicated-logs
+    verify:
+      - name: alpine-1
+        container:
+          name: alpine-1
+          image: alpine:3.15.4
+          command: ["/bin/sh"]
+          args: ["-c", "echo alpine-1; sleep 2; echo bye alpine-1"]

--- a/pkg/skaffold/verify/k8sjob/verify.go
+++ b/pkg/skaffold/verify/k8sjob/verify.go
@@ -51,6 +51,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/log"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/status"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/util"
 )
 
 // Verifier verifies deployments using kubernetes libs/CLI.
@@ -329,6 +330,7 @@ func (v *Verifier) createJob(jobName string, container latest.VerifyContainer) *
 			Namespace: v.defaultNamespace,
 		},
 		Spec: batchv1.JobSpec{
+			BackoffLimit: util.Ptr[int32](0),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{


### PR DESCRIPTION
Fixes: #8672

**Description**
This PR adds a wait group in the k8s and docker logger to avoid a race condition when:
1. We have the loggers running, and
2. The execution of the containers/jobs finish, and 
3. We trigger the loggers stop to start draining their content
 
Before, we were draining the logs in the stop step without waiting for the logs triggered during execution to finish.