### PR TITLE
fix: new `remove` method in docker client to use in custom actions and don't get the error related with prune

### DIFF
--- a/pkg/skaffold/actions/docker/task.go
+++ b/pkg/skaffold/actions/docker/task.go
@@ -127,7 +127,8 @@ func (t Task) Cleanup(ctx context.Context, out io.Writer) error {
 		return nil
 	}
 
-	if err := t.client.Delete(ctx, out, id); err != nil {
+	t.client.Stop(ctx, id, nil)
+	if err := t.client.Remove(ctx, id); err != nil {
 		return err
 	}
 	t.portManager.RelinquishPorts(id)

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -106,6 +106,7 @@ type LocalDaemon interface {
 	VolumeCreate(ctx context.Context, opts volume.VolumeCreateBody) (types.Volume, error)
 	VolumeRemove(ctx context.Context, id string) error
 	Stop(ctx context.Context, id string, stopTimeout *time.Duration) error
+	Remove(ctx context.Context, id string) error
 }
 
 // BuildOptions provides parameters related to the LocalDaemon build.
@@ -715,6 +716,15 @@ func (l *localDaemon) Stop(ctx context.Context, id string, stopTimeout *time.Dur
 	if err := l.apiClient.ContainerStop(ctx, id, stopTimeout); err != nil {
 		log.Entry(ctx).Debugf("unable to stop running container: %s", err.Error())
 		return err
+	}
+
+	return nil
+}
+
+func (l *localDaemon) Remove(ctx context.Context, id string) error {
+	if err := l.apiClient.ContainerRemove(ctx, id, types.ContainerRemoveOptions{}); err != nil {
+		log.Entry(ctx).Debugf("unable to remove container: %s", err.Error())
+		return fmt.Errorf("unable to remove container: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
**Description**
This PR is to remove the warning message we get when running a custom action with more than one container, caused by a docker prune executed for each container.