### PR TITLE
fix: Replace Kustomize field `patches` in examples

### DIFF
--- a/examples/go-integration-coverage/k8s/overlays/coverage/Kustomization
+++ b/examples/go-integration-coverage/k8s/overlays/coverage/Kustomization
@@ -23,5 +23,5 @@ bases:
 replicas:
 - name: go-integration-coverage
   count: 1
-patches:
+patchesStrategicMerge:
 - coverage-patch.yaml

--- a/examples/kustomize/kustomization.yaml
+++ b/examples/kustomize/kustomization.yaml
@@ -1,4 +1,4 @@
 resources:
   - deployment.yaml
-patches:
+patchesStrategicMerge:
   - patch.yaml

--- a/integration/examples/go-integration-coverage/k8s/overlays/coverage/Kustomization
+++ b/integration/examples/go-integration-coverage/k8s/overlays/coverage/Kustomization
@@ -23,5 +23,5 @@ bases:
 replicas:
 - name: go-integration-coverage
   count: 1
-patches:
+patchesStrategicMerge:
 - coverage-patch.yaml

--- a/integration/examples/kustomize/kustomization.yaml
+++ b/integration/examples/kustomize/kustomization.yaml
@@ -1,4 +1,4 @@
 resources:
   - deployment.yaml
-patches:
+patchesStrategicMerge:
   - patch.yaml


### PR DESCRIPTION
This change replaces the obsolete use of the Kustomize `patches` field in the Skaffold examples with `patchesStrategicMerge`.

Context:
Kustomize v5 removed support for `patches` being an array of strings.

The `patchesStrategicMerge` field introduced in Kustomize v3 retains the previous behavior of the `patches`.

The `patches` field can still be used in v5 with an array of `patch` objects.

Additional information:
- https://github.com/kubernetes-sigs/kustomize/pull/4911
- https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv5.0.0
