### PR TITLE
fix: change util pkg import to use ParseEnvVariablesFromFile

### DIFF
--- a/pkg/skaffold/runner/actions_runner.go
+++ b/pkg/skaffold/runner/actions_runner.go
@@ -27,7 +27,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/util"
-	vutil "github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/verify/util"
 )
 
 // ActionsRunner defines the API used to run custom actions.
@@ -110,5 +109,5 @@ func loadEnvMap(envFile string) (map[string]string, error) {
 	if envFile == "" {
 		return nil, nil
 	}
-	return vutil.ParseEnvVariablesFromFile(envFile)
+	return util.ParseEnvVariablesFromFile(envFile)
 }


### PR DESCRIPTION
**Related PRs**: 
- https://github.com/GoogleContainerTools/skaffold/pull/8647
- https://github.com/GoogleContainerTools/skaffold/pull/8681

**Description**
In https://github.com/GoogleContainerTools/skaffold/pull/8647 we changed the pkg where the `ParseEnvVariablesFromFile` function is defined. At the same time we had https://github.com/GoogleContainerTools/skaffold/pull/8681 where we are consuming the `ParseEnvVariablesFromFile` from the previous pkg. After merging all the changes, now we have to update the util pkg in the `ActionsRunner`.
