### PR TITLE
chore: fix for Helm render with dependencies v2.4.1

### DIFF
--- a/pkg/skaffold/render/renderer/helm/helm.go
+++ b/pkg/skaffold/render/renderer/helm/helm.go
@@ -167,8 +167,7 @@ func (h Helm) generateHelmManifests(ctx context.Context, builds []graph.Artifact
 		// Build Chart dependencies, but allow a user to skip it.
 		if !release.SkipBuildDependencies && release.ChartPath != "" {
 			log.Entry(ctx).Info("Building helm dependencies...")
-
-			if err := helm.ExecWithStdoutAndStderr(ctx, h, outBuffer, errBuffer, false, helmEnv, "dep", "build", release.ChartPath); err != nil {
+			if err := helm.ExecWithStdoutAndStderr(ctx, h, io.Discard, errBuffer, false, helmEnv, "dep", "build", release.ChartPath); err != nil {
 				log.Entry(ctx).Infof(errBuffer.String())
 				return nil, helm.UserErr("building helm dependencies", err)
 			}


### PR DESCRIPTION
This is a cherry pick to fix Helm render, on top of `v2.4.0`:

- Change in helm renderer d2732961a8dbdf251c5bc21bfdd4cdd9ce806e27 , pr: https://github.com/GoogleContainerTools/skaffold/pull/8756