### PR TITLE
fix: logic to interrupt a k8sjob logs as soon as it fails

### DIFF
--- a/integration/testdata/custom-actions-k8s/skaffold.yaml
+++ b/integration/testdata/custom-actions-k8s/skaffold.yaml
@@ -39,25 +39,6 @@ customActions:
           - name: FOO
             value: from-task4
   
-  - name: action-fail-fast-logs
-    executionMode:
-      kubernetesCluster: {}
-    containers:
-      - name: task3l
-        image: alpine:3.15.4
-        command: ["/bin/sh"]
-        args: ["-c", "echo hello-$FOO && sleep 1 && echo bye-$FOO"]
-        env:
-          - name: FOO
-            value: from-task3l
-      - name: task4l
-        image: alpine:3.15.4
-        command: ["/bin/sh"]
-        args: ["-c", "echo hello-$FOO && exit 1"]
-        env:
-          - name: FOO
-            value: from-task4l
-  
   - name: action-fail-safe
     executionMode:
       kubernetesCluster: {}


### PR DESCRIPTION
Fixes: #8839

**Description**
This PR adds the logic to interrupt the k8sjob custom actions log when a task fails, so we don't see the logs of a job that shouldn't be running. Also, the change in how we do the delete is changing: now we delete first the job and then its pod; before, we could have cases when we kill the pod, and before killing the job, it created a new pod.