### PR TITLE
feat: new verify timeout config feature

### DIFF
--- a/docs-v2/content/en/schemas/v4beta6.json
+++ b/docs-v2/content/en/schemas/v4beta6.json
@@ -4446,10 +4446,16 @@
           "type": "string",
           "description": "name descriptor for the verify test.",
           "x-intellij-html-description": "name descriptor for the verify test."
+        },
+        "timeout": {
+          "type": "integer",
+          "description": "indicates the max time (in seconds) that the verify test is allowed to run.",
+          "x-intellij-html-description": "indicates the max time (in seconds) that the verify test is allowed to run."
         }
       },
       "preferredOrder": [
         "name",
+        "timeout",
         "container",
         "executionMode"
       ],

--- a/integration/testdata/verify-fail-k8s/skaffold.yaml
+++ b/integration/testdata/verify-fail-k8s/skaffold.yaml
@@ -36,3 +36,56 @@ profiles:
           image: alpine:3.15.4
           command: ["/bin/sh"]
           args: ["-c", "echo alpine-2; echo bye alpine-2; exit 1"]
+
+  - name: fail-timeout
+    verify:
+      - name: alpine-3
+        timeout: 5
+        executionMode:
+          kubernetesCluster: {}
+        container:
+          name: alpine-3
+          image: alpine:3.15.4
+          command: ["/bin/sh"]
+          args: ["-c", "echo alpine-3; sleep 10; echo bye alpine-3"]
+  
+  - name: fail-two-test-timeout
+    verify:
+      - name: alpine-4
+        timeout: 6
+        executionMode:
+          kubernetesCluster: {}
+        container:
+          name: alpine-4
+          image: alpine:3.15.4
+          command: ["/bin/sh"]
+          args: ["-c", "echo alpine-4; sleep 10; echo bye alpine-4"]
+      - name: alpine-5
+        timeout: 5
+        executionMode:
+          kubernetesCluster: {}
+        container:
+          name: alpine-5
+          image: alpine:3.15.4
+          command: ["/bin/sh"]
+          args: ["-c", "echo alpine-5; sleep 8; echo bye alpine-5"]
+  
+  - name: fail-only-one-test-timeout
+    verify:
+      - name: alpine-6
+        timeout: 6
+        executionMode:
+          kubernetesCluster: {}
+        container:
+          name: alpine-6
+          image: alpine:3.15.4
+          command: ["/bin/sh"]
+          args: ["-c", "echo alpine-6; sleep 10; echo bye alpine-6"]
+      - name: alpine-7
+        executionMode:
+          kubernetesCluster: {}
+        container:
+          name: alpine-7
+          image: alpine:3.15.4
+          command: ["/bin/sh"]
+          args: ["-c", "echo alpine-7; sleep 15; echo bye alpine-7"]

--- a/integration/testdata/verify-fail/skaffold.yaml
+++ b/integration/testdata/verify-fail/skaffold.yaml
@@ -28,3 +28,47 @@ profiles:
           image: alpine:3.15.4
           command: ["/bin/sh"]
           args: ["-c", "echo alpine-2; echo bye alpine-2; exit 1"]
+  
+  - name: fail-timeout
+    verify:
+      - name: alpine-1
+        timeout: 5
+        container:
+          name: alpine-1
+          image: alpine:3.15.4
+          command: ["/bin/sh"]
+          args: ["-c", "echo alpine-1; sleep 10; echo bye alpine-1"]
+    
+  - name: fail-two-test-timeout
+    verify:
+      - name: alpine-1
+        timeout: 6
+        container:
+          name: alpine-1
+          image: alpine:3.15.4
+          command: ["/bin/sh"]
+          args: ["-c", "echo alpine-1; sleep 10; echo bye alpine-1"]
+      - name: alpine-2
+        timeout: 5
+        container:
+          name: alpine-2
+          image: alpine:3.15.4
+          command: ["/bin/sh"]
+          args: ["-c", "echo alpine-2; sleep 8; echo bye alpine-2"]
+  
+  - name: fail-only-one-test-timeout
+    verify:
+      - name: alpine-1
+        timeout: 6
+        container:
+          name: alpine-1
+          image: alpine:3.15.4
+          command: ["/bin/sh"]
+          args: ["-c", "echo alpine-1; sleep 10; echo bye alpine-1"]
+      - name: alpine-2
+        container:
+          name: alpine-2
+          image: alpine:3.15.4
+          command: ["/bin/sh"]
+          args: ["-c", "echo alpine-2; sleep 15; echo bye alpine-2"]
+

--- a/integration/testdata/verify-succeed-k8s/skaffold.yaml
+++ b/integration/testdata/verify-succeed-k8s/skaffold.yaml
@@ -47,3 +47,44 @@ profiles:
           image: alpine:3.15.4
           command: ["/bin/sh"]
           args: ["-c", "echo alpine-1; sleep 1; echo bye alpine-1"]
+
+  - name: succeed-with-timeout
+    verify:
+      - name: alpine-8
+        timeout: 30
+        executionMode:
+          kubernetesCluster: {}
+        container:
+          name: alpine-8
+          image: alpine:3.15.4
+          command: ["/bin/sh"]
+          args: ["-c", "echo alpine-8; sleep 10; echo bye alpine-8"]
+      - name: alpine-9
+        timeout: 35
+        executionMode:
+          kubernetesCluster: {}
+        container:
+          name: alpine-9
+          image: alpine:3.15.4
+          command: ["/bin/sh"]
+          args: ["-c", "echo alpine-9; sleep 15; echo bye alpine-9"]
+  
+  - name: succeed-all-one-with-timeout
+    verify:
+      - name: alpine-10
+        executionMode:
+          kubernetesCluster: {}
+        container:
+          name: alpine-10
+          image: alpine:3.15.4
+          command: ["/bin/sh"]
+          args: ["-c", "echo alpine-10; sleep 10; echo bye alpine-10"]
+      - name: alpine-11
+        timeout: 25
+        executionMode:
+          kubernetesCluster: {}
+        container:
+          name: alpine-11
+          image: alpine:3.15.4
+          command: ["/bin/sh"]
+          args: ["-c", "echo alpine-11; sleep 15; echo bye alpine-11"]

--- a/integration/testdata/verify-succeed/skaffold.yaml
+++ b/integration/testdata/verify-succeed/skaffold.yaml
@@ -54,3 +54,36 @@ profiles:
         container:
           name: localtask
           image: localtask
+
+  - name: succeed-with-timeout
+    verify:
+      - name: alpine-1
+        timeout: 20
+        container:
+          name: alpine-1
+          image: alpine:3.15.4
+          command: ["/bin/sh"]
+          args: ["-c", "echo alpine-1; sleep 10; echo bye alpine-1"]
+      - name: alpine-2
+        timeout: 25
+        container:
+          name: alpine-2
+          image: alpine:3.15.4
+          command: ["/bin/sh"]
+          args: ["-c", "echo alpine-2; sleep 15; echo bye alpine-2"]
+
+  - name: succeed-all-one-with-timeout
+    verify:
+      - name: alpine-1
+        container:
+          name: alpine-1
+          image: alpine:3.15.4
+          command: ["/bin/sh"]
+          args: ["-c", "echo alpine-1; sleep 10; echo bye alpine-1"]
+      - name: alpine-2
+        timeout: 25
+        container:
+          name: alpine-2
+          image: alpine:3.15.4
+          command: ["/bin/sh"]
+          args: ["-c", "echo alpine-2; sleep 15; echo bye alpine-2"]

--- a/pkg/skaffold/k8sjob/util.go
+++ b/pkg/skaffold/k8sjob/util.go
@@ -17,16 +17,34 @@ limitations under the License.
 package k8sjob
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
+	"time"
 
 	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/pkg/errors"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	typesbatchv1 "k8s.io/client-go/kubernetes/typed/batch/v1"
 	"k8s.io/kubectl/pkg/scheme"
+
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/deploy/kubectl"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/util"
 )
+
+type checkK8sRetryableErr func(error) bool
+
+// Functions slice that check if a given k8s error is a retryable error or not.
+var retryableErrChecks []checkK8sRetryableErr = []checkK8sRetryableErr{
+	apierrs.IsServerTimeout,
+	apierrs.IsTimeout,
+	apierrs.IsTooManyRequests,
+}
 
 func ApplyOverrides(obj runtime.Object, overrides string) (runtime.Object, error) {
 	codec := runtime.NewCodec(scheme.DefaultJSONEncoder(), scheme.Codecs.UniversalDecoder(scheme.Scheme.PrioritizedVersionsAllGroups()...))
@@ -111,4 +129,57 @@ func GetGenericJob() *batchv1.Job {
 			},
 		},
 	}
+}
+
+func ForceJobDelete(ctx context.Context, jobName string, jobsManager typesbatchv1.JobInterface, kubectl *kubectl.CLI) error {
+	err := WithRetryablePoll(ctx, func(ctx context.Context) error {
+		_, err := jobsManager.Get(ctx, jobName, metav1.GetOptions{})
+		return err
+	})
+
+	if apierrs.IsNotFound(err) {
+		return nil
+	}
+
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("deleting %v job", jobName))
+	}
+
+	err = WithRetryablePoll(ctx, func(ctx context.Context) error {
+		return jobsManager.Delete(ctx, jobName, metav1.DeleteOptions{
+			GracePeriodSeconds: util.Ptr[int64](0),
+			PropagationPolicy:  util.Ptr(metav1.DeletePropagationForeground),
+		})
+	})
+
+	if err != nil && !apierrs.IsNotFound(err) {
+		return err
+	}
+
+	return deleteJobPod(ctx, jobName, kubectl)
+}
+
+func deleteJobPod(ctx context.Context, jobName string, kubectl *kubectl.CLI) error {
+	// We execute the Pods delete with the kubectl CLI client to be able to force the deletion.
+	_, err := kubectl.RunOut(ctx, "delete", "pod", "--force", "--grace-period", "0", "--wait=true", "--selector", fmt.Sprintf("job-name=%v", jobName))
+	return err
+}
+
+func WithRetryablePoll(ctx context.Context, execF func(context.Context) error) error {
+	return wait.PollImmediateWithContext(ctx, 100*time.Millisecond, 10*time.Second, func(ctx context.Context) (bool, error) {
+		err := execF(ctx)
+		if isRetryableErr(err) {
+			return false, nil
+		}
+
+		return true, err
+	})
+}
+
+func isRetryableErr(k8sErr error) bool {
+	isRetryable := false
+	for _, checkIsRetryableErr := range retryableErrChecks {
+		isRetryable = isRetryable || checkIsRetryableErr(k8sErr)
+	}
+	return isRetryable
 }

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -634,10 +634,18 @@ type KubernetesClusterVerifier struct {
 type VerifyTestCase struct {
 	// Name is the name descriptor for the verify test.
 	Name string `yaml:"name" yamltags:"required"`
+	// Config describes general configuration for the verify test.
+	Config VerifyConfig `yaml:",inline"`
 	// Container is the container information for the verify test.
 	Container VerifyContainer `yaml:"container" yamltags:"required"`
 	// ExecutionMode is the execution mode used to execute the verify test case.
 	ExecutionMode VerifyExecutionModeConfig `yaml:"executionMode,omitempty"`
+}
+
+// VerifyConfig describes general configuration options available for a verify test.
+type VerifyConfig struct {
+	// Timeout indicates the max time (in seconds) that the verify test is allowed to run.
+	Timeout *int `yaml:"timeout,omitempty"`
 }
 
 // VerifyContainer is a list of tests to run on images that Skaffold builds.

--- a/pkg/skaffold/verify/docker/verify.go
+++ b/pkg/skaffold/verify/docker/verify.go
@@ -46,6 +46,7 @@ import (
 	olog "github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/output/log"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/status"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/util"
 )
 
 // Verifier verifies deployments using Docker libs/CLI.
@@ -64,7 +65,6 @@ type Verifier struct {
 	envMap             map[string]string
 	resources          []*latest.PortForwardResource
 	once               sync.Once
-	testTimeout        time.Duration
 }
 
 func NewVerifier(ctx context.Context, cfg dockerutil.Config, labeller *label.DefaultLabeller, testCases []*latest.VerifyTestCase, resources []*latest.PortForwardResource, network string, envMap map[string]string) (*Verifier, error) {
@@ -99,8 +99,6 @@ func NewVerifier(ctx context.Context, cfg dockerutil.Config, labeller *label.Def
 		portManager:        dockerport.NewPortManager(), // fulfills Accessor interface
 		logger:             l,
 		monitor:            &status.NoopMonitor{},
-		// TODO(aaron-prindle) make testTimeout user configurable
-		testTimeout: time.Minute * 10,
 	}, nil
 }
 
@@ -244,6 +242,11 @@ func (v *Verifier) createAndRunContainer(ctx context.Context, out io.Writer, art
 		Tag:       opts.VerifyTestName,
 	}, tracker.Container{Name: containerName, ID: id})
 
+	var timeoutDuration *time.Duration = nil
+	if tc.Config.Timeout != nil {
+		timeoutDuration = util.Ptr(time.Second * time.Duration(*tc.Config.Timeout))
+	}
+
 	var containerErr error
 	select {
 	case err := <-errCh:
@@ -254,10 +257,10 @@ func (v *Verifier) createAndRunContainer(ctx context.Context, out io.Writer, art
 		if status.StatusCode != 0 {
 			containerErr = errors.New(fmt.Sprintf("%q running container image %q errored during run with status code: %d", opts.VerifyTestName, opts.ContainerConfig.Image, status.StatusCode))
 		}
-	case <-time.After(v.testTimeout):
+	case <-v.timeout(timeoutDuration):
 		// verify test timed out
-		containerErr = errors.New(fmt.Sprintf("%q running container image %q timed out after : %s", opts.VerifyTestName, opts.ContainerConfig.Image, v.testTimeout))
-		v.client.Stop(ctx, id, nil)
+		containerErr = errors.New(fmt.Sprintf("%q running container image %q timed out after : %v", opts.VerifyTestName, opts.ContainerConfig.Image, *timeoutDuration))
+		v.client.Stop(ctx, id, util.Ptr(time.Second*0))
 		err := v.client.Remove(ctx, id)
 		if err != nil {
 			return errors.Wrap(containerErr, err.Error())
@@ -337,4 +340,12 @@ func (v *Verifier) GetStatusMonitor() status.Monitor {
 
 func (v *Verifier) RegisterLocalImages([]graph.Artifact) {
 	// all images are local, so this is a noop
+}
+
+func (v *Verifier) timeout(duration *time.Duration) <-chan time.Time {
+	if duration != nil {
+		return time.After(*duration)
+	}
+	// Nil channel will never emit a value, so it will simulate an endless timeout.
+	return nil
 }


### PR DESCRIPTION
Fixes: #7366

**Description**
This PR adds the needed logic to support the configuration of a user define time out for every verify test case, for docker and k8s implementations.

**User facing changes**
This PR includes a schema upgrade.

- Now the `verify` stanza supports a `timeout` field:
```
verify:
- name: alpine-1
  timeout: 5
  container:
    name: alpine-1
    image: alpine:3.15.4
    command: ["/bin/sh"]
    args: ["-c", "echo alpine-1; sleep 10; echo bye alpine-1"]```