### PR TITLE
fix: scanning filter not working properly due to version sorting

### DIFF
--- a/deploy/vuln-monitor/scan.sh
+++ b/deploy/vuln-monitor/scan.sh
@@ -44,7 +44,7 @@ check_vulnerability(){
     done
     tags_filter+="^edge$"
     # get the latest patches tags for lts images. gcloud will return extra tags if an image has multiple tags and we only want tags specified in the filter, so use grep to further filter the result.
-    tags=$(gcloud container images list-tags "$base_image" --filter="tags~$tags_filter" --format='value(tags)' | sort -nr | awk -F'[.]' '$1$2!=p&&p=$1$2' | grep -Po "$tags_filter|edge")
+    tags=$(gcloud container images list-tags "$base_image" --filter="tags~$tags_filter" --format='value(tags)' | sort -Vr | awk -F'[.]' '$1$2!=p&&p=$1$2' | grep -Po "$tags_filter|edge")
   fi
 
   for tagsByComma in $tags; do


### PR DESCRIPTION
**Description**

 - the script was using wrong flag for sort versions , this causes vul monitor misreporting, e.g. it's supposed to scan v2.0.10 instead of v2.0.9, 
 - We should use -V flag to compare version directly instead of comparing numeric values with -n flag. 