### PR TITLE
chore: update release build script to support internal scanning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,7 @@ release-build:
 		-f deploy/skaffold/Dockerfile \
 		--target release \
 		-t gcr.io/$(GCP_PROJECT)/skaffold:edge \
+		-t gcr.io/$(GCP_PROJECT)/skaffold:public-image-edge \
 		-t gcr.io/$(GCP_PROJECT)/skaffold:$(COMMIT) \
 		.
 
@@ -177,6 +178,7 @@ release-lts: $(BUILD_DIR)/VERSION
 		--target release \
 		-t gcr.io/$(GCP_PROJECT)/skaffold:lts \
 		-t gcr.io/$(GCP_PROJECT)/skaffold:$(VERSION)-lts \
+		-t gcr.io/$(GCP_PROJECT)/skaffold:$(SCANNING_MARKER)-lts \
 		.
 
 .PHONY: release-slim

--- a/deploy/cloudbuild-release-lts.yaml
+++ b/deploy/cloudbuild-release-lts.yaml
@@ -49,6 +49,7 @@ steps:
     - 'make'
     - 'release-lts'
     - 'VERSION=$TAG_NAME'
+    - 'SCANNING_MARKER=$_SCANNING_MARKER'
     - 'RELEASE_BUCKET=$_RELEASE_BUCKET'
     - 'GCP_PROJECT=$PROJECT_ID'
 

--- a/deploy/cloudbuild.yaml
+++ b/deploy/cloudbuild.yaml
@@ -57,6 +57,7 @@ steps:
 images:
 - 'gcr.io/$PROJECT_ID/build_deps:latest'
 - 'gcr.io/$PROJECT_ID/skaffold:edge'
+- 'gcr.io/$PROJECT_ID/skaffold:public-image-edge'
 - 'gcr.io/$PROJECT_ID/skaffold:$COMMIT_SHA'
 - 'us-east1-docker.pkg.dev/$PROJECT_ID/scanning/skaffold:edge'
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #7169 
**Related**:  Need to do the same for v1.39, v2.0, v2.3, 


**Description**
 - bug filing works as expected. b/285167256 
 - Add another tag in release process for vulnerabilities scanning
 - the tag used for scanning marker purposed is in minor version level, which means for only one patch release(the latest one) within the same minor version will possesses the tag.  For example, if 1.39.10 is the latest patch release for v1.39 version, the corresponding lts image will have the public-image-v1.39-lts tag, if we release a new patch version for v1.39 later, the tag will be moved to the corresponding 1.39.11 lts image.   



