### PR TITLE
test: comment last line of expected log due to issue #8728

### DIFF
--- a/integration/exec_test.go
+++ b/integration/exec_test.go
@@ -152,7 +152,8 @@ func TestExec_ActionsEvents(t *testing.T) {
 				`"execEvent":{"id":"task8","taskId":"Exec-0","status":"InProgress"}}`,
 				`"execEvent":{"id":"task7","taskId":"Exec-0","status":"Succeeded"}}`,
 				`"execEvent":{"id":"task8","taskId":"Exec-0","status":"Succeeded"}}`,
-				`"taskEvent":{"id":"Exec-0","task":"Exec","status":"Succeeded"}}`,
+				// TODO(#8728): Uncomment this expected log line when the flaky behaviour is solved.
+				// `"taskEvent":{"id":"Exec-0","task":"Exec","status":"Succeeded"}}`,
 			},
 		},
 		{


### PR DESCRIPTION
**Related**: #8728 

**Description**
Comment last line of expected log to avoid flaky behaviour in `exec_test` integration tests. We need to solve #8728 before uncommenting it again.