### PR TITLE
test: v1.39.13 increase progressDeadlineSeconds timeout for TestRunUnstableChecked

### DIFF
--- a/integration/testdata/unstable-deployment/incorrect-deployment.yaml
+++ b/integration/testdata/unstable-deployment/incorrect-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: unstable-deployment
 spec:
-  progressDeadlineSeconds: 10
+  progressDeadlineSeconds: 20
   replicas: 1
   selector:
     matchLabels:


### PR DESCRIPTION
(Cherry-pick)
Related: #8822

**Description**
The TestRunUnstableChecked integration test is failing due to it reaches the deadline specified in `Deployment.spec.progressDeadlineSeconds` before reaching the expected error in the test; the `Deployment.spec.progressDeadlineSeconds` is used to [configure the status check timeout](https://skaffold.dev/docs/status-check/#configuring-timeout-for-status-check). This PR increase the deadline.