### PR TITLE
fix: discard standout from helm dep command to not have corrupted data in output yaml file

### DIFF
--- a/pkg/skaffold/render/renderer/helm/helm.go
+++ b/pkg/skaffold/render/renderer/helm/helm.go
@@ -167,8 +167,7 @@ func (h Helm) generateHelmManifests(ctx context.Context, builds []graph.Artifact
 		// Build Chart dependencies, but allow a user to skip it.
 		if !release.SkipBuildDependencies && release.ChartPath != "" {
 			log.Entry(ctx).Info("Building helm dependencies...")
-
-			if err := helm.ExecWithStdoutAndStderr(ctx, h, outBuffer, errBuffer, false, helmEnv, "dep", "build", release.ChartPath); err != nil {
+			if err := helm.ExecWithStdoutAndStderr(ctx, h, io.Discard, errBuffer, false, helmEnv, "dep", "build", release.ChartPath); err != nil {
 				log.Entry(ctx).Infof(errBuffer.String())
 				return nil, helm.UserErr("building helm dependencies", err)
 			}


### PR DESCRIPTION
Fixes: #8754

**Description**
Discard output from running `helm dep` so we don't corrupt the resulting yaml file with the rendered manifest.

**Verifying the issue was solve**
- To reproduce the error we used the [helm-deployment-dependencies](https://github.com/GoogleContainerTools/skaffold/tree/0c0c5d18d174b6250f19629b459dba5f46d2d550/examples/helm-deployment-dependencies) example, updating the `skaffold.yaml` with this content:
```
apiVersion: skaffold/v4beta5
kind: Config
build:
  tagPolicy:
    sha256: {}
  artifacts:
  - image: skaffold-helm
manifests:
  helm:
    releases:
    - name: skaffold-helm
      chartPath: skaffold-helm
```
- We ran `skaffold render --output=manifest.yaml`, and the resulting yaml file looked like this:
```
Saving 1 charts
Dependency subchart did not declare a repository. Assuming it exists in the charts directory
Deleting outdated charts
apiVersion: v1
data:
  index.html: |-
    <html lang="en">
    <head>
        <title>Skaffold Helm</title>
        <link rel="stylesheet" href="style.css">
```
Where the first lines are from the `stdout` we get from running `helm dep build`

With this change the `stdout` from `helm dep build` is ignored so the extra content is not printed in the generated manifests:

- With the same modified example, after running `skaffold render --output=manifest.yaml`, we get a resulting file like this:
```
apiVersion: v1
data:
  index.html: |-
    <html lang="en">
    <head>
        <title>Skaffold Helm</title>
        <link rel="stylesheet" href="style.css">
```
No extra content is printed there, making the `manifest.yaml` file a valid yaml file for k8s (`skaffold apply manifest.yaml` will work).