### PR TITLE
feat: change inspect executionMode list to list all actions exec mode per default

### DIFF
--- a/cmd/skaffold/app/cmd/inspect_execution_modes.go
+++ b/cmd/skaffold/app/cmd/inspect_execution_modes.go
@@ -37,13 +37,10 @@ func cmdExecutionModesList() *cobra.Command {
 		WithExample("Get list of executionModes", "inspect executionModes list --format json").
 		WithExample("Get list of executionModes targeting a specific configuration", "inspect executionModes list --profile local --format json").
 		WithDescription("Print the list of executionModes that would be run for a given configuration (default skaffold configuration, specific module, specific profile, etc).").
-		WithArgs(func(cmd *cobra.Command, args []string) error {
-			// skaffold inspect executionModes list take in an optional list of customActions as well
-			return nil
-		}, listExecutionModes)
+		NoArgs(listExecutionModes)
 }
 
-func listExecutionModes(ctx context.Context, out io.Writer, args []string) error {
+func listExecutionModes(ctx context.Context, out io.Writer) error {
 	return executionModes.PrintExecutionModesList(ctx, out, inspect.Options{
 		Filename:          inspectFlags.filename,
 		RepoCacheDir:      inspectFlags.repoCacheDir,
@@ -51,5 +48,5 @@ func listExecutionModes(ctx context.Context, out io.Writer, args []string) error
 		Modules:           inspectFlags.modules,
 		Profiles:          inspectFlags.profiles,
 		PropagateProfiles: inspectFlags.propagateProfiles,
-	}, args)
+	})
 }

--- a/pkg/skaffold/inspect/executionModes/list.go
+++ b/pkg/skaffold/inspect/executionModes/list.go
@@ -29,7 +29,7 @@ type executionModeList struct {
 	CustomActionsExecutionModes map[string]string `json:"customActionsExecutionModes"`
 }
 
-func PrintExecutionModesList(ctx context.Context, out io.Writer, opts inspect.Options, customActions []string) error {
+func PrintExecutionModesList(ctx context.Context, out io.Writer, opts inspect.Options) error {
 	formatter := inspect.OutputFormatter(out, opts.OutFormat)
 	cfgs, err := inspect.GetConfigSet(ctx, config.SkaffoldOptions{
 		ConfigurationFile:   opts.Filename,
@@ -48,8 +48,6 @@ func PrintExecutionModesList(ctx context.Context, out io.Writer, opts inspect.Op
 		CustomActionsExecutionModes: map[string]string{},
 	}
 
-	allActions := map[string]string{}
-
 	for _, c := range cfgs {
 		for _, tc := range c.Verify {
 			if tc.ExecutionMode.KubernetesClusterExecutionMode != nil {
@@ -61,16 +59,10 @@ func PrintExecutionModesList(ctx context.Context, out io.Writer, opts inspect.Op
 
 		for _, a := range c.CustomActions {
 			if a.ExecutionModeConfig.KubernetesClusterExecutionMode != nil {
-				allActions[a.Name] = "kubernetesCluster"
+				l.CustomActionsExecutionModes[a.Name] = "kubernetesCluster"
 			} else {
-				allActions[a.Name] = "local"
+				l.CustomActionsExecutionModes[a.Name] = "local"
 			}
-		}
-	}
-
-	for _, a := range customActions {
-		if execMode, found := allActions[a]; found {
-			l.CustomActionsExecutionModes[a] = execMode
 		}
 	}
 

--- a/pkg/skaffold/inspect/executionModes/list_test.go
+++ b/pkg/skaffold/inspect/executionModes/list_test.go
@@ -34,12 +34,11 @@ import (
 
 func TestPrintExecutionModesList(t *testing.T) {
 	tests := []struct {
-		description   string
-		profiles      []string
-		module        []string
-		customActions []string
-		err           error
-		expected      string
+		description string
+		profiles    []string
+		module      []string
+		err         error
+		expected    string
 	}{
 		{
 			description: "print all executionModes where no executionMode is set in the verify config",
@@ -68,22 +67,14 @@ func TestPrintExecutionModesList(t *testing.T) {
 			expected:    `{"errorCode":"INSPECT_UNKNOWN_ERR","errorMessage":"some error occurred"}` + "\n",
 		},
 		{
-			description:   "print executionModes for k8s custom action",
-			expected:      `{"verifyExecutionModes":{},"customActionsExecutionModes":{"action1":"kubernetesCluster"}}` + "\n",
-			customActions: []string{"action1"},
-			module:        []string{"cfg-with-customActions"},
+			description: "print executionModes for custom actions",
+			expected:    `{"verifyExecutionModes":{},"customActionsExecutionModes":{"action1":"kubernetesCluster","action2":"local"}}` + "\n",
+			module:      []string{"cfg-with-customActions"},
 		},
 		{
-			description:   "print executionModes for local custom action",
-			expected:      `{"verifyExecutionModes":{},"customActionsExecutionModes":{"action2":"local"}}` + "\n",
-			customActions: []string{"action2"},
-			module:        []string{"cfg-with-customActions"},
-		},
-		{
-			description:   "print executionModes for custom action and verify",
-			expected:      `{"verifyExecutionModes":{"bar":"kubernetesCluster"},"customActionsExecutionModes":{"action1":"kubernetesCluster"}}` + "\n",
-			customActions: []string{"action1"},
-			module:        []string{"cfg-with-customActions-and-verify"},
+			description: "print executionModes for custom action and verify",
+			expected:    `{"verifyExecutionModes":{"bar":"kubernetesCluster"},"customActionsExecutionModes":{"action1":"kubernetesCluster"}}` + "\n",
+			module:      []string{"cfg-with-customActions-and-verify"},
 		},
 	}
 
@@ -223,7 +214,7 @@ func TestPrintExecutionModesList(t *testing.T) {
 			})
 			var buf bytes.Buffer
 			err := PrintExecutionModesList(context.Background(), &buf, inspect.Options{
-				OutFormat: "json", Modules: test.module, Profiles: test.profiles}, test.customActions)
+				OutFormat: "json", Modules: test.module, Profiles: test.profiles})
 			t.CheckError(test.err != nil, err)
 			t.CheckDeepEqual(test.expected, buf.String())
 		})


### PR DESCRIPTION
**Description**
This PR changes the `inspect executionMode list` command to not receive any custom action name as parameter and to list all the custom actions execution modes per default. This change makes the command to have the same behaviour as `inspect jobManifestPaths list`.
