### PR TITLE
feat: extend `inspect jobManifestPaths [list|modify]` to include custom actions info

### DIFF
--- a/pkg/skaffold/inspect/jobManifestPaths/list.go
+++ b/pkg/skaffold/inspect/jobManifestPaths/list.go
@@ -52,7 +52,12 @@ func PrintJobManifestPathsList(ctx context.Context, out io.Writer, opts inspect.
 			if tc.ExecutionMode.KubernetesClusterExecutionMode != nil && tc.ExecutionMode.KubernetesClusterExecutionMode.JobManifestPath != "" {
 				l.VerifyJobManifestPaths[tc.Name] = tc.ExecutionMode.KubernetesClusterExecutionMode.JobManifestPath
 			}
-			// TODO(#8572) add similar logic for customAction schema fields when they are complete
+		}
+
+		for _, a := range c.CustomActions {
+			if a.ExecutionModeConfig.KubernetesClusterExecutionMode != nil && a.ExecutionModeConfig.KubernetesClusterExecutionMode.JobManifestPath != "" {
+				l.CustomActionJobManifestPaths[a.Name] = a.ExecutionModeConfig.KubernetesClusterExecutionMode.JobManifestPath
+			}
 		}
 	}
 	return formatter.Write(l)

--- a/pkg/skaffold/inspect/jobManifestPaths/modify.go
+++ b/pkg/skaffold/inspect/jobManifestPaths/modify.go
@@ -79,6 +79,16 @@ func Modify(ctx context.Context, out io.Writer, opts config.SkaffoldOptions, inp
 				configs[i].(*latest.SkaffoldConfig).Verify[j].ExecutionMode.KubernetesClusterExecutionMode.JobManifestPath = jobManifestPath
 			}
 		}
+
+		for j := range configs[i].(*latest.SkaffoldConfig).CustomActions {
+			if jobManifestPath, found := result.CustomActionJobManifestPaths[configs[i].(*latest.SkaffoldConfig).CustomActions[j].Name]; found {
+				if configs[i].(*latest.SkaffoldConfig).CustomActions[j].ExecutionModeConfig.KubernetesClusterExecutionMode == nil {
+					configs[i].(*latest.SkaffoldConfig).CustomActions[j].ExecutionModeConfig.KubernetesClusterExecutionMode = &latest.KubernetesClusterVerifier{}
+				}
+
+				configs[i].(*latest.SkaffoldConfig).CustomActions[j].ExecutionModeConfig.KubernetesClusterExecutionMode.JobManifestPath = jobManifestPath
+			}
+		}
 	}
 
 	buf, err := yaml.MarshalWithSeparator(configs)

--- a/pkg/skaffold/inspect/jobManifestPaths/modify_test.go
+++ b/pkg/skaffold/inspect/jobManifestPaths/modify_test.go
@@ -33,11 +33,12 @@ func TestPrintJobManifestPathsModify(t *testing.T) {
 		input       string
 		shouldErr   bool
 		expected    string
+		originalCfg latest.SkaffoldConfig
 	}{
 		{
-			description: "successfully modifies jobManifestPath as intended",
+			description: "successfully modifies jobManifestPath in verify stanza as intended",
 			input:       "{\"verifyJobManifestPaths\":{\"foo\":\"modified-foo.yaml\"},\"customActionJobManifestPaths\":{}}",
-			expected: `apiVersion: skaffold/v4beta4
+			expected: `apiVersion: skaffold/v4beta5
 kind: Config
 verify:
   - name: foo
@@ -49,11 +50,187 @@ verify:
       kubernetesCluster:
         jobManifestPath: modified-foo.yaml
 `,
+			originalCfg: latest.SkaffoldConfig{
+				APIVersion: "skaffold/v4beta5",
+				Kind:       "Config",
+				Pipeline: latest.Pipeline{
+					Verify: []*latest.VerifyTestCase{
+						{
+							Name: "foo",
+							Container: latest.VerifyContainer{
+								Name:  "foo",
+								Image: "foo",
+							},
+							ExecutionMode: latest.VerifyExecutionModeConfig{
+								VerifyExecutionModeType: latest.VerifyExecutionModeType{
+									KubernetesClusterExecutionMode: &latest.KubernetesClusterVerifier{
+										JobManifestPath: "foo.yaml",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		{
 			description: "failure with invalid transform yaml input",
 			input:       "invalid",
 			shouldErr:   true,
+		},
+		{
+			description: "successfully modifies jobManifestPath in customActions stanza as intended",
+			input:       `{"verifyJobManifestPaths":{},"customActionJobManifestPaths":{"action1":"modified-manifest.yaml"}}`,
+			expected: `apiVersion: skaffold/v4beta5
+kind: Config
+verify:
+  - name: foo
+    container:
+      name: foo
+      image: foo
+      env: []
+    executionMode:
+      kubernetesCluster:
+        jobManifestPath: verify-manifest.yaml
+customActions:
+  - name: action1
+    executionMode:
+      kubernetesCluster:
+        jobManifestPath: modified-manifest.yaml
+    containers:
+      - name: task1
+        image: task1-img
+        env: []
+  - name: action2
+    executionMode:
+      kubernetesCluster:
+        jobManifestPath: custom-action-job-manifest.yaml
+    containers:
+      - name: task2
+        image: task2-img
+        env: []
+`,
+			originalCfg: latest.SkaffoldConfig{
+				APIVersion: "skaffold/v4beta5",
+				Kind:       "Config",
+				Pipeline: latest.Pipeline{
+					Verify: []*latest.VerifyTestCase{
+						{
+							Name: "foo",
+							Container: latest.VerifyContainer{
+								Name:  "foo",
+								Image: "foo",
+							},
+							ExecutionMode: latest.VerifyExecutionModeConfig{
+								VerifyExecutionModeType: latest.VerifyExecutionModeType{
+									KubernetesClusterExecutionMode: &latest.KubernetesClusterVerifier{
+										JobManifestPath: "verify-manifest.yaml",
+									},
+								},
+							},
+						},
+					},
+					CustomActions: []latest.Action{
+						{
+							Name: "action1",
+							Containers: []latest.VerifyContainer{
+								{
+									Name:  "task1",
+									Image: "task1-img",
+								},
+							},
+							ExecutionModeConfig: latest.ActionExecutionModeConfig{
+								VerifyExecutionModeType: latest.VerifyExecutionModeType{
+									KubernetesClusterExecutionMode: &latest.KubernetesClusterVerifier{
+										JobManifestPath: "original-manifest.yaml",
+									},
+								},
+							},
+						},
+						{
+							Name: "action2",
+							Containers: []latest.VerifyContainer{
+								{
+									Name:  "task2",
+									Image: "task2-img",
+								},
+							},
+							ExecutionModeConfig: latest.ActionExecutionModeConfig{
+								VerifyExecutionModeType: latest.VerifyExecutionModeType{
+									KubernetesClusterExecutionMode: &latest.KubernetesClusterVerifier{
+										JobManifestPath: "custom-action-job-manifest.yaml",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "successfully modifies jobManifestPath in customActions and verify stanza as intended",
+			input:       `{"verifyJobManifestPaths":{"foo":"modified-foo.yaml"},"customActionJobManifestPaths":{"action1":"modified-manifest.yaml"}}`,
+			expected: `apiVersion: skaffold/v4beta5
+kind: Config
+verify:
+  - name: foo
+    container:
+      name: foo
+      image: foo
+      env: []
+    executionMode:
+      kubernetesCluster:
+        jobManifestPath: modified-foo.yaml
+customActions:
+  - name: action1
+    executionMode:
+      kubernetesCluster:
+        jobManifestPath: modified-manifest.yaml
+    containers:
+      - name: task1
+        image: task1-img
+        env: []
+`,
+			originalCfg: latest.SkaffoldConfig{
+				APIVersion: "skaffold/v4beta5",
+				Kind:       "Config",
+				Pipeline: latest.Pipeline{
+					Verify: []*latest.VerifyTestCase{
+						{
+							Name: "foo",
+							Container: latest.VerifyContainer{
+								Name:  "foo",
+								Image: "foo",
+							},
+							ExecutionMode: latest.VerifyExecutionModeConfig{
+								VerifyExecutionModeType: latest.VerifyExecutionModeType{
+									KubernetesClusterExecutionMode: &latest.KubernetesClusterVerifier{
+										JobManifestPath: "verify-manifest.yaml",
+									},
+								},
+							},
+						},
+					},
+					CustomActions: []latest.Action{
+						{
+							Name: "action1",
+							Containers: []latest.VerifyContainer{
+								{
+									Name:  "task1",
+									Image: "task1-img",
+								},
+							},
+							ExecutionModeConfig: latest.ActionExecutionModeConfig{
+								VerifyExecutionModeType: latest.VerifyExecutionModeType{
+									KubernetesClusterExecutionMode: &latest.KubernetesClusterVerifier{
+										JobManifestPath: "original-manifest.yaml",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 
@@ -62,30 +239,7 @@ verify:
 			inputFile := t.TempFile("", []byte(test.input))
 
 			t.Override(&getCfgs, func(context.Context, config.SkaffoldOptions) ([]util.VersionedConfig, error) {
-				return []util.VersionedConfig{
-					&latest.SkaffoldConfig{
-						APIVersion: "skaffold/v4beta4",
-						Kind:       "Config",
-						Pipeline: latest.Pipeline{
-							Verify: []*latest.VerifyTestCase{
-								{
-									Name: "foo",
-									Container: latest.VerifyContainer{
-										Name:  "foo",
-										Image: "foo",
-									},
-									ExecutionMode: latest.VerifyExecutionModeConfig{
-										VerifyExecutionModeType: latest.VerifyExecutionModeType{
-											KubernetesClusterExecutionMode: &latest.KubernetesClusterVerifier{
-												JobManifestPath: "foo.yaml",
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				}, nil
+				return []util.VersionedConfig{&test.originalCfg}, nil
 			})
 			var b bytes.Buffer
 			err := Modify(context.Background(), &b, config.SkaffoldOptions{}, inputFile, "")


### PR DESCRIPTION
Fixes: #8572

**Description**
This PR extends the `inspect jobManifestPaths [list|modify]` command to include/modify info about custom actions.