### PR TITLE
test: disable failing buildpacks tests

### DIFF
--- a/integration/debug_test.go
+++ b/integration/debug_test.go
@@ -54,13 +54,14 @@ func TestDebug(t *testing.T) {
 			deployments: []string{"java"},
 			pods:        []string{"nodejs", "npm" /*, "python3"*/, "go" /*, "netcore"*/},
 		},
-		{
-			description: "buildpacks",
-			dir:         "testdata/debug",
-			args:        []string{"--profile", "buildpacks"},
-			deployments: []string{"java"},
-			pods:        []string{"nodejs", "npm" /*, "python3"*/, "go" /*, "netcore"*/},
-		},
+		// TODO(#8811): Enable this test when issue is solve.
+		// {
+		// 	description: "buildpacks",
+		// 	dir:         "testdata/debug",
+		// 	args:        []string{"--profile", "buildpacks"},
+		// 	deployments: []string{"java"},
+		// 	pods:        []string{"nodejs", "npm" /*, "python3"*/, "go" /*, "netcore"*/},
+		// },
 		{
 			description:   "helm",
 			dir:           "examples/helm-deployment",

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -130,26 +130,30 @@ var tests = []struct {
 		dir:         "examples/custom",
 		pods:        []string{"getting-started-custom"},
 	},
-	{
-		description: "buildpacks Go",
-		dir:         "examples/buildpacks",
-		deployments: []string{"web"},
-	},
-	{
-		description: "buildpacks NodeJS",
-		dir:         "examples/buildpacks-node",
-		deployments: []string{"web"},
-	},
-	{
-		description: "buildpacks Python",
-		dir:         "examples/buildpacks-python",
-		deployments: []string{"web"},
-	},
-	{
-		description: "buildpacks Java",
-		dir:         "examples/buildpacks-java",
-		deployments: []string{"web"},
-	},
+	// TODO(#8811): Enable this test when issue is solve.
+	// {
+	// 	description: "buildpacks Go",
+	// 	dir:         "examples/buildpacks",
+	// 	deployments: []string{"web"},
+	// },
+	// TODO(#8811): Enable this test when issue is solve.
+	// {
+	// 	description: "buildpacks NodeJS",
+	// 	dir:         "examples/buildpacks-node",
+	// 	deployments: []string{"web"},
+	// },
+	// TODO(#8811): Enable this test when issue is solve.
+	// {
+	// 	description: "buildpacks Python",
+	// 	dir:         "examples/buildpacks-python",
+	// 	deployments: []string{"web"},
+	// },
+	// TODO(#8811): Enable this test when issue is solve.
+	// {
+	// 	description: "buildpacks Java",
+	// 	dir:         "examples/buildpacks-java",
+	// 	deployments: []string{"web"},
+	// },
 	{
 		description: "kustomize",
 		dir:         "examples/getting-started-kustomize",


### PR DESCRIPTION
**Related**: #8811

**Description**
This PR disable the buildpacks tests that are failing. These tests started to fail without any changes in the Skaffold logic related with buildpacks.