### PR TITLE
fix: missing Sessionable ID in exported metrics

### DIFF
--- a/pkg/skaffold/instrumentation/firelog/exporter_test.go
+++ b/pkg/skaffold/instrumentation/firelog/exporter_test.go
@@ -140,18 +140,16 @@ func TestBuildMetricData(t *testing.T) {
 				LogSource:  "CONCORD",
 				LogEvent: LogEvent{
 					EventTimeMS:                  100,
-					EventUptimeMS:                200,
 					SourceExtensionJSONProto3Str: "{foo:a}",
 				},
-				RequestTimeMS:   100,
-				RequestUptimeMS: 200,
+				RequestTimeMS: 100,
 			},
 		},
 	}
 
 	for _, test := range tests {
 		testutil.Run(t, test.name, func(t *testutil.T) {
-			actual := buildMetricData(test.proto, test.startTimeMS, test.upTimeMS)
+			actual := buildMetricData(test.proto, test.startTimeMS)
 			t.CheckDeepEqual(test.expected, actual)
 		})
 	}
@@ -170,7 +168,7 @@ func TestBuildProtoStr(t *testing.T) {
 			name:      "no kvs",
 			eventName: "no kvs",
 			kvs:       EventMetadata{},
-			expected:  `{"project_id":"skaffold","console_type":"SKAFFOLD","client_install_id":"","event_name":"no kvs","event_metadata":[]}`,
+			expected:  `{"console_type":"SKAFFOLD","client_install_id":"00000000-0000-0000-0000-000000000000","event_name":"no kvs","event_metadata":[]}`,
 			wantErr:   false,
 		},
 		{
@@ -180,7 +178,7 @@ func TestBuildProtoStr(t *testing.T) {
 				{"key1", "value1"},
 				{"key2", "value2"},
 			},
-			expected: `{"project_id":"skaffold","console_type":"SKAFFOLD","client_install_id":"","event_name":"with kvs","event_metadata":[{"key":"key1","value":"value1"},{"key":"key2","value":"value2"}]}`,
+			expected: `{"console_type":"SKAFFOLD","client_install_id":"00000000-0000-0000-0000-000000000000","event_name":"with kvs","event_metadata":[{"key":"key1","value":"value1"},{"key":"key2","value":"value2"}]}`,
 			wantErr:  false,
 		},
 		{
@@ -199,6 +197,7 @@ func TestBuildProtoStr(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.name, func(t *testutil.T) {
+			t.Override(&GetClientInstallID, func() string { return "00000000-0000-0000-0000-000000000000" })
 			if test.marshalFunc != nil {
 				t.Override(&Marshal, test.marshalFunc)
 			}

--- a/pkg/skaffold/instrumentation/firelog/types.go
+++ b/pkg/skaffold/instrumentation/firelog/types.go
@@ -30,16 +30,14 @@ type ClientInfo struct {
 }
 
 type MetricData struct {
-	ClientInfo      ClientInfo `json:"client_info"`
-	LogSource       string     `json:"log_source"`
-	LogEvent        LogEvent   `json:"log_event"`
-	RequestTimeMS   int64      `json:"request_time_ms"`
-	RequestUptimeMS int64      `json:"request_uptime_ms"`
+	ClientInfo    ClientInfo `json:"client_info"`
+	LogSource     string     `json:"log_source"`
+	LogEvent      LogEvent   `json:"log_event"`
+	RequestTimeMS int64      `json:"request_time_ms"`
 }
 
 type LogEvent struct {
 	EventTimeMS                  int64  `json:"event_time_ms"`
-	EventUptimeMS                int64  `json:"event_uptime_ms"`
 	SourceExtensionJSONProto3Str string `json:"source_extension_json_proto3"`
 }
 
@@ -51,7 +49,6 @@ type KeyValue struct {
 type EventMetadata []KeyValue
 
 type SourceExtensionJSONProto3 struct {
-	ProjectID       string     `json:"project_id"`
 	ConsoleType     string     `json:"console_type"`
 	ClientInstallID string     `json:"client_install_id"`
 	EventName       string     `json:"event_name"`
@@ -76,7 +73,6 @@ type DataPoint interface {
 	value() string
 	attributes() attribute.Set
 	eventTime() int64
-	upTime() int64
 }
 
 type DataPointInt64 metricdata.DataPoint[int64]
@@ -89,10 +85,6 @@ func (d DataPointInt64) eventTime() int64 {
 	return d.StartTime.UnixMilli()
 }
 
-func (d DataPointInt64) upTime() int64 {
-	return d.Time.UnixMilli()
-}
-
 type DataPointFloat64 metricdata.DataPoint[float64]
 
 func (d DataPointFloat64) attributes() attribute.Set {
@@ -103,10 +95,6 @@ func (d DataPointFloat64) eventTime() int64 {
 	return d.StartTime.UnixMilli()
 }
 
-func (d DataPointFloat64) upTime() int64 {
-	return d.Time.UnixMilli()
-}
-
 type DataPointHistogram metricdata.HistogramDataPoint
 
 func (d DataPointHistogram) attributes() attribute.Set {
@@ -115,10 +103,6 @@ func (d DataPointHistogram) attributes() attribute.Set {
 
 func (d DataPointHistogram) eventTime() int64 {
 	return d.StartTime.UnixMilli()
-}
-
-func (d DataPointHistogram) upTime() int64 {
-	return d.Time.UnixMilli()
 }
 
 func (d DataPointInt64) value() string {


### PR DESCRIPTION
This PR:
* adds a sessionable ID (`client_install_id`) set to a random GUID
* removes event fields not required or incorrectly set in current iteration