### PR TITLE
fix(ko): Ko builder push vs load behavior

### DIFF
--- a/pkg/skaffold/build/ko/publisher.go
+++ b/pkg/skaffold/build/ko/publisher.go
@@ -46,6 +46,10 @@ func publishOptions(ref string, pushImages bool, dockerClient daemon.Client, ins
 		return nil, err
 	}
 	imageNameWithoutTag := imageRef.Context().Name()
+	localDomain := ""
+	if !pushImages {
+		localDomain = imageNameWithoutTag
+	}
 
 	return &options.PublishOptions{
 		Bare:             true,
@@ -53,7 +57,7 @@ func publishOptions(ref string, pushImages bool, dockerClient daemon.Client, ins
 		DockerRepo:       imageNameWithoutTag,
 		InsecureRegistry: useInsecureRegistry(imageNameWithoutTag, insecureRegistries),
 		Local:            !pushImages,
-		LocalDomain:      imageNameWithoutTag,
+		LocalDomain:      localDomain,
 		Push:             pushImages,
 		Tags:             []string{imageRef.Identifier()},
 		UserAgent:        version.UserAgentWithClient(),

--- a/pkg/skaffold/build/ko/publisher_test.go
+++ b/pkg/skaffold/build/ko/publisher_test.go
@@ -84,7 +84,10 @@ func TestPublishOptions(t *testing.T) {
 				t.Errorf("wanted InsecureRegistry (%v), got (%v)", test.wantInsecureRegistry, po.InsecureRegistry)
 			}
 			if !test.pushImages && po.LocalDomain != test.repo {
-				t.Errorf("wanted LocalDomain (%q), got (%q)", test.repo, po.DockerRepo)
+				t.Errorf("wanted LocalDomain (%q), got (%q)", test.repo, po.LocalDomain)
+			}
+			if test.pushImages && po.LocalDomain != "" {
+				t.Errorf("wanted zero value for LocalDomain, got (%q)", po.LocalDomain)
 			}
 			if test.pushImages == po.Local {
 				t.Errorf("Local (%v) should be the inverse of pushImages (%v)", po.Local, test.pushImages)


### PR DESCRIPTION
Ko v0.13.0 introduced a change to the handling of image names when loading images into a Docker daemon (instead of pushing to a registry).

Specifically, ko v0.13.0 assumes that if the image repo name matches the [`LocalDomain` field](https://github.com/ko-build/ko/blob/v0.13.0/pkg/commands/options/publish.go#L37), the build image should be loaded into the Docker daemon, regardless of the values of the [`Push` and `Local` fields](https://github.com/ko-build/ko/blob/v0.13.0/pkg/commands/options/publish.go#L52-L56). In fairness, the comment on `LocalDomain` says "Use with `Local=true`." 😃. For reference, the implementation of this behavior is in [ko's `makePublisher()` function](https://github.com/ko-build/ko/blob/v0.13.0/pkg/commands/resolver.go#L189-L190).

This change ensures that Skaffold only sets the `LocalDomain` field for images that should be loaded.

Fixes: #8760
Related: https://github.com/ko-build/ko/pull/820
