### PR TITLE
chore: bump schema version to v4beta6

### DIFF
--- a/docs-v2/config.toml
+++ b/docs-v2/config.toml
@@ -82,7 +82,7 @@ weight = 1
 copyright = "Skaffold Authors"
 privacy_policy = "https://policies.google.com/privacy"
 github_repo = "https://github.com/GoogleContainerTools/skaffold"
-skaffold_version = "skaffold/v4beta5"
+skaffold_version = "skaffold/v4beta6"
 
 # Google Custom Search Engine ID. Remove or comment out to disable search.
 # gcs_engine_id = "013756393218025596041:3nojel67sum"

--- a/docs-v2/content/en/docs/references/cli/_index.md
+++ b/docs-v2/content/en/docs/references/cli/_index.md
@@ -988,7 +988,7 @@ Options:
       --overwrite=false: Overwrite original config with fixed config
       --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
       --sync-remote-cache='missing': Controls how Skaffold manages the remote config cache (see `remote-cache-dir`). One of `always` (default), `missing`, or `never`. `always` syncs remote repositories to latest on access. `missing` only clones remote repositories if they do not exist locally. `never` means the user takes responsibility for updating remote repositories.
-      --version='skaffold/v4beta5': Target schema version to upgrade to
+      --version='skaffold/v4beta6': Target schema version to upgrade to
 
 Usage:
   skaffold fix [options]

--- a/docs-v2/content/en/schemas/v4beta6.json
+++ b/docs-v2/content/en/schemas/v4beta6.json
@@ -1,0 +1,4462 @@
+{
+  "type": "object",
+  "anyOf": [
+    {
+      "$ref": "#/definitions/SkaffoldConfig"
+    }
+  ],
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "Action": {
+      "required": [
+        "name",
+        "containers"
+      ],
+      "properties": {
+        "containers": {
+          "items": {
+            "$ref": "#/definitions/VerifyContainer"
+          },
+          "type": "array",
+          "description": "containers list to execute as part of the custom action.",
+          "x-intellij-html-description": "containers list to execute as part of the custom action."
+        },
+        "executionMode": {
+          "$ref": "#/definitions/ActionExecutionModeConfig",
+          "description": "describes the execution mode used to execute the custom action.",
+          "x-intellij-html-description": "describes the execution mode used to execute the custom action."
+        },
+        "failFast": {
+          "type": "boolean",
+          "description": "indicates if the action should be executed with a fail-fast strategy or not (fail-safe). Defaults to true.",
+          "x-intellij-html-description": "indicates if the action should be executed with a fail-fast strategy or not (fail-safe). Defaults to true."
+        },
+        "name": {
+          "type": "string",
+          "description": "unique name assigned to the action.",
+          "x-intellij-html-description": "unique name assigned to the action."
+        },
+        "timeout": {
+          "type": "integer",
+          "description": "indicates the max time (in seconds) that the action is allowed to run.",
+          "x-intellij-html-description": "indicates the max time (in seconds) that the action is allowed to run."
+        }
+      },
+      "preferredOrder": [
+        "name",
+        "failFast",
+        "timeout",
+        "executionMode",
+        "containers"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "describes a user defined action defined by a list of container to execute.",
+      "x-intellij-html-description": "describes a user defined action defined by a list of container to execute."
+    },
+    "ActionExecutionModeConfig": {
+      "properties": {
+        "kubernetesCluster": {
+          "$ref": "#/definitions/KubernetesClusterVerifier",
+          "description": "uses the `kubectl` CLI to create veriy test case container in a kubernetes cluster.",
+          "x-intellij-html-description": "uses the <code>kubectl</code> CLI to create veriy test case container in a kubernetes cluster."
+        },
+        "local": {
+          "$ref": "#/definitions/LocalVerifier",
+          "description": "uses the `docker` CLI to create verify test case containers on the host machine in Docker. This is the default execution mode.",
+          "x-intellij-html-description": "uses the <code>docker</code> CLI to create verify test case containers on the host machine in Docker. This is the default execution mode."
+        }
+      },
+      "preferredOrder": [
+        "local",
+        "kubernetesCluster"
+      ],
+      "type": "object",
+      "description": "describes the configuration to use to execute an action.",
+      "x-intellij-html-description": "describes the configuration to use to execute an action."
+    },
+    "Activation": {
+      "properties": {
+        "command": {
+          "type": "string",
+          "description": "a Skaffold command for which the profile is auto-activated.",
+          "x-intellij-html-description": "a Skaffold command for which the profile is auto-activated.",
+          "examples": [
+            "dev"
+          ]
+        },
+        "env": {
+          "type": "string",
+          "description": "a `key=pattern` pair. The profile is auto-activated if an Environment Variable `key` matches the pattern. If the pattern starts with `!`, activation happens if the remaining pattern is _not_ matched. The pattern matches if the Environment Variable value is exactly `pattern`, or the regex `pattern` is found in it. An empty `pattern` (e.g. `env: \"key=\"`) always only matches if the Environment Variable is undefined or empty.",
+          "x-intellij-html-description": "a <code>key=pattern</code> pair. The profile is auto-activated if an Environment Variable <code>key</code> matches the pattern. If the pattern starts with <code>!</code>, activation happens if the remaining pattern is <em>not</em> matched. The pattern matches if the Environment Variable value is exactly <code>pattern</code>, or the regex <code>pattern</code> is found in it. An empty <code>pattern</code> (e.g. <code>env: &quot;key=&quot;</code>) always only matches if the Environment Variable is undefined or empty.",
+          "examples": [
+            "ENV=production"
+          ]
+        },
+        "kubeContext": {
+          "type": "string",
+          "description": "a Kubernetes context for which the profile is auto-activated.",
+          "x-intellij-html-description": "a Kubernetes context for which the profile is auto-activated.",
+          "examples": [
+            "minikube"
+          ]
+        }
+      },
+      "preferredOrder": [
+        "env",
+        "kubeContext",
+        "command"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "criteria by which a profile is auto-activated.",
+      "x-intellij-html-description": "criteria by which a profile is auto-activated."
+    },
+    "Artifact": {
+      "required": [
+        "image"
+      ],
+      "type": "object",
+      "anyOf": [
+        {
+          "properties": {
+            "context": {
+              "type": "string",
+              "description": "directory containing the artifact's sources.",
+              "x-intellij-html-description": "directory containing the artifact's sources.",
+              "default": "."
+            },
+            "hooks": {
+              "$ref": "#/definitions/BuildHooks",
+              "description": "describes a set of lifecycle hooks that are executed before and after each build of the target artifact.",
+              "x-intellij-html-description": "describes a set of lifecycle hooks that are executed before and after each build of the target artifact."
+            },
+            "image": {
+              "type": "string",
+              "description": "name of the image to be built.",
+              "x-intellij-html-description": "name of the image to be built.",
+              "examples": [
+                "gcr.io/k8s-skaffold/example"
+              ]
+            },
+            "platforms": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "description": "list of platforms to build this artifact image for. It overrides the values inferred through heuristics or provided in the top level `platforms` property or in the global config. If the target builder cannot build for atleast one of the specified platforms, then the build fails. Each platform is of the format `os[/arch[/variant]]`, e.g., `linux/amd64`. Example: `[\"linux/amd64\", \"linux/arm64\"]`.",
+              "x-intellij-html-description": "list of platforms to build this artifact image for. It overrides the values inferred through heuristics or provided in the top level <code>platforms</code> property or in the global config. If the target builder cannot build for atleast one of the specified platforms, then the build fails. Each platform is of the format <code>os[/arch[/variant]]</code>, e.g., <code>linux/amd64</code>. Example: <code>[&quot;linux/amd64&quot;, &quot;linux/arm64&quot;]</code>.",
+              "default": "[]"
+            },
+            "requires": {
+              "items": {
+                "$ref": "#/definitions/ArtifactDependency"
+              },
+              "type": "array",
+              "description": "describes build artifacts that this artifact depends on.",
+              "x-intellij-html-description": "describes build artifacts that this artifact depends on."
+            },
+            "runtimeType": {
+              "type": "string",
+              "description": "specifies the target language runtime for this artifact that is used to configure debug support. Should be one of `go`, `nodejs`, `jvm`, `python` or `netcore`. If unspecified the language runtime is inferred from common heuristics for the list of supported runtimes.",
+              "x-intellij-html-description": "specifies the target language runtime for this artifact that is used to configure debug support. Should be one of <code>go</code>, <code>nodejs</code>, <code>jvm</code>, <code>python</code> or <code>netcore</code>. If unspecified the language runtime is inferred from common heuristics for the list of supported runtimes."
+            },
+            "sync": {
+              "$ref": "#/definitions/Sync",
+              "description": "*beta* local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
+              "x-intellij-html-description": "<em>beta</em> local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
+              "default": "infer: [\"**/*\"]"
+            }
+          },
+          "preferredOrder": [
+            "image",
+            "context",
+            "sync",
+            "requires",
+            "hooks",
+            "platforms",
+            "runtimeType"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "context": {
+              "type": "string",
+              "description": "directory containing the artifact's sources.",
+              "x-intellij-html-description": "directory containing the artifact's sources.",
+              "default": "."
+            },
+            "docker": {
+              "$ref": "#/definitions/DockerArtifact",
+              "description": "*beta* describes an artifact built from a Dockerfile.",
+              "x-intellij-html-description": "<em>beta</em> describes an artifact built from a Dockerfile."
+            },
+            "hooks": {
+              "$ref": "#/definitions/BuildHooks",
+              "description": "describes a set of lifecycle hooks that are executed before and after each build of the target artifact.",
+              "x-intellij-html-description": "describes a set of lifecycle hooks that are executed before and after each build of the target artifact."
+            },
+            "image": {
+              "type": "string",
+              "description": "name of the image to be built.",
+              "x-intellij-html-description": "name of the image to be built.",
+              "examples": [
+                "gcr.io/k8s-skaffold/example"
+              ]
+            },
+            "platforms": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "description": "list of platforms to build this artifact image for. It overrides the values inferred through heuristics or provided in the top level `platforms` property or in the global config. If the target builder cannot build for atleast one of the specified platforms, then the build fails. Each platform is of the format `os[/arch[/variant]]`, e.g., `linux/amd64`. Example: `[\"linux/amd64\", \"linux/arm64\"]`.",
+              "x-intellij-html-description": "list of platforms to build this artifact image for. It overrides the values inferred through heuristics or provided in the top level <code>platforms</code> property or in the global config. If the target builder cannot build for atleast one of the specified platforms, then the build fails. Each platform is of the format <code>os[/arch[/variant]]</code>, e.g., <code>linux/amd64</code>. Example: <code>[&quot;linux/amd64&quot;, &quot;linux/arm64&quot;]</code>.",
+              "default": "[]"
+            },
+            "requires": {
+              "items": {
+                "$ref": "#/definitions/ArtifactDependency"
+              },
+              "type": "array",
+              "description": "describes build artifacts that this artifact depends on.",
+              "x-intellij-html-description": "describes build artifacts that this artifact depends on."
+            },
+            "runtimeType": {
+              "type": "string",
+              "description": "specifies the target language runtime for this artifact that is used to configure debug support. Should be one of `go`, `nodejs`, `jvm`, `python` or `netcore`. If unspecified the language runtime is inferred from common heuristics for the list of supported runtimes.",
+              "x-intellij-html-description": "specifies the target language runtime for this artifact that is used to configure debug support. Should be one of <code>go</code>, <code>nodejs</code>, <code>jvm</code>, <code>python</code> or <code>netcore</code>. If unspecified the language runtime is inferred from common heuristics for the list of supported runtimes."
+            },
+            "sync": {
+              "$ref": "#/definitions/Sync",
+              "description": "*beta* local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
+              "x-intellij-html-description": "<em>beta</em> local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
+              "default": "infer: [\"**/*\"]"
+            }
+          },
+          "preferredOrder": [
+            "image",
+            "context",
+            "sync",
+            "requires",
+            "hooks",
+            "platforms",
+            "runtimeType",
+            "docker"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "bazel": {
+              "$ref": "#/definitions/BazelArtifact",
+              "description": "*beta* requires bazel CLI to be installed and the sources to contain [Bazel](https://bazel.build/) configuration files.",
+              "x-intellij-html-description": "<em>beta</em> requires bazel CLI to be installed and the sources to contain <a href=\"https://bazel.build/\">Bazel</a> configuration files."
+            },
+            "context": {
+              "type": "string",
+              "description": "directory containing the artifact's sources.",
+              "x-intellij-html-description": "directory containing the artifact's sources.",
+              "default": "."
+            },
+            "hooks": {
+              "$ref": "#/definitions/BuildHooks",
+              "description": "describes a set of lifecycle hooks that are executed before and after each build of the target artifact.",
+              "x-intellij-html-description": "describes a set of lifecycle hooks that are executed before and after each build of the target artifact."
+            },
+            "image": {
+              "type": "string",
+              "description": "name of the image to be built.",
+              "x-intellij-html-description": "name of the image to be built.",
+              "examples": [
+                "gcr.io/k8s-skaffold/example"
+              ]
+            },
+            "platforms": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "description": "list of platforms to build this artifact image for. It overrides the values inferred through heuristics or provided in the top level `platforms` property or in the global config. If the target builder cannot build for atleast one of the specified platforms, then the build fails. Each platform is of the format `os[/arch[/variant]]`, e.g., `linux/amd64`. Example: `[\"linux/amd64\", \"linux/arm64\"]`.",
+              "x-intellij-html-description": "list of platforms to build this artifact image for. It overrides the values inferred through heuristics or provided in the top level <code>platforms</code> property or in the global config. If the target builder cannot build for atleast one of the specified platforms, then the build fails. Each platform is of the format <code>os[/arch[/variant]]</code>, e.g., <code>linux/amd64</code>. Example: <code>[&quot;linux/amd64&quot;, &quot;linux/arm64&quot;]</code>.",
+              "default": "[]"
+            },
+            "requires": {
+              "items": {
+                "$ref": "#/definitions/ArtifactDependency"
+              },
+              "type": "array",
+              "description": "describes build artifacts that this artifact depends on.",
+              "x-intellij-html-description": "describes build artifacts that this artifact depends on."
+            },
+            "runtimeType": {
+              "type": "string",
+              "description": "specifies the target language runtime for this artifact that is used to configure debug support. Should be one of `go`, `nodejs`, `jvm`, `python` or `netcore`. If unspecified the language runtime is inferred from common heuristics for the list of supported runtimes.",
+              "x-intellij-html-description": "specifies the target language runtime for this artifact that is used to configure debug support. Should be one of <code>go</code>, <code>nodejs</code>, <code>jvm</code>, <code>python</code> or <code>netcore</code>. If unspecified the language runtime is inferred from common heuristics for the list of supported runtimes."
+            },
+            "sync": {
+              "$ref": "#/definitions/Sync",
+              "description": "*beta* local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
+              "x-intellij-html-description": "<em>beta</em> local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
+              "default": "infer: [\"**/*\"]"
+            }
+          },
+          "preferredOrder": [
+            "image",
+            "context",
+            "sync",
+            "requires",
+            "hooks",
+            "platforms",
+            "runtimeType",
+            "bazel"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "context": {
+              "type": "string",
+              "description": "directory containing the artifact's sources.",
+              "x-intellij-html-description": "directory containing the artifact's sources.",
+              "default": "."
+            },
+            "hooks": {
+              "$ref": "#/definitions/BuildHooks",
+              "description": "describes a set of lifecycle hooks that are executed before and after each build of the target artifact.",
+              "x-intellij-html-description": "describes a set of lifecycle hooks that are executed before and after each build of the target artifact."
+            },
+            "image": {
+              "type": "string",
+              "description": "name of the image to be built.",
+              "x-intellij-html-description": "name of the image to be built.",
+              "examples": [
+                "gcr.io/k8s-skaffold/example"
+              ]
+            },
+            "ko": {
+              "$ref": "#/definitions/KoArtifact",
+              "description": "builds images using [ko](https://github.com/google/ko).",
+              "x-intellij-html-description": "builds images using <a href=\"https://github.com/google/ko\">ko</a>."
+            },
+            "platforms": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "description": "list of platforms to build this artifact image for. It overrides the values inferred through heuristics or provided in the top level `platforms` property or in the global config. If the target builder cannot build for atleast one of the specified platforms, then the build fails. Each platform is of the format `os[/arch[/variant]]`, e.g., `linux/amd64`. Example: `[\"linux/amd64\", \"linux/arm64\"]`.",
+              "x-intellij-html-description": "list of platforms to build this artifact image for. It overrides the values inferred through heuristics or provided in the top level <code>platforms</code> property or in the global config. If the target builder cannot build for atleast one of the specified platforms, then the build fails. Each platform is of the format <code>os[/arch[/variant]]</code>, e.g., <code>linux/amd64</code>. Example: <code>[&quot;linux/amd64&quot;, &quot;linux/arm64&quot;]</code>.",
+              "default": "[]"
+            },
+            "requires": {
+              "items": {
+                "$ref": "#/definitions/ArtifactDependency"
+              },
+              "type": "array",
+              "description": "describes build artifacts that this artifact depends on.",
+              "x-intellij-html-description": "describes build artifacts that this artifact depends on."
+            },
+            "runtimeType": {
+              "type": "string",
+              "description": "specifies the target language runtime for this artifact that is used to configure debug support. Should be one of `go`, `nodejs`, `jvm`, `python` or `netcore`. If unspecified the language runtime is inferred from common heuristics for the list of supported runtimes.",
+              "x-intellij-html-description": "specifies the target language runtime for this artifact that is used to configure debug support. Should be one of <code>go</code>, <code>nodejs</code>, <code>jvm</code>, <code>python</code> or <code>netcore</code>. If unspecified the language runtime is inferred from common heuristics for the list of supported runtimes."
+            },
+            "sync": {
+              "$ref": "#/definitions/Sync",
+              "description": "*beta* local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
+              "x-intellij-html-description": "<em>beta</em> local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
+              "default": "infer: [\"**/*\"]"
+            }
+          },
+          "preferredOrder": [
+            "image",
+            "context",
+            "sync",
+            "requires",
+            "hooks",
+            "platforms",
+            "runtimeType",
+            "ko"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "context": {
+              "type": "string",
+              "description": "directory containing the artifact's sources.",
+              "x-intellij-html-description": "directory containing the artifact's sources.",
+              "default": "."
+            },
+            "hooks": {
+              "$ref": "#/definitions/BuildHooks",
+              "description": "describes a set of lifecycle hooks that are executed before and after each build of the target artifact.",
+              "x-intellij-html-description": "describes a set of lifecycle hooks that are executed before and after each build of the target artifact."
+            },
+            "image": {
+              "type": "string",
+              "description": "name of the image to be built.",
+              "x-intellij-html-description": "name of the image to be built.",
+              "examples": [
+                "gcr.io/k8s-skaffold/example"
+              ]
+            },
+            "jib": {
+              "$ref": "#/definitions/JibArtifact",
+              "description": "builds images using the [Jib plugins for Maven or Gradle](https://github.com/GoogleContainerTools/jib/).",
+              "x-intellij-html-description": "builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/\">Jib plugins for Maven or Gradle</a>."
+            },
+            "platforms": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "description": "list of platforms to build this artifact image for. It overrides the values inferred through heuristics or provided in the top level `platforms` property or in the global config. If the target builder cannot build for atleast one of the specified platforms, then the build fails. Each platform is of the format `os[/arch[/variant]]`, e.g., `linux/amd64`. Example: `[\"linux/amd64\", \"linux/arm64\"]`.",
+              "x-intellij-html-description": "list of platforms to build this artifact image for. It overrides the values inferred through heuristics or provided in the top level <code>platforms</code> property or in the global config. If the target builder cannot build for atleast one of the specified platforms, then the build fails. Each platform is of the format <code>os[/arch[/variant]]</code>, e.g., <code>linux/amd64</code>. Example: <code>[&quot;linux/amd64&quot;, &quot;linux/arm64&quot;]</code>.",
+              "default": "[]"
+            },
+            "requires": {
+              "items": {
+                "$ref": "#/definitions/ArtifactDependency"
+              },
+              "type": "array",
+              "description": "describes build artifacts that this artifact depends on.",
+              "x-intellij-html-description": "describes build artifacts that this artifact depends on."
+            },
+            "runtimeType": {
+              "type": "string",
+              "description": "specifies the target language runtime for this artifact that is used to configure debug support. Should be one of `go`, `nodejs`, `jvm`, `python` or `netcore`. If unspecified the language runtime is inferred from common heuristics for the list of supported runtimes.",
+              "x-intellij-html-description": "specifies the target language runtime for this artifact that is used to configure debug support. Should be one of <code>go</code>, <code>nodejs</code>, <code>jvm</code>, <code>python</code> or <code>netcore</code>. If unspecified the language runtime is inferred from common heuristics for the list of supported runtimes."
+            },
+            "sync": {
+              "$ref": "#/definitions/Sync",
+              "description": "*beta* local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
+              "x-intellij-html-description": "<em>beta</em> local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
+              "default": "infer: [\"**/*\"]"
+            }
+          },
+          "preferredOrder": [
+            "image",
+            "context",
+            "sync",
+            "requires",
+            "hooks",
+            "platforms",
+            "runtimeType",
+            "jib"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "context": {
+              "type": "string",
+              "description": "directory containing the artifact's sources.",
+              "x-intellij-html-description": "directory containing the artifact's sources.",
+              "default": "."
+            },
+            "hooks": {
+              "$ref": "#/definitions/BuildHooks",
+              "description": "describes a set of lifecycle hooks that are executed before and after each build of the target artifact.",
+              "x-intellij-html-description": "describes a set of lifecycle hooks that are executed before and after each build of the target artifact."
+            },
+            "image": {
+              "type": "string",
+              "description": "name of the image to be built.",
+              "x-intellij-html-description": "name of the image to be built.",
+              "examples": [
+                "gcr.io/k8s-skaffold/example"
+              ]
+            },
+            "kaniko": {
+              "$ref": "#/definitions/KanikoArtifact",
+              "description": "builds images using [kaniko](https://github.com/GoogleContainerTools/kaniko).",
+              "x-intellij-html-description": "builds images using <a href=\"https://github.com/GoogleContainerTools/kaniko\">kaniko</a>."
+            },
+            "platforms": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "description": "list of platforms to build this artifact image for. It overrides the values inferred through heuristics or provided in the top level `platforms` property or in the global config. If the target builder cannot build for atleast one of the specified platforms, then the build fails. Each platform is of the format `os[/arch[/variant]]`, e.g., `linux/amd64`. Example: `[\"linux/amd64\", \"linux/arm64\"]`.",
+              "x-intellij-html-description": "list of platforms to build this artifact image for. It overrides the values inferred through heuristics or provided in the top level <code>platforms</code> property or in the global config. If the target builder cannot build for atleast one of the specified platforms, then the build fails. Each platform is of the format <code>os[/arch[/variant]]</code>, e.g., <code>linux/amd64</code>. Example: <code>[&quot;linux/amd64&quot;, &quot;linux/arm64&quot;]</code>.",
+              "default": "[]"
+            },
+            "requires": {
+              "items": {
+                "$ref": "#/definitions/ArtifactDependency"
+              },
+              "type": "array",
+              "description": "describes build artifacts that this artifact depends on.",
+              "x-intellij-html-description": "describes build artifacts that this artifact depends on."
+            },
+            "runtimeType": {
+              "type": "string",
+              "description": "specifies the target language runtime for this artifact that is used to configure debug support. Should be one of `go`, `nodejs`, `jvm`, `python` or `netcore`. If unspecified the language runtime is inferred from common heuristics for the list of supported runtimes.",
+              "x-intellij-html-description": "specifies the target language runtime for this artifact that is used to configure debug support. Should be one of <code>go</code>, <code>nodejs</code>, <code>jvm</code>, <code>python</code> or <code>netcore</code>. If unspecified the language runtime is inferred from common heuristics for the list of supported runtimes."
+            },
+            "sync": {
+              "$ref": "#/definitions/Sync",
+              "description": "*beta* local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
+              "x-intellij-html-description": "<em>beta</em> local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
+              "default": "infer: [\"**/*\"]"
+            }
+          },
+          "preferredOrder": [
+            "image",
+            "context",
+            "sync",
+            "requires",
+            "hooks",
+            "platforms",
+            "runtimeType",
+            "kaniko"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "buildpacks": {
+              "$ref": "#/definitions/BuildpackArtifact",
+              "description": "builds images using [Cloud Native Buildpacks](https://buildpacks.io/).",
+              "x-intellij-html-description": "builds images using <a href=\"https://buildpacks.io/\">Cloud Native Buildpacks</a>."
+            },
+            "context": {
+              "type": "string",
+              "description": "directory containing the artifact's sources.",
+              "x-intellij-html-description": "directory containing the artifact's sources.",
+              "default": "."
+            },
+            "hooks": {
+              "$ref": "#/definitions/BuildHooks",
+              "description": "describes a set of lifecycle hooks that are executed before and after each build of the target artifact.",
+              "x-intellij-html-description": "describes a set of lifecycle hooks that are executed before and after each build of the target artifact."
+            },
+            "image": {
+              "type": "string",
+              "description": "name of the image to be built.",
+              "x-intellij-html-description": "name of the image to be built.",
+              "examples": [
+                "gcr.io/k8s-skaffold/example"
+              ]
+            },
+            "platforms": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "description": "list of platforms to build this artifact image for. It overrides the values inferred through heuristics or provided in the top level `platforms` property or in the global config. If the target builder cannot build for atleast one of the specified platforms, then the build fails. Each platform is of the format `os[/arch[/variant]]`, e.g., `linux/amd64`. Example: `[\"linux/amd64\", \"linux/arm64\"]`.",
+              "x-intellij-html-description": "list of platforms to build this artifact image for. It overrides the values inferred through heuristics or provided in the top level <code>platforms</code> property or in the global config. If the target builder cannot build for atleast one of the specified platforms, then the build fails. Each platform is of the format <code>os[/arch[/variant]]</code>, e.g., <code>linux/amd64</code>. Example: <code>[&quot;linux/amd64&quot;, &quot;linux/arm64&quot;]</code>.",
+              "default": "[]"
+            },
+            "requires": {
+              "items": {
+                "$ref": "#/definitions/ArtifactDependency"
+              },
+              "type": "array",
+              "description": "describes build artifacts that this artifact depends on.",
+              "x-intellij-html-description": "describes build artifacts that this artifact depends on."
+            },
+            "runtimeType": {
+              "type": "string",
+              "description": "specifies the target language runtime for this artifact that is used to configure debug support. Should be one of `go`, `nodejs`, `jvm`, `python` or `netcore`. If unspecified the language runtime is inferred from common heuristics for the list of supported runtimes.",
+              "x-intellij-html-description": "specifies the target language runtime for this artifact that is used to configure debug support. Should be one of <code>go</code>, <code>nodejs</code>, <code>jvm</code>, <code>python</code> or <code>netcore</code>. If unspecified the language runtime is inferred from common heuristics for the list of supported runtimes."
+            },
+            "sync": {
+              "$ref": "#/definitions/Sync",
+              "description": "*beta* local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
+              "x-intellij-html-description": "<em>beta</em> local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
+              "default": "infer: [\"**/*\"]"
+            }
+          },
+          "preferredOrder": [
+            "image",
+            "context",
+            "sync",
+            "requires",
+            "hooks",
+            "platforms",
+            "runtimeType",
+            "buildpacks"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "context": {
+              "type": "string",
+              "description": "directory containing the artifact's sources.",
+              "x-intellij-html-description": "directory containing the artifact's sources.",
+              "default": "."
+            },
+            "custom": {
+              "$ref": "#/definitions/CustomArtifact",
+              "description": "*beta* builds images using a custom build script written by the user.",
+              "x-intellij-html-description": "<em>beta</em> builds images using a custom build script written by the user."
+            },
+            "hooks": {
+              "$ref": "#/definitions/BuildHooks",
+              "description": "describes a set of lifecycle hooks that are executed before and after each build of the target artifact.",
+              "x-intellij-html-description": "describes a set of lifecycle hooks that are executed before and after each build of the target artifact."
+            },
+            "image": {
+              "type": "string",
+              "description": "name of the image to be built.",
+              "x-intellij-html-description": "name of the image to be built.",
+              "examples": [
+                "gcr.io/k8s-skaffold/example"
+              ]
+            },
+            "platforms": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "description": "list of platforms to build this artifact image for. It overrides the values inferred through heuristics or provided in the top level `platforms` property or in the global config. If the target builder cannot build for atleast one of the specified platforms, then the build fails. Each platform is of the format `os[/arch[/variant]]`, e.g., `linux/amd64`. Example: `[\"linux/amd64\", \"linux/arm64\"]`.",
+              "x-intellij-html-description": "list of platforms to build this artifact image for. It overrides the values inferred through heuristics or provided in the top level <code>platforms</code> property or in the global config. If the target builder cannot build for atleast one of the specified platforms, then the build fails. Each platform is of the format <code>os[/arch[/variant]]</code>, e.g., <code>linux/amd64</code>. Example: <code>[&quot;linux/amd64&quot;, &quot;linux/arm64&quot;]</code>.",
+              "default": "[]"
+            },
+            "requires": {
+              "items": {
+                "$ref": "#/definitions/ArtifactDependency"
+              },
+              "type": "array",
+              "description": "describes build artifacts that this artifact depends on.",
+              "x-intellij-html-description": "describes build artifacts that this artifact depends on."
+            },
+            "runtimeType": {
+              "type": "string",
+              "description": "specifies the target language runtime for this artifact that is used to configure debug support. Should be one of `go`, `nodejs`, `jvm`, `python` or `netcore`. If unspecified the language runtime is inferred from common heuristics for the list of supported runtimes.",
+              "x-intellij-html-description": "specifies the target language runtime for this artifact that is used to configure debug support. Should be one of <code>go</code>, <code>nodejs</code>, <code>jvm</code>, <code>python</code> or <code>netcore</code>. If unspecified the language runtime is inferred from common heuristics for the list of supported runtimes."
+            },
+            "sync": {
+              "$ref": "#/definitions/Sync",
+              "description": "*beta* local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
+              "x-intellij-html-description": "<em>beta</em> local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
+              "default": "infer: [\"**/*\"]"
+            }
+          },
+          "preferredOrder": [
+            "image",
+            "context",
+            "sync",
+            "requires",
+            "hooks",
+            "platforms",
+            "runtimeType",
+            "custom"
+          ],
+          "additionalProperties": false
+        }
+      ],
+      "description": "items that need to be built, along with the context in which they should be built.",
+      "x-intellij-html-description": "items that need to be built, along with the context in which they should be built."
+    },
+    "ArtifactDependency": {
+      "required": [
+        "image"
+      ],
+      "properties": {
+        "alias": {
+          "type": "string",
+          "description": "a token that is replaced with the image reference in the builder definition files. For example, the `docker` builder will use the alias as a build-arg key. Defaults to the value of `image`.",
+          "x-intellij-html-description": "a token that is replaced with the image reference in the builder definition files. For example, the <code>docker</code> builder will use the alias as a build-arg key. Defaults to the value of <code>image</code>."
+        },
+        "image": {
+          "type": "string",
+          "description": "a reference to an artifact's image name.",
+          "x-intellij-html-description": "a reference to an artifact's image name."
+        }
+      },
+      "preferredOrder": [
+        "image",
+        "alias"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "describes a specific build dependency for an artifact.",
+      "x-intellij-html-description": "describes a specific build dependency for an artifact."
+    },
+    "BazelArtifact": {
+      "required": [
+        "target"
+      ],
+      "properties": {
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "additional args to pass to `bazel build`.",
+          "x-intellij-html-description": "additional args to pass to <code>bazel build</code>.",
+          "default": "[]",
+          "examples": [
+            "[\"-flag\", \"--otherflag\"]"
+          ]
+        },
+        "target": {
+          "type": "string",
+          "description": "`bazel build` target to run.",
+          "x-intellij-html-description": "<code>bazel build</code> target to run.",
+          "examples": [
+            "//:skaffold_example.tar"
+          ]
+        }
+      },
+      "preferredOrder": [
+        "target",
+        "args"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "describes an artifact built with [Bazel](https://bazel.build/).",
+      "x-intellij-html-description": "describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
+    },
+    "BuildConfig": {
+      "type": "object",
+      "anyOf": [
+        {
+          "properties": {
+            "artifacts": {
+              "items": {
+                "$ref": "#/definitions/Artifact"
+              },
+              "type": "array",
+              "description": "the images you're going to be building.",
+              "x-intellij-html-description": "the images you're going to be building."
+            },
+            "insecureRegistries": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "description": "a list of registries declared by the user to be insecure. These registries will be connected to via HTTP instead of HTTPS.",
+              "x-intellij-html-description": "a list of registries declared by the user to be insecure. These registries will be connected to via HTTP instead of HTTPS.",
+              "default": "[]"
+            },
+            "platforms": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "description": "list of platforms to build all artifact images for. It can be overridden by the individual artifact's `platforms` property. If the target builder cannot build for atleast one of the specified platforms, then the build fails. Each platform is of the format `os[/arch[/variant]]`, e.g., `linux/amd64`. Example: `[\"linux/amd64\", \"linux/arm64\"]`.",
+              "x-intellij-html-description": "list of platforms to build all artifact images for. It can be overridden by the individual artifact's <code>platforms</code> property. If the target builder cannot build for atleast one of the specified platforms, then the build fails. Each platform is of the format <code>os[/arch[/variant]]</code>, e.g., <code>linux/amd64</code>. Example: <code>[&quot;linux/amd64&quot;, &quot;linux/arm64&quot;]</code>.",
+              "default": "[]"
+            },
+            "tagPolicy": {
+              "$ref": "#/definitions/TagPolicy",
+              "description": "*beta* determines how images are tagged. A few strategies are provided here, although you most likely won't need to care! If not specified, it defaults to `gitCommit: {variant: Tags}`.",
+              "x-intellij-html-description": "<em>beta</em> determines how images are tagged. A few strategies are provided here, although you most likely won't need to care! If not specified, it defaults to <code>gitCommit: {variant: Tags}</code>."
+            }
+          },
+          "preferredOrder": [
+            "artifacts",
+            "insecureRegistries",
+            "tagPolicy",
+            "platforms"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "artifacts": {
+              "items": {
+                "$ref": "#/definitions/Artifact"
+              },
+              "type": "array",
+              "description": "the images you're going to be building.",
+              "x-intellij-html-description": "the images you're going to be building."
+            },
+            "insecureRegistries": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "description": "a list of registries declared by the user to be insecure. These registries will be connected to via HTTP instead of HTTPS.",
+              "x-intellij-html-description": "a list of registries declared by the user to be insecure. These registries will be connected to via HTTP instead of HTTPS.",
+              "default": "[]"
+            },
+            "local": {
+              "$ref": "#/definitions/LocalBuild",
+              "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
+              "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
+            },
+            "platforms": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "description": "list of platforms to build all artifact images for. It can be overridden by the individual artifact's `platforms` property. If the target builder cannot build for atleast one of the specified platforms, then the build fails. Each platform is of the format `os[/arch[/variant]]`, e.g., `linux/amd64`. Example: `[\"linux/amd64\", \"linux/arm64\"]`.",
+              "x-intellij-html-description": "list of platforms to build all artifact images for. It can be overridden by the individual artifact's <code>platforms</code> property. If the target builder cannot build for atleast one of the specified platforms, then the build fails. Each platform is of the format <code>os[/arch[/variant]]</code>, e.g., <code>linux/amd64</code>. Example: <code>[&quot;linux/amd64&quot;, &quot;linux/arm64&quot;]</code>.",
+              "default": "[]"
+            },
+            "tagPolicy": {
+              "$ref": "#/definitions/TagPolicy",
+              "description": "*beta* determines how images are tagged. A few strategies are provided here, although you most likely won't need to care! If not specified, it defaults to `gitCommit: {variant: Tags}`.",
+              "x-intellij-html-description": "<em>beta</em> determines how images are tagged. A few strategies are provided here, although you most likely won't need to care! If not specified, it defaults to <code>gitCommit: {variant: Tags}</code>."
+            }
+          },
+          "preferredOrder": [
+            "artifacts",
+            "insecureRegistries",
+            "tagPolicy",
+            "platforms",
+            "local"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "artifacts": {
+              "items": {
+                "$ref": "#/definitions/Artifact"
+              },
+              "type": "array",
+              "description": "the images you're going to be building.",
+              "x-intellij-html-description": "the images you're going to be building."
+            },
+            "googleCloudBuild": {
+              "$ref": "#/definitions/GoogleCloudBuild",
+              "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/).",
+              "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/\">Google Cloud Build</a>."
+            },
+            "insecureRegistries": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "description": "a list of registries declared by the user to be insecure. These registries will be connected to via HTTP instead of HTTPS.",
+              "x-intellij-html-description": "a list of registries declared by the user to be insecure. These registries will be connected to via HTTP instead of HTTPS.",
+              "default": "[]"
+            },
+            "platforms": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "description": "list of platforms to build all artifact images for. It can be overridden by the individual artifact's `platforms` property. If the target builder cannot build for atleast one of the specified platforms, then the build fails. Each platform is of the format `os[/arch[/variant]]`, e.g., `linux/amd64`. Example: `[\"linux/amd64\", \"linux/arm64\"]`.",
+              "x-intellij-html-description": "list of platforms to build all artifact images for. It can be overridden by the individual artifact's <code>platforms</code> property. If the target builder cannot build for atleast one of the specified platforms, then the build fails. Each platform is of the format <code>os[/arch[/variant]]</code>, e.g., <code>linux/amd64</code>. Example: <code>[&quot;linux/amd64&quot;, &quot;linux/arm64&quot;]</code>.",
+              "default": "[]"
+            },
+            "tagPolicy": {
+              "$ref": "#/definitions/TagPolicy",
+              "description": "*beta* determines how images are tagged. A few strategies are provided here, although you most likely won't need to care! If not specified, it defaults to `gitCommit: {variant: Tags}`.",
+              "x-intellij-html-description": "<em>beta</em> determines how images are tagged. A few strategies are provided here, although you most likely won't need to care! If not specified, it defaults to <code>gitCommit: {variant: Tags}</code>."
+            }
+          },
+          "preferredOrder": [
+            "artifacts",
+            "insecureRegistries",
+            "tagPolicy",
+            "platforms",
+            "googleCloudBuild"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "artifacts": {
+              "items": {
+                "$ref": "#/definitions/Artifact"
+              },
+              "type": "array",
+              "description": "the images you're going to be building.",
+              "x-intellij-html-description": "the images you're going to be building."
+            },
+            "cluster": {
+              "$ref": "#/definitions/ClusterDetails",
+              "description": "*beta* describes how to do an on-cluster build.",
+              "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
+            },
+            "insecureRegistries": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "description": "a list of registries declared by the user to be insecure. These registries will be connected to via HTTP instead of HTTPS.",
+              "x-intellij-html-description": "a list of registries declared by the user to be insecure. These registries will be connected to via HTTP instead of HTTPS.",
+              "default": "[]"
+            },
+            "platforms": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "description": "list of platforms to build all artifact images for. It can be overridden by the individual artifact's `platforms` property. If the target builder cannot build for atleast one of the specified platforms, then the build fails. Each platform is of the format `os[/arch[/variant]]`, e.g., `linux/amd64`. Example: `[\"linux/amd64\", \"linux/arm64\"]`.",
+              "x-intellij-html-description": "list of platforms to build all artifact images for. It can be overridden by the individual artifact's <code>platforms</code> property. If the target builder cannot build for atleast one of the specified platforms, then the build fails. Each platform is of the format <code>os[/arch[/variant]]</code>, e.g., <code>linux/amd64</code>. Example: <code>[&quot;linux/amd64&quot;, &quot;linux/arm64&quot;]</code>.",
+              "default": "[]"
+            },
+            "tagPolicy": {
+              "$ref": "#/definitions/TagPolicy",
+              "description": "*beta* determines how images are tagged. A few strategies are provided here, although you most likely won't need to care! If not specified, it defaults to `gitCommit: {variant: Tags}`.",
+              "x-intellij-html-description": "<em>beta</em> determines how images are tagged. A few strategies are provided here, although you most likely won't need to care! If not specified, it defaults to <code>gitCommit: {variant: Tags}</code>."
+            }
+          },
+          "preferredOrder": [
+            "artifacts",
+            "insecureRegistries",
+            "tagPolicy",
+            "platforms",
+            "cluster"
+          ],
+          "additionalProperties": false
+        }
+      ],
+      "description": "contains all the configuration for the build steps.",
+      "x-intellij-html-description": "contains all the configuration for the build steps."
+    },
+    "BuildHooks": {
+      "properties": {
+        "after": {
+          "items": {
+            "$ref": "#/definitions/HostHook"
+          },
+          "type": "array",
+          "description": "describes the list of lifecycle hooks to execute *after* each artifact build step.",
+          "x-intellij-html-description": "describes the list of lifecycle hooks to execute <em>after</em> each artifact build step."
+        },
+        "before": {
+          "items": {
+            "$ref": "#/definitions/HostHook"
+          },
+          "type": "array",
+          "description": "describes the list of lifecycle hooks to execute *before* each artifact build step.",
+          "x-intellij-html-description": "describes the list of lifecycle hooks to execute <em>before</em> each artifact build step."
+        }
+      },
+      "preferredOrder": [
+        "before",
+        "after"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "describes the list of lifecycle hooks to execute before and after each artifact build step.",
+      "x-intellij-html-description": "describes the list of lifecycle hooks to execute before and after each artifact build step."
+    },
+    "BuildpackArtifact": {
+      "properties": {
+        "builder": {
+          "type": "string",
+          "description": "builder image used.",
+          "x-intellij-html-description": "builder image used."
+        },
+        "buildpacks": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "a list of strings, where each string is a specific buildpack to use with the builder. If you specify buildpacks the builder image automatic detection will be ignored. These buildpacks will be used to build the Image from your source code. Order matters.",
+          "x-intellij-html-description": "a list of strings, where each string is a specific buildpack to use with the builder. If you specify buildpacks the builder image automatic detection will be ignored. These buildpacks will be used to build the Image from your source code. Order matters.",
+          "default": "[]"
+        },
+        "clearCache": {
+          "type": "boolean",
+          "description": "removes old cache volume associated with the specific image and supplies a clean cache volume for build.",
+          "x-intellij-html-description": "removes old cache volume associated with the specific image and supplies a clean cache volume for build.",
+          "default": "false"
+        },
+        "dependencies": {
+          "$ref": "#/definitions/BuildpackDependencies",
+          "description": "file dependencies that skaffold should watch for both rebuilding and file syncing for this artifact.",
+          "x-intellij-html-description": "file dependencies that skaffold should watch for both rebuilding and file syncing for this artifact."
+        },
+        "env": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "environment variables, in the `key=value` form,  passed to the build. Values can use the go template syntax.",
+          "x-intellij-html-description": "environment variables, in the <code>key=value</code> form,  passed to the build. Values can use the go template syntax.",
+          "default": "[]",
+          "examples": [
+            "[\"key1=value1\", \"key2=value2\", \"key3={{.ENV_VARIABLE}}\"]"
+          ]
+        },
+        "projectDescriptor": {
+          "type": "string",
+          "description": "path to the project descriptor file.",
+          "x-intellij-html-description": "path to the project descriptor file.",
+          "default": "project.toml"
+        },
+        "runImage": {
+          "type": "string",
+          "description": "overrides the stack's default run image.",
+          "x-intellij-html-description": "overrides the stack's default run image."
+        },
+        "trustBuilder": {
+          "type": "boolean",
+          "description": "indicates that the builder should be trusted.",
+          "x-intellij-html-description": "indicates that the builder should be trusted.",
+          "default": "false"
+        },
+        "volumes": {
+          "items": {
+            "$ref": "#/definitions/BuildpackVolume"
+          },
+          "type": "array",
+          "description": "support mounting host volumes into the container.",
+          "x-intellij-html-description": "support mounting host volumes into the container."
+        }
+      },
+      "preferredOrder": [
+        "builder",
+        "runImage",
+        "env",
+        "buildpacks",
+        "trustBuilder",
+        "clearCache",
+        "projectDescriptor",
+        "dependencies",
+        "volumes"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "*alpha* describes an artifact built using [Cloud Native Buildpacks](https://buildpacks.io/). It can be used to build images out of project's sources without any additional configuration.",
+      "x-intellij-html-description": "<em>alpha</em> describes an artifact built using <a href=\"https://buildpacks.io/\">Cloud Native Buildpacks</a>. It can be used to build images out of project's sources without any additional configuration."
+    },
+    "BuildpackDependencies": {
+      "properties": {
+        "ignore": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "specifies the paths that should be ignored by skaffold's file watcher. If a file exists in both `paths` and in `ignore`, it will be ignored, and will be excluded from both rebuilds and file synchronization. Will only work in conjunction with `paths`.",
+          "x-intellij-html-description": "specifies the paths that should be ignored by skaffold's file watcher. If a file exists in both <code>paths</code> and in <code>ignore</code>, it will be ignored, and will be excluded from both rebuilds and file synchronization. Will only work in conjunction with <code>paths</code>.",
+          "default": "[]"
+        },
+        "paths": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "should be set to the file dependencies for this artifact, so that the skaffold file watcher knows when to rebuild and perform file synchronization.",
+          "x-intellij-html-description": "should be set to the file dependencies for this artifact, so that the skaffold file watcher knows when to rebuild and perform file synchronization.",
+          "default": "[]"
+        }
+      },
+      "preferredOrder": [
+        "paths",
+        "ignore"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "*alpha* used to specify dependencies for an artifact built by buildpacks.",
+      "x-intellij-html-description": "<em>alpha</em> used to specify dependencies for an artifact built by buildpacks."
+    },
+    "BuildpackVolume": {
+      "required": [
+        "host",
+        "target"
+      ],
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "local volume or absolute directory of the path to mount.",
+          "x-intellij-html-description": "local volume or absolute directory of the path to mount."
+        },
+        "options": {
+          "type": "string",
+          "description": "specify a list of comma-separated mount options. Valid options are: `ro` (default): volume contents are read-only. `rw`: volume contents are readable and writable. `volume-opt=<key>=<value>`: can be specified more than once, takes a key-value pair.",
+          "x-intellij-html-description": "specify a list of comma-separated mount options. Valid options are: <code>ro</code> (default): volume contents are read-only. <code>rw</code>: volume contents are readable and writable. <code>volume-opt=&lt;key&gt;=&lt;value&gt;</code>: can be specified more than once, takes a key-value pair.",
+          "enum": [
+            "ro",
+            "rw",
+            "volume-opt=<key>=<value>"
+          ]
+        },
+        "target": {
+          "type": "string",
+          "description": "path where the file or directory is available in the container. It is strongly recommended to not specify locations under `/cnb` or `/layers`.",
+          "x-intellij-html-description": "path where the file or directory is available in the container. It is strongly recommended to not specify locations under <code>/cnb</code> or <code>/layers</code>."
+        }
+      },
+      "preferredOrder": [
+        "host",
+        "target",
+        "options"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "*alpha* used to mount host volumes or directories in the build container.",
+      "x-intellij-html-description": "<em>alpha</em> used to mount host volumes or directories in the build container."
+    },
+    "CloudRunDeploy": {
+      "properties": {
+        "hooks": {
+          "$ref": "#/definitions/CloudRunDeployHooks",
+          "description": "describes a set of lifecycle host hooks that are executed before and after the Cloud Run deployer.",
+          "x-intellij-html-description": "describes a set of lifecycle host hooks that are executed before and after the Cloud Run deployer."
+        },
+        "projectid": {
+          "type": "string",
+          "description": "the GCP Project to use for Cloud Run. If specified, all Services will be deployed to this project. If not specified, each Service will be deployed to the project specified in `metadata.namespace` of the Cloud Run manifest.",
+          "x-intellij-html-description": "the GCP Project to use for Cloud Run. If specified, all Services will be deployed to this project. If not specified, each Service will be deployed to the project specified in <code>metadata.namespace</code> of the Cloud Run manifest."
+        },
+        "region": {
+          "type": "string",
+          "description": "GCP location to use for the Cloud Run Deploy. Must be one of the regions listed in https://cloud.google.com/run/docs/locations.",
+          "x-intellij-html-description": "GCP location to use for the Cloud Run Deploy. Must be one of the regions listed in https://cloud.google.com/run/docs/locations."
+        }
+      },
+      "preferredOrder": [
+        "projectid",
+        "region",
+        "hooks"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "*alpha* deploys the container to Google Cloud Run.",
+      "x-intellij-html-description": "<em>alpha</em> deploys the container to Google Cloud Run."
+    },
+    "CloudRunDeployHooks": {
+      "properties": {
+        "after": {
+          "items": {
+            "$ref": "#/definitions/HostHook"
+          },
+          "type": "array",
+          "description": "describes the list of lifecycle hooks to execute *after* the Cloud Run deployer.",
+          "x-intellij-html-description": "describes the list of lifecycle hooks to execute <em>after</em> the Cloud Run deployer."
+        },
+        "before": {
+          "items": {
+            "$ref": "#/definitions/HostHook"
+          },
+          "type": "array",
+          "description": "describes the list of lifecycle hooks to execute *before* the Cloud Run deployer.",
+          "x-intellij-html-description": "describes the list of lifecycle hooks to execute <em>before</em> the Cloud Run deployer."
+        }
+      },
+      "preferredOrder": [
+        "before",
+        "after"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "describes the list of lifecycle hooks to execute in the host before and after the Cloud Run deployer.",
+      "x-intellij-html-description": "describes the list of lifecycle hooks to execute in the host before and after the Cloud Run deployer."
+    },
+    "ClusterDetails": {
+      "properties": {
+        "HTTPS_PROXY": {
+          "type": "string",
+          "description": "for kaniko pod.",
+          "x-intellij-html-description": "for kaniko pod."
+        },
+        "HTTP_PROXY": {
+          "type": "string",
+          "description": "for kaniko pod.",
+          "x-intellij-html-description": "for kaniko pod."
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "describes the Kubernetes annotations for the pod.",
+          "x-intellij-html-description": "describes the Kubernetes annotations for the pod.",
+          "default": "{}"
+        },
+        "concurrency": {
+          "type": "integer",
+          "description": "how many artifacts can be built concurrently. 0 means \"no-limit\".",
+          "x-intellij-html-description": "how many artifacts can be built concurrently. 0 means &quot;no-limit&quot;.",
+          "default": "0"
+        },
+        "dockerConfig": {
+          "$ref": "#/definitions/DockerConfig",
+          "description": "describes how to mount the local Docker configuration into a pod.",
+          "x-intellij-html-description": "describes how to mount the local Docker configuration into a pod."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Kubernetes namespace. Defaults to current namespace in Kubernetes configuration.",
+          "x-intellij-html-description": "Kubernetes namespace. Defaults to current namespace in Kubernetes configuration."
+        },
+        "nodeSelector": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "describes the Kubernetes node selector for the pod.",
+          "x-intellij-html-description": "describes the Kubernetes node selector for the pod.",
+          "default": "{}"
+        },
+        "pullSecretMountPath": {
+          "type": "string",
+          "description": "path the pull secret will be mounted at within the running container.",
+          "x-intellij-html-description": "path the pull secret will be mounted at within the running container."
+        },
+        "pullSecretName": {
+          "type": "string",
+          "description": "name of the Kubernetes secret for pulling base images and pushing the final image. If given, the secret needs to contain the Google Cloud service account secret key under the key `kaniko-secret`.",
+          "x-intellij-html-description": "name of the Kubernetes secret for pulling base images and pushing the final image. If given, the secret needs to contain the Google Cloud service account secret key under the key <code>kaniko-secret</code>.",
+          "default": "kaniko-secret"
+        },
+        "pullSecretPath": {
+          "type": "string",
+          "description": "path to the Google Cloud service account secret key file.",
+          "x-intellij-html-description": "path to the Google Cloud service account secret key file."
+        },
+        "randomDockerConfigSecret": {
+          "type": "boolean",
+          "description": "adds a random UUID postfix to the default name of the docker secret to facilitate parallel builds, e.g. docker-cfgfd154022-c761-416f-8eb3-cf8258450b85.",
+          "x-intellij-html-description": "adds a random UUID postfix to the default name of the docker secret to facilitate parallel builds, e.g. docker-cfgfd154022-c761-416f-8eb3-cf8258450b85.",
+          "default": "false"
+        },
+        "randomPullSecret": {
+          "type": "boolean",
+          "description": "adds a random UUID postfix to the default name of the pull secret to facilitate parallel builds, e.g. kaniko-secretdocker-cfgfd154022-c761-416f-8eb3-cf8258450b85.",
+          "x-intellij-html-description": "adds a random UUID postfix to the default name of the pull secret to facilitate parallel builds, e.g. kaniko-secretdocker-cfgfd154022-c761-416f-8eb3-cf8258450b85.",
+          "default": "false"
+        },
+        "resources": {
+          "$ref": "#/definitions/ResourceRequirements",
+          "description": "define the resource requirements for the kaniko pod.",
+          "x-intellij-html-description": "define the resource requirements for the kaniko pod."
+        },
+        "runAsUser": {
+          "type": "integer",
+          "description": "defines the UID to request for running the container. If omitted, no SecurityContext will be specified for the pod and will therefore be inherited from the service account.",
+          "x-intellij-html-description": "defines the UID to request for running the container. If omitted, no SecurityContext will be specified for the pod and will therefore be inherited from the service account."
+        },
+        "serviceAccount": {
+          "type": "string",
+          "description": "describes the Kubernetes service account to use for the pod. Defaults to 'default'.",
+          "x-intellij-html-description": "describes the Kubernetes service account to use for the pod. Defaults to 'default'."
+        },
+        "timeout": {
+          "type": "string",
+          "description": "amount of time (in seconds) that this build is allowed to run. Defaults to 20 minutes (`20m`).",
+          "x-intellij-html-description": "amount of time (in seconds) that this build is allowed to run. Defaults to 20 minutes (<code>20m</code>)."
+        },
+        "tolerations": {
+          "items": {},
+          "type": "array",
+          "description": "describes the Kubernetes tolerations for the pod.",
+          "x-intellij-html-description": "describes the Kubernetes tolerations for the pod.",
+          "default": "[]"
+        },
+        "volumes": {
+          "items": {},
+          "type": "array",
+          "description": "defines container mounts for ConfigMap and Secret resources.",
+          "x-intellij-html-description": "defines container mounts for ConfigMap and Secret resources.",
+          "default": "[]"
+        }
+      },
+      "preferredOrder": [
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "pullSecretPath",
+        "pullSecretName",
+        "pullSecretMountPath",
+        "namespace",
+        "timeout",
+        "dockerConfig",
+        "serviceAccount",
+        "tolerations",
+        "nodeSelector",
+        "annotations",
+        "runAsUser",
+        "resources",
+        "concurrency",
+        "volumes",
+        "randomPullSecret",
+        "randomDockerConfigSecret"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "*beta* describes how to do an on-cluster build.",
+      "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
+    },
+    "ConfigDependency": {
+      "properties": {
+        "activeProfiles": {
+          "items": {
+            "$ref": "#/definitions/ProfileDependency"
+          },
+          "type": "array",
+          "description": "describes the list of profiles to activate when resolving the required configs. These profiles must exist in the imported config.",
+          "x-intellij-html-description": "describes the list of profiles to activate when resolving the required configs. These profiles must exist in the imported config."
+        },
+        "configs": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "includes specific named configs within the file path. If empty, then all configs in the file are included.",
+          "x-intellij-html-description": "includes specific named configs within the file path. If empty, then all configs in the file are included.",
+          "default": "[]"
+        },
+        "git": {
+          "$ref": "#/definitions/GitInfo",
+          "description": "describes a remote git repository containing the required configs.",
+          "x-intellij-html-description": "describes a remote git repository containing the required configs."
+        },
+        "path": {
+          "type": "string",
+          "description": "describes the path to the file containing the required configs.",
+          "x-intellij-html-description": "describes the path to the file containing the required configs."
+        }
+      },
+      "preferredOrder": [
+        "configs",
+        "path",
+        "git",
+        "activeProfiles"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "describes a dependency on another skaffold configuration.",
+      "x-intellij-html-description": "describes a dependency on another skaffold configuration."
+    },
+    "ContainerHook": {
+      "required": [
+        "command"
+      ],
+      "properties": {
+        "command": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "command to execute.",
+          "x-intellij-html-description": "command to execute.",
+          "default": "[]"
+        }
+      },
+      "preferredOrder": [
+        "command"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "describes a lifecycle hook definition to execute on a container. The container name is inferred from the scope in which this hook is defined.",
+      "x-intellij-html-description": "describes a lifecycle hook definition to execute on a container. The container name is inferred from the scope in which this hook is defined."
+    },
+    "CustomArtifact": {
+      "properties": {
+        "buildCommand": {
+          "type": "string",
+          "description": "command executed to build the image.",
+          "x-intellij-html-description": "command executed to build the image."
+        },
+        "dependencies": {
+          "$ref": "#/definitions/CustomDependencies",
+          "description": "file dependencies that skaffold should watch for both rebuilding and file syncing for this artifact.",
+          "x-intellij-html-description": "file dependencies that skaffold should watch for both rebuilding and file syncing for this artifact."
+        }
+      },
+      "preferredOrder": [
+        "buildCommand",
+        "dependencies"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "*beta* describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold.",
+      "x-intellij-html-description": "<em>beta</em> describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold."
+    },
+    "CustomDependencies": {
+      "properties": {
+        "command": {
+          "type": "string",
+          "description": "represents a custom command that skaffold executes to obtain dependencies. The output of this command *must* be a valid JSON array.",
+          "x-intellij-html-description": "represents a custom command that skaffold executes to obtain dependencies. The output of this command <em>must</em> be a valid JSON array."
+        },
+        "dockerfile": {
+          "$ref": "#/definitions/DockerfileDependency",
+          "description": "should be set if the artifact is built from a Dockerfile, from which skaffold can determine dependencies.",
+          "x-intellij-html-description": "should be set if the artifact is built from a Dockerfile, from which skaffold can determine dependencies."
+        },
+        "ignore": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "specifies the paths that should be ignored by skaffold's file watcher. If a file exists in both `paths` and in `ignore`, it will be ignored, and will be excluded from both rebuilds and file synchronization. Will only work in conjunction with `paths`.",
+          "x-intellij-html-description": "specifies the paths that should be ignored by skaffold's file watcher. If a file exists in both <code>paths</code> and in <code>ignore</code>, it will be ignored, and will be excluded from both rebuilds and file synchronization. Will only work in conjunction with <code>paths</code>.",
+          "default": "[]"
+        },
+        "paths": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "should be set to the file dependencies for this artifact, so that the skaffold file watcher knows when to rebuild and perform file synchronization.",
+          "x-intellij-html-description": "should be set to the file dependencies for this artifact, so that the skaffold file watcher knows when to rebuild and perform file synchronization.",
+          "default": "[]"
+        }
+      },
+      "preferredOrder": [
+        "dockerfile",
+        "command",
+        "paths",
+        "ignore"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "*beta* used to specify dependencies for an artifact built by a custom build script. Either `dockerfile` or `paths` should be specified for file watching to work as expected.",
+      "x-intellij-html-description": "<em>beta</em> used to specify dependencies for an artifact built by a custom build script. Either <code>dockerfile</code> or <code>paths</code> should be specified for file watching to work as expected."
+    },
+    "CustomTemplateTagger": {
+      "required": [
+        "template"
+      ],
+      "properties": {
+        "components": {
+          "items": {
+            "$ref": "#/definitions/TaggerComponent"
+          },
+          "type": "array",
+          "description": "TaggerComponents that the template (see field above) can be executed against.",
+          "x-intellij-html-description": "TaggerComponents that the template (see field above) can be executed against."
+        },
+        "template": {
+          "type": "string",
+          "description": "used to produce the image name and tag. See golang [text/template](https://golang.org/pkg/text/template/). The template is executed against the provided components with those variables injected.",
+          "x-intellij-html-description": "used to produce the image name and tag. See golang <a href=\"https://golang.org/pkg/text/template/\">text/template</a>. The template is executed against the provided components with those variables injected.",
+          "examples": [
+            "{{.DATE}}"
+          ]
+        }
+      },
+      "preferredOrder": [
+        "template",
+        "components"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "*beta* tags images with a configurable template string.",
+      "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
+    },
+    "CustomTest": {
+      "required": [
+        "command"
+      ],
+      "properties": {
+        "command": {
+          "type": "string",
+          "description": "custom command to be executed.  If the command exits with a non-zero return code, the test will be considered to have failed.",
+          "x-intellij-html-description": "custom command to be executed.  If the command exits with a non-zero return code, the test will be considered to have failed."
+        },
+        "dependencies": {
+          "$ref": "#/definitions/CustomTestDependencies",
+          "description": "additional test-specific file dependencies; changes to these files will re-run this test.",
+          "x-intellij-html-description": "additional test-specific file dependencies; changes to these files will re-run this test."
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "description": "sets the wait time for skaffold for the command to complete. If unset or 0, Skaffold will wait until the command completes.",
+          "x-intellij-html-description": "sets the wait time for skaffold for the command to complete. If unset or 0, Skaffold will wait until the command completes."
+        }
+      },
+      "preferredOrder": [
+        "command",
+        "timeoutSeconds",
+        "dependencies"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "describes the custom test command provided by the user. Custom tests are run after an image build whenever build or test dependencies are changed.",
+      "x-intellij-html-description": "describes the custom test command provided by the user. Custom tests are run after an image build whenever build or test dependencies are changed."
+    },
+    "CustomTestDependencies": {
+      "properties": {
+        "command": {
+          "type": "string",
+          "description": "represents a command that skaffold executes to obtain dependencies. The output of this command *must* be a valid JSON array.",
+          "x-intellij-html-description": "represents a command that skaffold executes to obtain dependencies. The output of this command <em>must</em> be a valid JSON array."
+        },
+        "ignore": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "specifies the paths that should be ignored by skaffold's file watcher. If a file exists in both `paths` and in `ignore`, it will be ignored, and will be excluded from both retest and file synchronization. Will only work in conjunction with `paths`.",
+          "x-intellij-html-description": "specifies the paths that should be ignored by skaffold's file watcher. If a file exists in both <code>paths</code> and in <code>ignore</code>, it will be ignored, and will be excluded from both retest and file synchronization. Will only work in conjunction with <code>paths</code>.",
+          "default": "[]"
+        },
+        "paths": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "locates the file dependencies for the command relative to workspace. Paths should be set to the file dependencies for this command, so that the skaffold file watcher knows when to retest and perform file synchronization.",
+          "x-intellij-html-description": "locates the file dependencies for the command relative to workspace. Paths should be set to the file dependencies for this command, so that the skaffold file watcher knows when to retest and perform file synchronization.",
+          "default": "[]",
+          "examples": [
+            "[\"src/test/**\"]"
+          ]
+        }
+      },
+      "preferredOrder": [
+        "command",
+        "paths",
+        "ignore"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "used to specify dependencies for custom test command. `paths` should be specified for file watching to work as expected.",
+      "x-intellij-html-description": "used to specify dependencies for custom test command. <code>paths</code> should be specified for file watching to work as expected."
+    },
+    "DateTimeTagger": {
+      "properties": {
+        "format": {
+          "type": "string",
+          "description": "formats the date and time. See [#Time.Format](https://golang.org/pkg/time/#Time.Format).",
+          "x-intellij-html-description": "formats the date and time. See <a href=\"https://golang.org/pkg/time/#Time.Format\">#Time.Format</a>.",
+          "default": "2006-01-02_15-04-05.999_MST"
+        },
+        "timezone": {
+          "type": "string",
+          "description": "sets the timezone for the date and time. See [Time.LoadLocation](https://golang.org/pkg/time/#Time.LoadLocation). Defaults to the local timezone.",
+          "x-intellij-html-description": "sets the timezone for the date and time. See <a href=\"https://golang.org/pkg/time/#Time.LoadLocation\">Time.LoadLocation</a>. Defaults to the local timezone."
+        }
+      },
+      "preferredOrder": [
+        "format",
+        "timezone"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "*beta* tags images with the build timestamp.",
+      "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
+    },
+    "DeployConfig": {
+      "properties": {
+        "cloudrun": {
+          "$ref": "#/definitions/CloudRunDeploy",
+          "description": "*alpha* deploys to Google Cloud Run using the Cloud Run v1 API.",
+          "x-intellij-html-description": "<em>alpha</em> deploys to Google Cloud Run using the Cloud Run v1 API."
+        },
+        "docker": {
+          "$ref": "#/definitions/DockerDeploy",
+          "description": "*alpha* uses the `docker` CLI to create application containers in Docker.",
+          "x-intellij-html-description": "<em>alpha</em> uses the <code>docker</code> CLI to create application containers in Docker."
+        },
+        "helm": {
+          "$ref": "#/definitions/LegacyHelmDeploy",
+          "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
+          "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
+        },
+        "kpt": {
+          "$ref": "#/definitions/KptDeploy",
+          "description": "*alpha* uses the `kpt` CLI to manage and deploy manifests.",
+          "x-intellij-html-description": "<em>alpha</em> uses the <code>kpt</code> CLI to manage and deploy manifests."
+        },
+        "kubeContext": {
+          "type": "string",
+          "description": "Kubernetes context that Skaffold should deploy to.",
+          "x-intellij-html-description": "Kubernetes context that Skaffold should deploy to.",
+          "examples": [
+            "minikube"
+          ]
+        },
+        "kubectl": {
+          "$ref": "#/definitions/KubectlDeploy",
+          "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
+          "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
+        },
+        "logs": {
+          "$ref": "#/definitions/LogsConfig",
+          "description": "configures how container logs are printed as a result of a deployment.",
+          "x-intellij-html-description": "configures how container logs are printed as a result of a deployment."
+        },
+        "statusCheck": {
+          "type": "boolean",
+          "description": "*beta* enables waiting for deployments to stabilize.",
+          "x-intellij-html-description": "<em>beta</em> enables waiting for deployments to stabilize."
+        },
+        "statusCheckDeadlineSeconds": {
+          "type": "integer",
+          "description": "*beta* deadline for deployments to stabilize in seconds.",
+          "x-intellij-html-description": "<em>beta</em> deadline for deployments to stabilize in seconds."
+        },
+        "tolerateFailuresUntilDeadline": {
+          "type": "boolean",
+          "description": "configures the Skaffold \"status-check\" to tolerate failures (flapping deployments, etc.) until the statusCheckDeadlineSeconds duration or k8s object timeouts such as progressDeadlineSeconds, etc.",
+          "x-intellij-html-description": "configures the Skaffold &quot;status-check&quot; to tolerate failures (flapping deployments, etc.) until the statusCheckDeadlineSeconds duration or k8s object timeouts such as progressDeadlineSeconds, etc.",
+          "default": "false"
+        }
+      },
+      "preferredOrder": [
+        "docker",
+        "helm",
+        "kpt",
+        "kubectl",
+        "cloudrun",
+        "statusCheck",
+        "statusCheckDeadlineSeconds",
+        "tolerateFailuresUntilDeadline",
+        "kubeContext",
+        "logs"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "contains all the configuration needed by the deploy steps.",
+      "x-intellij-html-description": "contains all the configuration needed by the deploy steps."
+    },
+    "DeployHookItem": {
+      "properties": {
+        "container": {
+          "$ref": "#/definitions/NamedContainerHook",
+          "description": "describes a single lifecycle hook to run on a container.",
+          "x-intellij-html-description": "describes a single lifecycle hook to run on a container."
+        },
+        "host": {
+          "$ref": "#/definitions/HostHook",
+          "description": "describes a single lifecycle hook to run on the host machine.",
+          "x-intellij-html-description": "describes a single lifecycle hook to run on the host machine."
+        }
+      },
+      "preferredOrder": [
+        "host",
+        "container"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "describes a single lifecycle hook to execute before or after each deployer step.",
+      "x-intellij-html-description": "describes a single lifecycle hook to execute before or after each deployer step."
+    },
+    "DeployHooks": {
+      "properties": {
+        "after": {
+          "items": {
+            "$ref": "#/definitions/DeployHookItem"
+          },
+          "type": "array",
+          "description": "describes the list of lifecycle hooks to execute *after* each deployer step.",
+          "x-intellij-html-description": "describes the list of lifecycle hooks to execute <em>after</em> each deployer step."
+        },
+        "before": {
+          "items": {
+            "$ref": "#/definitions/DeployHookItem"
+          },
+          "type": "array",
+          "description": "describes the list of lifecycle hooks to execute *before* each deployer step. Container hooks will only run if the container exists from a previous deployment step (for instance the successive iterations of a dev-loop during `skaffold dev`).",
+          "x-intellij-html-description": "describes the list of lifecycle hooks to execute <em>before</em> each deployer step. Container hooks will only run if the container exists from a previous deployment step (for instance the successive iterations of a dev-loop during <code>skaffold dev</code>)."
+        }
+      },
+      "preferredOrder": [
+        "before",
+        "after"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "describes the list of lifecycle hooks to execute before and after each deployer step.",
+      "x-intellij-html-description": "describes the list of lifecycle hooks to execute before and after each deployer step."
+    },
+    "DockerArtifact": {
+      "properties": {
+        "addHost": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "add host.",
+          "x-intellij-html-description": "add host.",
+          "default": "[]",
+          "examples": [
+            "[\"host1:ip1\", \"host2:ip2\"]"
+          ]
+        },
+        "buildArgs": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "arguments passed to the docker build.",
+          "x-intellij-html-description": "arguments passed to the docker build.",
+          "default": "{}",
+          "examples": [
+            "{\"key1\": \"value1\", \"key2\": \"{{ .ENV_VAR }}\"}"
+          ]
+        },
+        "cacheFrom": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "the Docker images used as cache sources.",
+          "x-intellij-html-description": "the Docker images used as cache sources.",
+          "default": "[]",
+          "examples": [
+            "[\"golang:1.10.1-alpine3.7\", \"alpine:3.7\"]"
+          ]
+        },
+        "cliFlags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "any additional flags to pass to the local daemon during a build. These flags are only used during a build through the Docker CLI.",
+          "x-intellij-html-description": "any additional flags to pass to the local daemon during a build. These flags are only used during a build through the Docker CLI.",
+          "default": "[]"
+        },
+        "dockerfile": {
+          "type": "string",
+          "description": "locates the Dockerfile relative to workspace.",
+          "x-intellij-html-description": "locates the Dockerfile relative to workspace.",
+          "default": "Dockerfile"
+        },
+        "network": {
+          "type": "string",
+          "description": "passed through to docker and overrides the network configuration of docker builder. If unset, use whatever is configured in the underlying docker daemon. Valid modes are `host`: use the host's networking stack. `bridge`: use the bridged network configuration. `container:<name|id>`: reuse another container's network stack. `none`: no networking in the container.",
+          "x-intellij-html-description": "passed through to docker and overrides the network configuration of docker builder. If unset, use whatever is configured in the underlying docker daemon. Valid modes are <code>host</code>: use the host's networking stack. <code>bridge</code>: use the bridged network configuration. <code>container:&lt;name|id&gt;</code>: reuse another container's network stack. <code>none</code>: no networking in the container.",
+          "enum": [
+            "host",
+            "bridge",
+            "container:<name|id>",
+            "none"
+          ]
+        },
+        "noCache": {
+          "type": "boolean",
+          "description": "set to true to pass in --no-cache to docker build, which will prevent caching.",
+          "x-intellij-html-description": "set to true to pass in --no-cache to docker build, which will prevent caching.",
+          "default": "false"
+        },
+        "pullParent": {
+          "type": "boolean",
+          "description": "used to attempt pulling the parent image even if an older image exists locally.",
+          "x-intellij-html-description": "used to attempt pulling the parent image even if an older image exists locally.",
+          "default": "false"
+        },
+        "secrets": {
+          "items": {
+            "$ref": "#/definitions/DockerSecret"
+          },
+          "type": "array",
+          "description": "used to pass in --secret to docker build, `useBuildKit: true` is required.",
+          "x-intellij-html-description": "used to pass in --secret to docker build, <code>useBuildKit: true</code> is required."
+        },
+        "squash": {
+          "type": "boolean",
+          "description": "used to pass in --squash to docker build to squash docker image layers into single layer.",
+          "x-intellij-html-description": "used to pass in --squash to docker build to squash docker image layers into single layer.",
+          "default": "false"
+        },
+        "ssh": {
+          "type": "string",
+          "description": "used to pass in --ssh to docker build to use SSH agent. Format is \"default|<id>[=<socket>|<key>[,<key>]]\".",
+          "x-intellij-html-description": "used to pass in --ssh to docker build to use SSH agent. Format is &quot;default|<id>[=<socket>|<key>[,<key>]]&quot;."
+        },
+        "target": {
+          "type": "string",
+          "description": "Dockerfile target name to build.",
+          "x-intellij-html-description": "Dockerfile target name to build."
+        }
+      },
+      "preferredOrder": [
+        "dockerfile",
+        "target",
+        "buildArgs",
+        "network",
+        "addHost",
+        "cacheFrom",
+        "cliFlags",
+        "pullParent",
+        "noCache",
+        "squash",
+        "secrets",
+        "ssh"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "describes an artifact built from a Dockerfile, usually using `docker build`.",
+      "x-intellij-html-description": "describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
+    },
+    "DockerConfig": {
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "path to the docker `config.json`.",
+          "x-intellij-html-description": "path to the docker <code>config.json</code>."
+        },
+        "secretName": {
+          "type": "string",
+          "description": "Kubernetes secret that contains the `config.json` Docker configuration. Note that the expected secret type is not 'kubernetes.io/dockerconfigjson' but 'Opaque'.",
+          "x-intellij-html-description": "Kubernetes secret that contains the <code>config.json</code> Docker configuration. Note that the expected secret type is not 'kubernetes.io/dockerconfigjson' but 'Opaque'."
+        }
+      },
+      "preferredOrder": [
+        "path",
+        "secretName"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "contains information about the docker `config.json` to mount.",
+      "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
+    },
+    "DockerDeploy": {
+      "required": [
+        "images"
+      ],
+      "properties": {
+        "images": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "container images to run in Docker.",
+          "x-intellij-html-description": "container images to run in Docker.",
+          "default": "[]"
+        },
+        "useCompose": {
+          "type": "boolean",
+          "description": "tells skaffold whether or not to deploy using `docker-compose`.",
+          "x-intellij-html-description": "tells skaffold whether or not to deploy using <code>docker-compose</code>.",
+          "default": "false"
+        }
+      },
+      "preferredOrder": [
+        "useCompose",
+        "images"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "uses the `docker` CLI to create application containers in Docker.",
+      "x-intellij-html-description": "uses the <code>docker</code> CLI to create application containers in Docker."
+    },
+    "DockerSecret": {
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "env": {
+          "type": "string",
+          "description": "environment variable name containing the secret value.",
+          "x-intellij-html-description": "environment variable name containing the secret value."
+        },
+        "id": {
+          "type": "string",
+          "description": "id of the secret.",
+          "x-intellij-html-description": "id of the secret."
+        },
+        "src": {
+          "type": "string",
+          "description": "path to the secret on the host machine.",
+          "x-intellij-html-description": "path to the secret on the host machine."
+        }
+      },
+      "preferredOrder": [
+        "id",
+        "src",
+        "env"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "used to pass in --secret to docker build, `useBuildKit: true` is required.",
+      "x-intellij-html-description": "used to pass in --secret to docker build, <code>useBuildKit: true</code> is required."
+    },
+    "DockerfileDependency": {
+      "properties": {
+        "buildArgs": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "key/value pairs used to resolve values of `ARG` instructions in a Dockerfile. Values can be constants or environment variables via the go template syntax.",
+          "x-intellij-html-description": "key/value pairs used to resolve values of <code>ARG</code> instructions in a Dockerfile. Values can be constants or environment variables via the go template syntax.",
+          "default": "{}",
+          "examples": [
+            "{\"key1\": \"value1\", \"key2\": \"value2\", \"key3\": \"'{{.ENV_VARIABLE}}'\"}"
+          ]
+        },
+        "path": {
+          "type": "string",
+          "description": "locates the Dockerfile relative to workspace.",
+          "x-intellij-html-description": "locates the Dockerfile relative to workspace."
+        }
+      },
+      "preferredOrder": [
+        "path",
+        "buildArgs"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "*beta* used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile.",
+      "x-intellij-html-description": "<em>beta</em> used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile."
+    },
+    "EnvTemplateTagger": {
+      "required": [
+        "template"
+      ],
+      "properties": {
+        "template": {
+          "type": "string",
+          "description": "used to produce the image name and tag. See golang [text/template](https://golang.org/pkg/text/template/). The template is executed against the current environment, with those variables injected.",
+          "x-intellij-html-description": "used to produce the image name and tag. See golang <a href=\"https://golang.org/pkg/text/template/\">text/template</a>. The template is executed against the current environment, with those variables injected.",
+          "examples": [
+            "{{.RELEASE}}"
+          ]
+        }
+      },
+      "preferredOrder": [
+        "template"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "*beta* tags images with a configurable template string.",
+      "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
+    },
+    "GitInfo": {
+      "required": [
+        "repo"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "relative path from the repo root to the skaffold configuration file. eg. `getting-started/skaffold.yaml`.",
+          "x-intellij-html-description": "relative path from the repo root to the skaffold configuration file. eg. <code>getting-started/skaffold.yaml</code>."
+        },
+        "ref": {
+          "type": "string",
+          "description": "git ref the package should be cloned from. eg. `master` or `main`.",
+          "x-intellij-html-description": "git ref the package should be cloned from. eg. <code>master</code> or <code>main</code>."
+        },
+        "repo": {
+          "type": "string",
+          "description": "git repository the package should be cloned from.  e.g. `https://github.com/GoogleContainerTools/skaffold.git`.",
+          "x-intellij-html-description": "git repository the package should be cloned from.  e.g. <code>https://github.com/GoogleContainerTools/skaffold.git</code>."
+        },
+        "sync": {
+          "type": "boolean",
+          "description": "when set to `true` will reset the cached repository to the latest commit from remote on every run. To use the cached repository with uncommitted changes or unpushed commits, it needs to be set to `false`.",
+          "x-intellij-html-description": "when set to <code>true</code> will reset the cached repository to the latest commit from remote on every run. To use the cached repository with uncommitted changes or unpushed commits, it needs to be set to <code>false</code>."
+        }
+      },
+      "preferredOrder": [
+        "repo",
+        "path",
+        "ref",
+        "sync"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "contains information on the origin of skaffold configurations cloned from a git repository.",
+      "x-intellij-html-description": "contains information on the origin of skaffold configurations cloned from a git repository."
+    },
+    "GitTagger": {
+      "properties": {
+        "ignoreChanges": {
+          "type": "boolean",
+          "description": "specifies whether to omit the `-dirty` postfix if there are uncommitted changes.",
+          "x-intellij-html-description": "specifies whether to omit the <code>-dirty</code> postfix if there are uncommitted changes.",
+          "default": "false"
+        },
+        "prefix": {
+          "type": "string",
+          "description": "adds a fixed prefix to the tag.",
+          "x-intellij-html-description": "adds a fixed prefix to the tag."
+        },
+        "variant": {
+          "type": "string",
+          "description": "determines the behavior of the git tagger. Valid variants are: `Tags` (default): use git tags or fall back to abbreviated commit hash. `CommitSha`: use the full git commit sha. `AbbrevCommitSha`: use the abbreviated git commit sha. `TreeSha`: use the full tree hash of the artifact workingdir. `AbbrevTreeSha`: use the abbreviated tree hash of the artifact workingdir.",
+          "x-intellij-html-description": "determines the behavior of the git tagger. Valid variants are: <code>Tags</code> (default): use git tags or fall back to abbreviated commit hash. <code>CommitSha</code>: use the full git commit sha. <code>AbbrevCommitSha</code>: use the abbreviated git commit sha. <code>TreeSha</code>: use the full tree hash of the artifact workingdir. <code>AbbrevTreeSha</code>: use the abbreviated tree hash of the artifact workingdir.",
+          "enum": [
+            "Tags",
+            "CommitSha",
+            "AbbrevCommitSha",
+            "TreeSha",
+            "AbbrevTreeSha"
+          ]
+        }
+      },
+      "preferredOrder": [
+        "variant",
+        "prefix",
+        "ignoreChanges"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
+      "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
+    },
+    "GoogleCloudBuild": {
+      "properties": {
+        "concurrency": {
+          "type": "integer",
+          "description": "how many artifacts can be built concurrently. 0 means \"no-limit\".",
+          "x-intellij-html-description": "how many artifacts can be built concurrently. 0 means &quot;no-limit&quot;.",
+          "default": "0"
+        },
+        "diskSizeGb": {
+          "type": "integer",
+          "description": "disk size of the VM that runs the build. See [Cloud Build Reference](https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#buildoptions).",
+          "x-intellij-html-description": "disk size of the VM that runs the build. See <a href=\"https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#buildoptions\">Cloud Build Reference</a>."
+        },
+        "dockerImage": {
+          "type": "string",
+          "description": "image that runs a Docker build. See [Cloud Builders](https://cloud.google.com/cloud-build/docs/cloud-builders).",
+          "x-intellij-html-description": "image that runs a Docker build. See <a href=\"https://cloud.google.com/cloud-build/docs/cloud-builders\">Cloud Builders</a>.",
+          "default": "gcr.io/cloud-builders/docker"
+        },
+        "gradleImage": {
+          "type": "string",
+          "description": "image that runs a Gradle build. See [Cloud Builders](https://cloud.google.com/cloud-build/docs/cloud-builders).",
+          "x-intellij-html-description": "image that runs a Gradle build. See <a href=\"https://cloud.google.com/cloud-build/docs/cloud-builders\">Cloud Builders</a>.",
+          "default": "gcr.io/cloud-builders/gradle"
+        },
+        "kanikoImage": {
+          "type": "string",
+          "description": "image that runs a Kaniko build. See [Cloud Builders](https://cloud.google.com/cloud-build/docs/cloud-builders).",
+          "x-intellij-html-description": "image that runs a Kaniko build. See <a href=\"https://cloud.google.com/cloud-build/docs/cloud-builders\">Cloud Builders</a>.",
+          "default": "gcr.io/kaniko-project/executor"
+        },
+        "koImage": {
+          "type": "string",
+          "description": "image that runs a ko build. The image must contain Skaffold, Go, and a shell (runnable as `sh`) that supports here documents. See [Cloud Builders](https://cloud.google.com/cloud-build/docs/cloud-builders).",
+          "x-intellij-html-description": "image that runs a ko build. The image must contain Skaffold, Go, and a shell (runnable as <code>sh</code>) that supports here documents. See <a href=\"https://cloud.google.com/cloud-build/docs/cloud-builders\">Cloud Builders</a>.",
+          "default": "gcr.io/k8s-skaffold/skaffold"
+        },
+        "logStreamingOption": {
+          "type": "string",
+          "description": "specifies the behavior when writing build logs to Google Cloud Storage. Valid options are: `STREAM_DEFAULT`: Service may automatically determine build log streaming behavior. `STREAM_ON`:  Build logs should be streamed to Google Cloud Storage. `STREAM_OFF`: Build logs should not be streamed to Google Cloud Storage; they will be written when the build is completed. See [Cloud Build Reference](https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#logstreamingoption).",
+          "x-intellij-html-description": "specifies the behavior when writing build logs to Google Cloud Storage. Valid options are: <code>STREAM_DEFAULT</code>: Service may automatically determine build log streaming behavior. <code>STREAM_ON</code>:  Build logs should be streamed to Google Cloud Storage. <code>STREAM_OFF</code>: Build logs should not be streamed to Google Cloud Storage; they will be written when the build is completed. See <a href=\"https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#logstreamingoption\">Cloud Build Reference</a>.",
+          "enum": [
+            "STREAM_DEFAULT",
+            "STREAM_ON",
+            "STREAM_OFF"
+          ]
+        },
+        "logging": {
+          "type": "string",
+          "description": "specifies the logging mode. Valid modes are: `LOGGING_UNSPECIFIED`: The service determines the logging mode. `LEGACY`: Stackdriver logging and Cloud Storage logging are enabled (default). `GCS_ONLY`: Only Cloud Storage logging is enabled. See [Cloud Build Reference](https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#loggingmode).",
+          "x-intellij-html-description": "specifies the logging mode. Valid modes are: <code>LOGGING_UNSPECIFIED</code>: The service determines the logging mode. <code>LEGACY</code>: Stackdriver logging and Cloud Storage logging are enabled (default). <code>GCS_ONLY</code>: Only Cloud Storage logging is enabled. See <a href=\"https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#loggingmode\">Cloud Build Reference</a>.",
+          "enum": [
+            "LOGGING_UNSPECIFIED",
+            "LEGACY",
+            "GCS_ONLY"
+          ]
+        },
+        "machineType": {
+          "type": "string",
+          "description": "type of the VM that runs the build. See [Cloud Build Reference](https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#buildoptions).",
+          "x-intellij-html-description": "type of the VM that runs the build. See <a href=\"https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#buildoptions\">Cloud Build Reference</a>."
+        },
+        "mavenImage": {
+          "type": "string",
+          "description": "image that runs a Maven build. See [Cloud Builders](https://cloud.google.com/cloud-build/docs/cloud-builders).",
+          "x-intellij-html-description": "image that runs a Maven build. See <a href=\"https://cloud.google.com/cloud-build/docs/cloud-builders\">Cloud Builders</a>.",
+          "default": "gcr.io/cloud-builders/mvn"
+        },
+        "packImage": {
+          "type": "string",
+          "description": "image that runs a Cloud Native Buildpacks build. See [Cloud Builders](https://cloud.google.com/cloud-build/docs/cloud-builders).",
+          "x-intellij-html-description": "image that runs a Cloud Native Buildpacks build. See <a href=\"https://cloud.google.com/cloud-build/docs/cloud-builders\">Cloud Builders</a>.",
+          "default": "gcr.io/k8s-skaffold/pack"
+        },
+        "platformEmulatorInstallStep": {
+          "$ref": "#/definitions/PlatformEmulatorInstallStep",
+          "description": "specifies a pre-build step to install the required tooling for QEMU emulation on the GoogleCloudBuild containers. This enables performing cross-platform builds on GoogleCloudBuild. If unspecified, Skaffold uses the `docker/binfmt` image by default.",
+          "x-intellij-html-description": "specifies a pre-build step to install the required tooling for QEMU emulation on the GoogleCloudBuild containers. This enables performing cross-platform builds on GoogleCloudBuild. If unspecified, Skaffold uses the <code>docker/binfmt</code> image by default."
+        },
+        "projectId": {
+          "type": "string",
+          "description": "ID of your Cloud Platform Project. If it is not provided, Skaffold will guess it from the image name. For example, given the artifact image name `gcr.io/myproject/image`, Skaffold will use the `myproject` GCP project.",
+          "x-intellij-html-description": "ID of your Cloud Platform Project. If it is not provided, Skaffold will guess it from the image name. For example, given the artifact image name <code>gcr.io/myproject/image</code>, Skaffold will use the <code>myproject</code> GCP project."
+        },
+        "region": {
+          "type": "string",
+          "description": "configures the region to run the build. If WorkerPool is configured, the region will be deduced from the WorkerPool configuration. If neither WorkerPool nor Region is configured, the build will be run in global(non-regional). See [Cloud Build locations](https://cloud.google.com/build/docs/locations).",
+          "x-intellij-html-description": "configures the region to run the build. If WorkerPool is configured, the region will be deduced from the WorkerPool configuration. If neither WorkerPool nor Region is configured, the build will be run in global(non-regional). See <a href=\"https://cloud.google.com/build/docs/locations\">Cloud Build locations</a>."
+        },
+        "serviceAccount": {
+          "type": "string",
+          "description": "Google Cloud platform service account used by Cloud Build. If unspecified, it defaults to the Cloud Build service account generated when the Cloud Build API is enabled.",
+          "x-intellij-html-description": "Google Cloud platform service account used by Cloud Build. If unspecified, it defaults to the Cloud Build service account generated when the Cloud Build API is enabled."
+        },
+        "timeout": {
+          "type": "string",
+          "description": "amount of time (in seconds) that this build should be allowed to run. See [Cloud Build Reference](https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#resource-build).",
+          "x-intellij-html-description": "amount of time (in seconds) that this build should be allowed to run. See <a href=\"https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#resource-build\">Cloud Build Reference</a>."
+        },
+        "workerPool": {
+          "type": "string",
+          "description": "configures a pool of workers to run the build.",
+          "x-intellij-html-description": "configures a pool of workers to run the build."
+        }
+      },
+      "preferredOrder": [
+        "projectId",
+        "diskSizeGb",
+        "machineType",
+        "timeout",
+        "logging",
+        "logStreamingOption",
+        "dockerImage",
+        "kanikoImage",
+        "mavenImage",
+        "gradleImage",
+        "packImage",
+        "koImage",
+        "concurrency",
+        "workerPool",
+        "region",
+        "platformEmulatorInstallStep",
+        "serviceAccount"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
+      "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
+    },
+    "Helm": {
+      "required": [
+        "releases"
+      ],
+      "properties": {
+        "flags": {
+          "$ref": "#/definitions/HelmDeployFlags",
+          "description": "additional option flags that are passed on the command line to `helm`.",
+          "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
+        },
+        "releases": {
+          "items": {
+            "$ref": "#/definitions/HelmRelease"
+          },
+          "type": "array",
+          "description": "a list of Helm releases.",
+          "x-intellij-html-description": "a list of Helm releases."
+        }
+      },
+      "preferredOrder": [
+        "flags",
+        "releases"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "defines the manifests from helm releases.",
+      "x-intellij-html-description": "defines the manifests from helm releases."
+    },
+    "HelmDeployFlags": {
+      "properties": {
+        "global": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "additional flags passed on every command.",
+          "x-intellij-html-description": "additional flags passed on every command.",
+          "default": "[]"
+        },
+        "install": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "additional flags passed to (`helm install`).",
+          "x-intellij-html-description": "additional flags passed to (<code>helm install</code>).",
+          "default": "[]"
+        },
+        "upgrade": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "additional flags passed to (`helm upgrade`).",
+          "x-intellij-html-description": "additional flags passed to (<code>helm upgrade</code>).",
+          "default": "[]"
+        }
+      },
+      "preferredOrder": [
+        "global",
+        "install",
+        "upgrade"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "additional option flags that are passed on the command line to `helm`.",
+      "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
+    },
+    "HelmPackaged": {
+      "properties": {
+        "appVersion": {
+          "type": "string",
+          "description": "sets the `appVersion` on the chart to this version.",
+          "x-intellij-html-description": "sets the <code>appVersion</code> on the chart to this version."
+        },
+        "version": {
+          "type": "string",
+          "description": "sets the `version` on the chart to this semver version.",
+          "x-intellij-html-description": "sets the <code>version</code> on the chart to this semver version."
+        }
+      },
+      "preferredOrder": [
+        "version",
+        "appVersion"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "parameters for packaging helm chart (`helm package`).",
+      "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
+    },
+    "HelmRelease": {
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "chartPath": {
+          "type": "string",
+          "description": "local path to a packaged Helm chart or an unpacked Helm chart directory.",
+          "x-intellij-html-description": "local path to a packaged Helm chart or an unpacked Helm chart directory."
+        },
+        "createNamespace": {
+          "type": "boolean",
+          "description": "if `true`, Skaffold will send `--create-namespace` flag to Helm CLI. `--create-namespace` flag is available in Helm since version 3.2. Defaults is `false`.",
+          "x-intellij-html-description": "if <code>true</code>, Skaffold will send <code>--create-namespace</code> flag to Helm CLI. <code>--create-namespace</code> flag is available in Helm since version 3.2. Defaults is <code>false</code>."
+        },
+        "name": {
+          "type": "string",
+          "description": "name of the Helm release. It accepts environment variables via the go template syntax.",
+          "x-intellij-html-description": "name of the Helm release. It accepts environment variables via the go template syntax."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Kubernetes namespace.",
+          "x-intellij-html-description": "Kubernetes namespace."
+        },
+        "overrides": {
+          "description": "key-value pairs. If present, Skaffold will build a Helm `values` file that overrides the original and use it to call Helm CLI (`--f` flag).",
+          "x-intellij-html-description": "key-value pairs. If present, Skaffold will build a Helm <code>values</code> file that overrides the original and use it to call Helm CLI (<code>--f</code> flag)."
+        },
+        "packaged": {
+          "$ref": "#/definitions/HelmPackaged",
+          "description": "parameters for packaging helm chart (`helm package`).",
+          "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
+        },
+        "recreatePods": {
+          "type": "boolean",
+          "description": "if `true`, Skaffold will send `--recreate-pods` flag to Helm CLI when upgrading a new version of a chart in subsequent dev loop deploy.",
+          "x-intellij-html-description": "if <code>true</code>, Skaffold will send <code>--recreate-pods</code> flag to Helm CLI when upgrading a new version of a chart in subsequent dev loop deploy.",
+          "default": "false"
+        },
+        "remoteChart": {
+          "type": "string",
+          "description": "refers to a remote Helm chart reference or URL.",
+          "x-intellij-html-description": "refers to a remote Helm chart reference or URL."
+        },
+        "repo": {
+          "type": "string",
+          "description": "specifies the helm repository for remote charts. If present, Skaffold will send `--repo` Helm CLI flag or flags.",
+          "x-intellij-html-description": "specifies the helm repository for remote charts. If present, Skaffold will send <code>--repo</code> Helm CLI flag or flags."
+        },
+        "setFiles": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "key-value pairs. If present, Skaffold will send `--set-file` flag to Helm CLI and append all pairs after the flag.",
+          "x-intellij-html-description": "key-value pairs. If present, Skaffold will send <code>--set-file</code> flag to Helm CLI and append all pairs after the flag.",
+          "default": "{}"
+        },
+        "setValueTemplates": {
+          "description": "key-value pairs. If present, Skaffold will try to parse the value part of each key-value pair using environment variables in the system, then send `--set` flag to Helm CLI and append all parsed pairs after the flag.",
+          "x-intellij-html-description": "key-value pairs. If present, Skaffold will try to parse the value part of each key-value pair using environment variables in the system, then send <code>--set</code> flag to Helm CLI and append all parsed pairs after the flag."
+        },
+        "setValues": {
+          "description": "key-value pairs. If present, Skaffold will send `--set` flag to Helm CLI and append all pairs after the flag.",
+          "x-intellij-html-description": "key-value pairs. If present, Skaffold will send <code>--set</code> flag to Helm CLI and append all pairs after the flag."
+        },
+        "skipBuildDependencies": {
+          "type": "boolean",
+          "description": "should build dependencies be skipped. Ignored for `remoteChart`.",
+          "x-intellij-html-description": "should build dependencies be skipped. Ignored for <code>remoteChart</code>.",
+          "default": "false"
+        },
+        "skipTests": {
+          "type": "boolean",
+          "description": "should ignore helm test during manifests generation.",
+          "x-intellij-html-description": "should ignore helm test during manifests generation.",
+          "default": "false"
+        },
+        "upgradeOnChange": {
+          "type": "boolean",
+          "description": "specifies whether to upgrade helm chart on code changes. Default is `true` when helm chart is local (has `chartPath`). Default is `false` when helm chart is remote (has `remoteChart`).",
+          "x-intellij-html-description": "specifies whether to upgrade helm chart on code changes. Default is <code>true</code> when helm chart is local (has <code>chartPath</code>). Default is <code>false</code> when helm chart is remote (has <code>remoteChart</code>)."
+        },
+        "useHelmSecrets": {
+          "type": "boolean",
+          "description": "instructs skaffold to use secrets plugin on deployment.",
+          "x-intellij-html-description": "instructs skaffold to use secrets plugin on deployment.",
+          "default": "false"
+        },
+        "valuesFiles": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "paths to the Helm `values` files.",
+          "x-intellij-html-description": "paths to the Helm <code>values</code> files.",
+          "default": "[]"
+        },
+        "version": {
+          "type": "string",
+          "description": "version of the chart.",
+          "x-intellij-html-description": "version of the chart."
+        },
+        "wait": {
+          "type": "boolean",
+          "description": "if `true`, Skaffold will send `--wait` flag to Helm CLI.",
+          "x-intellij-html-description": "if <code>true</code>, Skaffold will send <code>--wait</code> flag to Helm CLI.",
+          "default": "false"
+        }
+      },
+      "preferredOrder": [
+        "name",
+        "chartPath",
+        "remoteChart",
+        "valuesFiles",
+        "namespace",
+        "version",
+        "setValues",
+        "setValueTemplates",
+        "setFiles",
+        "createNamespace",
+        "wait",
+        "recreatePods",
+        "skipBuildDependencies",
+        "skipTests",
+        "useHelmSecrets",
+        "repo",
+        "upgradeOnChange",
+        "overrides",
+        "packaged"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "describes a helm release to be deployed.",
+      "x-intellij-html-description": "describes a helm release to be deployed."
+    },
+    "HostHook": {
+      "required": [
+        "command"
+      ],
+      "properties": {
+        "command": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "command to execute.",
+          "x-intellij-html-description": "command to execute.",
+          "default": "[]"
+        },
+        "dir": {
+          "type": "string",
+          "description": "specifies the working directory of the command. If empty, the command runs in the calling process's current directory.",
+          "x-intellij-html-description": "specifies the working directory of the command. If empty, the command runs in the calling process's current directory."
+        },
+        "os": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "an optional slice of operating system names. If the host machine OS is different, then it skips execution.",
+          "x-intellij-html-description": "an optional slice of operating system names. If the host machine OS is different, then it skips execution.",
+          "default": "[]"
+        }
+      },
+      "preferredOrder": [
+        "command",
+        "os",
+        "dir"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "describes a lifecycle hook definition to execute on the host machine.",
+      "x-intellij-html-description": "describes a lifecycle hook definition to execute on the host machine."
+    },
+    "InputDigest": {
+      "type": "object",
+      "description": "*beta* tags hashes the image content.",
+      "x-intellij-html-description": "<em>beta</em> tags hashes the image content."
+    },
+    "JSONParseConfig": {
+      "properties": {
+        "fields": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "specifies which top level fields should be printed.",
+          "x-intellij-html-description": "specifies which top level fields should be printed.",
+          "default": "[]"
+        }
+      },
+      "preferredOrder": [
+        "fields"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "defines the rules for parsing/outputting json logs.",
+      "x-intellij-html-description": "defines the rules for parsing/outputting json logs."
+    },
+    "JSONPatch": {
+      "required": [
+        "path"
+      ],
+      "properties": {
+        "from": {
+          "type": "string",
+          "description": "source position in the yaml, used for `copy` or `move` operations.",
+          "x-intellij-html-description": "source position in the yaml, used for <code>copy</code> or <code>move</code> operations."
+        },
+        "op": {
+          "type": "string",
+          "description": "operation carried by the patch: `add`, `remove`, `replace`, `move`, `copy` or `test`.",
+          "x-intellij-html-description": "operation carried by the patch: <code>add</code>, <code>remove</code>, <code>replace</code>, <code>move</code>, <code>copy</code> or <code>test</code>.",
+          "default": "replace"
+        },
+        "path": {
+          "type": "string",
+          "description": "position in the yaml where the operation takes place. For example, this targets the `dockerfile` of the first artifact built.",
+          "x-intellij-html-description": "position in the yaml where the operation takes place. For example, this targets the <code>dockerfile</code> of the first artifact built.",
+          "examples": [
+            "/build/artifacts/0/docker/dockerfile"
+          ]
+        },
+        "value": {
+          "description": "value to apply. Can be any portion of yaml.",
+          "x-intellij-html-description": "value to apply. Can be any portion of yaml."
+        }
+      },
+      "preferredOrder": [
+        "op",
+        "path",
+        "from",
+        "value"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "patch to be applied by a profile.",
+      "x-intellij-html-description": "patch to be applied by a profile."
+    },
+    "JibArtifact": {
+      "properties": {
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "additional build flags passed to the builder.",
+          "x-intellij-html-description": "additional build flags passed to the builder.",
+          "default": "[]",
+          "examples": [
+            "[\"--no-build-cache\"]"
+          ]
+        },
+        "fromImage": {
+          "type": "string",
+          "description": "overrides the configured jib base image.",
+          "x-intellij-html-description": "overrides the configured jib base image."
+        },
+        "project": {
+          "type": "string",
+          "description": "selects which sub-project to build for multi-module builds.",
+          "x-intellij-html-description": "selects which sub-project to build for multi-module builds."
+        },
+        "type": {
+          "type": "string",
+          "description": "the Jib builder type; normally determined automatically. Valid types are `maven`: for Maven. `gradle`: for Gradle.",
+          "x-intellij-html-description": "the Jib builder type; normally determined automatically. Valid types are <code>maven</code>: for Maven. <code>gradle</code>: for Gradle.",
+          "enum": [
+            "maven",
+            "gradle"
+          ]
+        }
+      },
+      "preferredOrder": [
+        "project",
+        "args",
+        "type",
+        "fromImage"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "builds images using the [Jib plugins for Maven and Gradle](https://github.com/GoogleContainerTools/jib/).",
+      "x-intellij-html-description": "builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/\">Jib plugins for Maven and Gradle</a>."
+    },
+    "KanikoArtifact": {
+      "properties": {
+        "buildArgs": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "arguments passed to the docker build. It also accepts environment variables and generated values via the go template syntax. Exposed generated values: IMAGE_REPO, IMAGE_NAME, IMAGE_TAG.",
+          "x-intellij-html-description": "arguments passed to the docker build. It also accepts environment variables and generated values via the go template syntax. Exposed generated values: IMAGE<em>REPO, IMAGE</em>NAME, IMAGE_TAG.",
+          "default": "{}",
+          "examples": [
+            "{\"key1\": \"value1\", \"key2\": \"value2\", \"key3\": \"'{{.ENV_VARIABLE}}'\"}"
+          ]
+        },
+        "cache": {
+          "$ref": "#/definitions/KanikoCache",
+          "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
+          "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
+        },
+        "cleanup": {
+          "type": "boolean",
+          "description": "to clean the filesystem at the end of the build.",
+          "x-intellij-html-description": "to clean the filesystem at the end of the build.",
+          "default": "false"
+        },
+        "contextSubPath": {
+          "type": "string",
+          "description": "to specify a sub path within the context.",
+          "x-intellij-html-description": "to specify a sub path within the context."
+        },
+        "digestFile": {
+          "type": "string",
+          "description": "to specify a file in the container. This file will receive the digest of a built image. This can be used to automatically track the exact image built by kaniko.",
+          "x-intellij-html-description": "to specify a file in the container. This file will receive the digest of a built image. This can be used to automatically track the exact image built by kaniko."
+        },
+        "dockerfile": {
+          "type": "string",
+          "description": "locates the Dockerfile relative to workspace.",
+          "x-intellij-html-description": "locates the Dockerfile relative to workspace.",
+          "default": "Dockerfile"
+        },
+        "env": {
+          "items": {},
+          "type": "array",
+          "description": "environment variables passed to the kaniko pod. It also accepts environment variables via the go template syntax.",
+          "x-intellij-html-description": "environment variables passed to the kaniko pod. It also accepts environment variables via the go template syntax.",
+          "default": "[]",
+          "examples": [
+            "[{\"name\": \"key1\", \"value\": \"value1\"}, {\"name\": \"key2\", \"value\": \"value2\"}, {\"name\": \"key3\", \"value\": \"'{{.ENV_VARIABLE}}'\"}]"
+          ]
+        },
+        "force": {
+          "type": "boolean",
+          "description": "building outside of a container.",
+          "x-intellij-html-description": "building outside of a container.",
+          "default": "false"
+        },
+        "ignorePaths": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "a list of ignored paths when making an image snapshot.",
+          "x-intellij-html-description": "a list of ignored paths when making an image snapshot.",
+          "default": "[]"
+        },
+        "image": {
+          "type": "string",
+          "description": "Docker image used by the Kaniko pod. Defaults to the latest released version of `gcr.io/kaniko-project/executor`.",
+          "x-intellij-html-description": "Docker image used by the Kaniko pod. Defaults to the latest released version of <code>gcr.io/kaniko-project/executor</code>."
+        },
+        "imageFSExtractRetry": {
+          "type": "string",
+          "description": "number of retries that should happen for extracting an image filesystem.",
+          "x-intellij-html-description": "number of retries that should happen for extracting an image filesystem."
+        },
+        "imageNameWithDigestFile": {
+          "type": "string",
+          "description": "specify a file to save the image name with digest of the built image to.",
+          "x-intellij-html-description": "specify a file to save the image name with digest of the built image to."
+        },
+        "initImage": {
+          "type": "string",
+          "description": "image used to run init container which mounts kaniko context.",
+          "x-intellij-html-description": "image used to run init container which mounts kaniko context."
+        },
+        "insecure": {
+          "type": "boolean",
+          "description": "if you want to push images to a plain HTTP registry.",
+          "x-intellij-html-description": "if you want to push images to a plain HTTP registry.",
+          "default": "false"
+        },
+        "insecurePull": {
+          "type": "boolean",
+          "description": "if you want to pull images from a plain HTTP registry.",
+          "x-intellij-html-description": "if you want to pull images from a plain HTTP registry.",
+          "default": "false"
+        },
+        "insecureRegistry": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "to use plain HTTP requests when accessing a registry.",
+          "x-intellij-html-description": "to use plain HTTP requests when accessing a registry.",
+          "default": "[]"
+        },
+        "label": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "key: value to set some metadata to the final image. This is equivalent as using the LABEL within the Dockerfile.",
+          "x-intellij-html-description": "key: value to set some metadata to the final image. This is equivalent as using the LABEL within the Dockerfile.",
+          "default": "{}"
+        },
+        "logFormat": {
+          "type": "string",
+          "description": "<text|color|json> to set the log format.",
+          "x-intellij-html-description": "<text|color|json> to set the log format."
+        },
+        "logTimestamp": {
+          "type": "boolean",
+          "description": "to add timestamps to log format.",
+          "x-intellij-html-description": "to add timestamps to log format.",
+          "default": "false"
+        },
+        "ociLayoutPath": {
+          "type": "string",
+          "description": "to specify a directory in the container where the OCI image layout of a built image will be placed. This can be used to automatically track the exact image built by kaniko.",
+          "x-intellij-html-description": "to specify a directory in the container where the OCI image layout of a built image will be placed. This can be used to automatically track the exact image built by kaniko."
+        },
+        "pushRetry": {
+          "type": "string",
+          "description": "Set this flag to the number of retries that should happen for the push of an image to a remote destination.",
+          "x-intellij-html-description": "Set this flag to the number of retries that should happen for the push of an image to a remote destination."
+        },
+        "registryCertificate": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "to provide a certificate for TLS communication with a given registry. my.registry.url: /path/to/the/certificate.cert is the expected format.",
+          "x-intellij-html-description": "to provide a certificate for TLS communication with a given registry. my.registry.url: /path/to/the/certificate.cert is the expected format.",
+          "default": "{}"
+        },
+        "registryMirror": {
+          "type": "string",
+          "description": "if you want to use a registry mirror instead of default `index.docker.io`.",
+          "x-intellij-html-description": "if you want to use a registry mirror instead of default <code>index.docker.io</code>."
+        },
+        "reproducible": {
+          "type": "boolean",
+          "description": "used to strip timestamps out of the built image.",
+          "x-intellij-html-description": "used to strip timestamps out of the built image.",
+          "default": "false"
+        },
+        "singleSnapshot": {
+          "type": "boolean",
+          "description": "takes a single snapshot of the filesystem at the end of the build. So only one layer will be appended to the base image.",
+          "x-intellij-html-description": "takes a single snapshot of the filesystem at the end of the build. So only one layer will be appended to the base image.",
+          "default": "false"
+        },
+        "skipTLS": {
+          "type": "boolean",
+          "description": "skips TLS certificate validation when pushing to a registry.",
+          "x-intellij-html-description": "skips TLS certificate validation when pushing to a registry.",
+          "default": "false"
+        },
+        "skipTLSVerifyPull": {
+          "type": "boolean",
+          "description": "skips TLS certificate validation when pulling from a registry.",
+          "x-intellij-html-description": "skips TLS certificate validation when pulling from a registry.",
+          "default": "false"
+        },
+        "skipTLSVerifyRegistry": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "skips TLS certificate validation when accessing a registry.",
+          "x-intellij-html-description": "skips TLS certificate validation when accessing a registry.",
+          "default": "[]"
+        },
+        "skipUnusedStages": {
+          "type": "boolean",
+          "description": "builds only used stages if defined to true. Otherwise it builds by default all stages, even the unnecessaries ones until it reaches the target stage / end of Dockerfile.",
+          "x-intellij-html-description": "builds only used stages if defined to true. Otherwise it builds by default all stages, even the unnecessaries ones until it reaches the target stage / end of Dockerfile.",
+          "default": "false"
+        },
+        "snapshotMode": {
+          "type": "string",
+          "description": "how Kaniko will snapshot the filesystem.",
+          "x-intellij-html-description": "how Kaniko will snapshot the filesystem."
+        },
+        "tarPath": {
+          "type": "string",
+          "description": "path to save the image as a tarball at path instead of pushing the image.",
+          "x-intellij-html-description": "path to save the image as a tarball at path instead of pushing the image."
+        },
+        "target": {
+          "type": "string",
+          "description": "to indicate which build stage is the target build stage.",
+          "x-intellij-html-description": "to indicate which build stage is the target build stage."
+        },
+        "useNewRun": {
+          "type": "boolean",
+          "description": "to Use the experimental run implementation for detecting changes without requiring file system snapshots. In some cases, this may improve build performance by 75%.",
+          "x-intellij-html-description": "to Use the experimental run implementation for detecting changes without requiring file system snapshots. In some cases, this may improve build performance by 75%.",
+          "default": "false"
+        },
+        "verbosity": {
+          "type": "string",
+          "description": "<panic|fatal|error|warn|info|debug|trace> to set the logging level.",
+          "x-intellij-html-description": "<panic|fatal|error|warn|info|debug|trace> to set the logging level."
+        },
+        "volumeMounts": {
+          "items": {},
+          "type": "array",
+          "description": "volume mounts passed to kaniko pod.",
+          "x-intellij-html-description": "volume mounts passed to kaniko pod.",
+          "default": "[]"
+        },
+        "whitelistVarRun": {
+          "type": "boolean",
+          "description": "used to ignore `/var/run` when taking image snapshot. Set it to false to preserve /var/run/* in destination image.",
+          "x-intellij-html-description": "used to ignore <code>/var/run</code> when taking image snapshot. Set it to false to preserve /var/run/* in destination image.",
+          "default": "false"
+        }
+      },
+      "preferredOrder": [
+        "cleanup",
+        "insecure",
+        "insecurePull",
+        "force",
+        "logTimestamp",
+        "reproducible",
+        "singleSnapshot",
+        "skipTLS",
+        "skipTLSVerifyPull",
+        "skipUnusedStages",
+        "useNewRun",
+        "whitelistVarRun",
+        "dockerfile",
+        "target",
+        "initImage",
+        "image",
+        "digestFile",
+        "imageFSExtractRetry",
+        "imageNameWithDigestFile",
+        "logFormat",
+        "ociLayoutPath",
+        "registryMirror",
+        "snapshotMode",
+        "pushRetry",
+        "tarPath",
+        "verbosity",
+        "insecureRegistry",
+        "skipTLSVerifyRegistry",
+        "env",
+        "cache",
+        "registryCertificate",
+        "label",
+        "buildArgs",
+        "volumeMounts",
+        "contextSubPath",
+        "ignorePaths"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "describes an artifact built from a Dockerfile, with kaniko.",
+      "x-intellij-html-description": "describes an artifact built from a Dockerfile, with kaniko."
+    },
+    "KanikoCache": {
+      "properties": {
+        "cacheCopyLayers": {
+          "type": "boolean",
+          "description": "enables caching of copy layers.",
+          "x-intellij-html-description": "enables caching of copy layers.",
+          "default": "false"
+        },
+        "hostPath": {
+          "type": "string",
+          "description": "specifies a path on the host that is mounted to each pod as read only cache volume containing base images. If set, must exist on each node and prepopulated with kaniko-warmer.",
+          "x-intellij-html-description": "specifies a path on the host that is mounted to each pod as read only cache volume containing base images. If set, must exist on each node and prepopulated with kaniko-warmer."
+        },
+        "repo": {
+          "type": "string",
+          "description": "a remote repository to store cached layers. If none is specified, one will be inferred from the image name. See [Kaniko Caching](https://github.com/GoogleContainerTools/kaniko#caching).",
+          "x-intellij-html-description": "a remote repository to store cached layers. If none is specified, one will be inferred from the image name. See <a href=\"https://github.com/GoogleContainerTools/kaniko#caching\">Kaniko Caching</a>."
+        },
+        "ttl": {
+          "type": "string",
+          "description": "Cache timeout in hours.",
+          "x-intellij-html-description": "Cache timeout in hours."
+        }
+      },
+      "preferredOrder": [
+        "repo",
+        "hostPath",
+        "ttl",
+        "cacheCopyLayers"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
+      "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
+    },
+    "KoArtifact": {
+      "properties": {
+        "dependencies": {
+          "$ref": "#/definitions/KoDependencies",
+          "description": "file dependencies that Skaffold should watch for both rebuilding and file syncing for this artifact.",
+          "x-intellij-html-description": "file dependencies that Skaffold should watch for both rebuilding and file syncing for this artifact."
+        },
+        "dir": {
+          "type": "string",
+          "description": "directory where the `go` tool will be run. The value is a directory path relative to the `context` directory. If empty, the `go` tool will run in the `context` directory. Example: `./my-app-sources`.",
+          "x-intellij-html-description": "directory where the <code>go</code> tool will be run. The value is a directory path relative to the <code>context</code> directory. If empty, the <code>go</code> tool will run in the <code>context</code> directory. Example: <code>./my-app-sources</code>."
+        },
+        "env": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "environment variables, in the `key=value` form, passed to the build. These environment variables are only used at build time. They are _not_ set in the resulting container image.",
+          "x-intellij-html-description": "environment variables, in the <code>key=value</code> form, passed to the build. These environment variables are only used at build time. They are <em>not</em> set in the resulting container image.",
+          "default": "[]",
+          "examples": [
+            "[\"GOPRIVATE=git.example.com\", \"GOCACHE=/workspace/.gocache\"]"
+          ]
+        },
+        "flags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "additional build flags passed to `go build`.",
+          "x-intellij-html-description": "additional build flags passed to <code>go build</code>.",
+          "default": "[]",
+          "examples": [
+            "[\"-trimpath\", \"-v\"]"
+          ]
+        },
+        "fromImage": {
+          "type": "string",
+          "description": "overrides the default ko base image (`gcr.io/distroless/static:nonroot`). Corresponds to, and overrides, the `defaultBaseImage` in `.ko.yaml`.",
+          "x-intellij-html-description": "overrides the default ko base image (<code>gcr.io/distroless/static:nonroot</code>). Corresponds to, and overrides, the <code>defaultBaseImage</code> in <code>.ko.yaml</code>."
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "key-value string pairs to add to the image config.",
+          "x-intellij-html-description": "key-value string pairs to add to the image config.",
+          "default": "{}",
+          "examples": [
+            "{\"foo\":\"bar\"}"
+          ]
+        },
+        "ldflags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "linker flags passed to the builder.",
+          "x-intellij-html-description": "linker flags passed to the builder.",
+          "default": "[]",
+          "examples": [
+            "[\"-buildid=\", \"-s\", \"-w\"]"
+          ]
+        },
+        "main": {
+          "type": "string",
+          "description": "location of the main package. It is the pattern passed to `go build`. If main is specified as a relative path, it is relative to the `context` directory. If main is empty, the ko builder uses a default value of `.`. If main is a pattern with wildcards, such as `./...`, the expansion must contain only one main package, otherwise ko fails. Main is ignored if the `ImageName` starts with `ko://`. Example: `./cmd/foo`.",
+          "x-intellij-html-description": "location of the main package. It is the pattern passed to <code>go build</code>. If main is specified as a relative path, it is relative to the <code>context</code> directory. If main is empty, the ko builder uses a default value of <code>.</code>. If main is a pattern with wildcards, such as <code>./...</code>, the expansion must contain only one main package, otherwise ko fails. Main is ignored if the <code>ImageName</code> starts with <code>ko://</code>. Example: <code>./cmd/foo</code>."
+        }
+      },
+      "preferredOrder": [
+        "fromImage",
+        "dependencies",
+        "dir",
+        "env",
+        "flags",
+        "labels",
+        "ldflags",
+        "main"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "builds images using [ko](https://github.com/google/ko).",
+      "x-intellij-html-description": "builds images using <a href=\"https://github.com/google/ko\">ko</a>."
+    },
+    "KoDependencies": {
+      "properties": {
+        "ignore": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "specifies the paths that should be ignored by Skaffold's file watcher. If a file exists in both `paths` and in `ignore`, it will be ignored, and will be excluded from both rebuilds and file synchronization.",
+          "x-intellij-html-description": "specifies the paths that should be ignored by Skaffold's file watcher. If a file exists in both <code>paths</code> and in <code>ignore</code>, it will be ignored, and will be excluded from both rebuilds and file synchronization.",
+          "default": "[]"
+        },
+        "paths": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "should be set to the file dependencies for this artifact, so that the Skaffold file watcher knows when to rebuild and perform file synchronization.",
+          "x-intellij-html-description": "should be set to the file dependencies for this artifact, so that the Skaffold file watcher knows when to rebuild and perform file synchronization.",
+          "default": "[\"**/*.go\"]"
+        }
+      },
+      "preferredOrder": [
+        "paths",
+        "ignore"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "used to specify dependencies for an artifact built by ko.",
+      "x-intellij-html-description": "used to specify dependencies for an artifact built by ko."
+    },
+    "KptDeploy": {
+      "properties": {
+        "applyFlags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "additional flags passed to `kpt live apply`.",
+          "x-intellij-html-description": "additional flags passed to <code>kpt live apply</code>.",
+          "default": "[]"
+        },
+        "defaultNamespace": {
+          "type": "string",
+          "description": "default namespace passed to kpt on deployment if no other override is given.",
+          "x-intellij-html-description": "default namespace passed to kpt on deployment if no other override is given."
+        },
+        "dir": {
+          "type": "string",
+          "description": "equivalent to the dir in `kpt live apply <dir>`. If not provided, skaffold deploys from the default hydrated path `<WORKDIR>/.kpt-pipeline`.",
+          "x-intellij-html-description": "equivalent to the dir in <code>kpt live apply &lt;dir&gt;</code>. If not provided, skaffold deploys from the default hydrated path <code>&lt;WORKDIR&gt;/.kpt-pipeline</code>."
+        },
+        "false": {
+          "type": "boolean",
+          "description": "used in `kpt live init`, which forces the inventory values to be updated, even if they are already set.",
+          "x-intellij-html-description": "used in <code>kpt live init</code>, which forces the inventory values to be updated, even if they are already set.",
+          "default": "false"
+        },
+        "flags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "kpt global flags.",
+          "x-intellij-html-description": "kpt global flags.",
+          "default": "[]"
+        },
+        "inventoryID": {
+          "type": "string",
+          "description": "*alpha* inventory ID which annotates the resources being lively applied by kpt.",
+          "x-intellij-html-description": "<em>alpha</em> inventory ID which annotates the resources being lively applied by kpt."
+        },
+        "name": {
+          "type": "string",
+          "description": "*alpha* inventory object name.",
+          "x-intellij-html-description": "<em>alpha</em> inventory object name."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "*alpha* sets the inventory namespace.",
+          "x-intellij-html-description": "<em>alpha</em> sets the inventory namespace."
+        }
+      },
+      "preferredOrder": [
+        "dir",
+        "applyFlags",
+        "flags",
+        "name",
+        "inventoryID",
+        "namespace",
+        "false",
+        "defaultNamespace"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "contains all the configuration needed by the deploy steps.",
+      "x-intellij-html-description": "contains all the configuration needed by the deploy steps."
+    },
+    "KubectlDeploy": {
+      "properties": {
+        "defaultNamespace": {
+          "type": "string",
+          "description": "default namespace passed to kubectl on deployment if no other override is given.",
+          "x-intellij-html-description": "default namespace passed to kubectl on deployment if no other override is given."
+        },
+        "flags": {
+          "$ref": "#/definitions/KubectlFlags",
+          "description": "additional flags passed to `kubectl`.",
+          "x-intellij-html-description": "additional flags passed to <code>kubectl</code>."
+        },
+        "hooks": {
+          "$ref": "#/definitions/DeployHooks",
+          "description": "describes a set of lifecycle hooks that are executed before and after every deploy.",
+          "x-intellij-html-description": "describes a set of lifecycle hooks that are executed before and after every deploy."
+        },
+        "remoteManifests": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Kubernetes manifests in remote clusters.",
+          "x-intellij-html-description": "Kubernetes manifests in remote clusters.",
+          "default": "[]"
+        }
+      },
+      "preferredOrder": [
+        "flags",
+        "remoteManifests",
+        "defaultNamespace",
+        "hooks"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
+      "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
+    },
+    "KubectlFlags": {
+      "properties": {
+        "apply": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "additional flags passed on creations (`kubectl apply`).",
+          "x-intellij-html-description": "additional flags passed on creations (<code>kubectl apply</code>).",
+          "default": "[]"
+        },
+        "delete": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "additional flags passed on deletions (`kubectl delete`).",
+          "x-intellij-html-description": "additional flags passed on deletions (<code>kubectl delete</code>).",
+          "default": "[]"
+        },
+        "disableValidation": {
+          "type": "boolean",
+          "description": "passes the `--validate=false` flag to supported `kubectl` commands when enabled.",
+          "x-intellij-html-description": "passes the <code>--validate=false</code> flag to supported <code>kubectl</code> commands when enabled.",
+          "default": "false"
+        },
+        "global": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "additional flags passed on every command.",
+          "x-intellij-html-description": "additional flags passed on every command.",
+          "default": "[]"
+        }
+      },
+      "preferredOrder": [
+        "global",
+        "apply",
+        "delete",
+        "disableValidation"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
+      "x-intellij-html-description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
+    },
+    "KubernetesClusterVerifier": {
+      "properties": {
+        "jobManifestPath": {
+          "type": "string",
+          "description": "path to the kubernetes Job manifest to use for the verify test This manifest will be deployed into the cluster with the Container information replaced by the information in the Container field.",
+          "x-intellij-html-description": "path to the kubernetes Job manifest to use for the verify test This manifest will be deployed into the cluster with the Container information replaced by the information in the Container field."
+        },
+        "overrides": {
+          "type": "string",
+          "description": "inline JSON override to use for the generated kubernetes Job. If this is non-empty, it is used to override the generated object. Similar to the `--overrides` kubectl flag.",
+          "x-intellij-html-description": "inline JSON override to use for the generated kubernetes Job. If this is non-empty, it is used to override the generated object. Similar to the <code>--overrides</code> kubectl flag."
+        }
+      },
+      "preferredOrder": [
+        "overrides",
+        "jobManifestPath"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "uses the `kubectl` CLI to create veriy test case container in a kubernetes cluster.",
+      "x-intellij-html-description": "uses the <code>kubectl</code> CLI to create veriy test case container in a kubernetes cluster."
+    },
+    "Kustomize": {
+      "properties": {
+        "buildArgs": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "additional args passed to `kustomize build`.",
+          "x-intellij-html-description": "additional args passed to <code>kustomize build</code>.",
+          "default": "[]"
+        },
+        "paths": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "path to Kustomization files.",
+          "x-intellij-html-description": "path to Kustomization files.",
+          "default": "[\".\"]"
+        }
+      },
+      "preferredOrder": [
+        "paths",
+        "buildArgs"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "defines the paths to be modified with kustomize, along with extra flags to be passed to kustomize.",
+      "x-intellij-html-description": "defines the paths to be modified with kustomize, along with extra flags to be passed to kustomize."
+    },
+    "LegacyHelmDeploy": {
+      "properties": {
+        "flags": {
+          "$ref": "#/definitions/HelmDeployFlags",
+          "description": "additional option flags that are passed on the command line to `helm`.",
+          "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
+        },
+        "hooks": {
+          "$ref": "#/definitions/DeployHooks",
+          "description": "describes a set of lifecycle hooks that are executed before and after every deploy.",
+          "x-intellij-html-description": "describes a set of lifecycle hooks that are executed before and after every deploy."
+        },
+        "releases": {
+          "items": {
+            "$ref": "#/definitions/HelmRelease"
+          },
+          "type": "array",
+          "description": "a list of Helm releases.",
+          "x-intellij-html-description": "a list of Helm releases."
+        }
+      },
+      "preferredOrder": [
+        "releases",
+        "flags",
+        "hooks"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
+      "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
+    },
+    "LocalBuild": {
+      "properties": {
+        "concurrency": {
+          "type": "integer",
+          "description": "how many artifacts can be built concurrently. 0 means \"no-limit\".",
+          "x-intellij-html-description": "how many artifacts can be built concurrently. 0 means &quot;no-limit&quot;.",
+          "default": "1"
+        },
+        "push": {
+          "type": "boolean",
+          "description": "should images be pushed to a registry. If not specified, images are pushed only if the current Kubernetes context connects to a remote cluster.",
+          "x-intellij-html-description": "should images be pushed to a registry. If not specified, images are pushed only if the current Kubernetes context connects to a remote cluster."
+        },
+        "tryImportMissing": {
+          "type": "boolean",
+          "description": "whether to attempt to import artifacts from Docker (either a local or remote registry) if not in the cache.",
+          "x-intellij-html-description": "whether to attempt to import artifacts from Docker (either a local or remote registry) if not in the cache.",
+          "default": "false"
+        },
+        "useBuildkit": {
+          "type": "boolean",
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
+        },
+        "useDockerCLI": {
+          "type": "boolean",
+          "description": "use `docker` command-line interface instead of Docker Engine APIs.",
+          "x-intellij-html-description": "use <code>docker</code> command-line interface instead of Docker Engine APIs.",
+          "default": "false"
+        }
+      },
+      "preferredOrder": [
+        "push",
+        "tryImportMissing",
+        "useDockerCLI",
+        "useBuildkit",
+        "concurrency"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
+      "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
+    },
+    "LocalVerifier": {
+      "type": "object",
+      "description": "uses the `docker` CLI to create verify test case containers on the host machine in Docker.",
+      "x-intellij-html-description": "uses the <code>docker</code> CLI to create verify test case containers on the host machine in Docker."
+    },
+    "LogsConfig": {
+      "properties": {
+        "jsonParse": {
+          "$ref": "#/definitions/JSONParseConfig",
+          "description": "defines the rules for parsing/outputting json logs.",
+          "x-intellij-html-description": "defines the rules for parsing/outputting json logs."
+        },
+        "prefix": {
+          "type": "string",
+          "description": "defines the prefix shown on each log line. Valid values are `container`: prefix logs lines with the name of the container. `podAndContainer`: prefix logs lines with the names of the pod and of the container. `auto`: same as `podAndContainer` except that the pod name is skipped if it's the same as the container name. `none`: don't add a prefix.",
+          "x-intellij-html-description": "defines the prefix shown on each log line. Valid values are <code>container</code>: prefix logs lines with the name of the container. <code>podAndContainer</code>: prefix logs lines with the names of the pod and of the container. <code>auto</code>: same as <code>podAndContainer</code> except that the pod name is skipped if it's the same as the container name. <code>none</code>: don't add a prefix.",
+          "default": "auto",
+          "enum": [
+            "container",
+            "podAndContainer",
+            "auto",
+            "none"
+          ]
+        }
+      },
+      "preferredOrder": [
+        "prefix",
+        "jsonParse"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "configures how container logs are printed as a result of a deployment.",
+      "x-intellij-html-description": "configures how container logs are printed as a result of a deployment."
+    },
+    "Metadata": {
+      "properties": {
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "a map of annotations providing additional metadata about the project.",
+          "x-intellij-html-description": "a map of annotations providing additional metadata about the project.",
+          "default": "{}"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "a map of labels identifying the project.",
+          "x-intellij-html-description": "a map of labels identifying the project.",
+          "default": "{}"
+        },
+        "name": {
+          "type": "string",
+          "description": "an identifier for the project.",
+          "x-intellij-html-description": "an identifier for the project."
+        }
+      },
+      "preferredOrder": [
+        "name",
+        "labels",
+        "annotations"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "holds an optional name of the project.",
+      "x-intellij-html-description": "holds an optional name of the project."
+    },
+    "NamedContainerHook": {
+      "required": [
+        "podName",
+        "command"
+      ],
+      "properties": {
+        "command": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "command to execute.",
+          "x-intellij-html-description": "command to execute.",
+          "default": "[]"
+        },
+        "containerName": {
+          "type": "string",
+          "description": "name of the container to execute the command in.",
+          "x-intellij-html-description": "name of the container to execute the command in."
+        },
+        "podName": {
+          "type": "string",
+          "description": "name of the pod to execute the command in.",
+          "x-intellij-html-description": "name of the pod to execute the command in."
+        }
+      },
+      "preferredOrder": [
+        "command",
+        "podName",
+        "containerName"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "describes a lifecycle hook definition to execute on a named container.",
+      "x-intellij-html-description": "describes a lifecycle hook definition to execute on a named container."
+    },
+    "PlatformEmulatorInstallStep": {
+      "required": [
+        "image"
+      ],
+      "properties": {
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "specifies arguments passed to the emulator installer image.",
+          "x-intellij-html-description": "specifies arguments passed to the emulator installer image.",
+          "default": "[]"
+        },
+        "entrypoint": {
+          "type": "string",
+          "description": "specifies the ENTRYPOINT argument to the emulator installer image.",
+          "x-intellij-html-description": "specifies the ENTRYPOINT argument to the emulator installer image."
+        },
+        "image": {
+          "type": "string",
+          "description": "specifies the image that will install the required tooling for QEMU emulation on the GoogleCloudBuild containers.",
+          "x-intellij-html-description": "specifies the image that will install the required tooling for QEMU emulation on the GoogleCloudBuild containers."
+        }
+      },
+      "preferredOrder": [
+        "image",
+        "args",
+        "entrypoint"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "specifies a pre-build step to install the required tooling for QEMU emulation on the GoogleCloudBuild containers. This enables performing cross-platform builds on GoogleCloudBuild.",
+      "x-intellij-html-description": "specifies a pre-build step to install the required tooling for QEMU emulation on the GoogleCloudBuild containers. This enables performing cross-platform builds on GoogleCloudBuild."
+    },
+    "PortForwardResource": {
+      "properties": {
+        "address": {
+          "type": "string",
+          "description": "local address to bind to. Defaults to the loopback address 127.0.0.1.",
+          "x-intellij-html-description": "local address to bind to. Defaults to the loopback address 127.0.0.1."
+        },
+        "localPort": {
+          "type": "integer",
+          "description": "local port to forward to. If the port is unavailable, Skaffold will choose a random open port to forward to. *Optional*.",
+          "x-intellij-html-description": "local port to forward to. If the port is unavailable, Skaffold will choose a random open port to forward to. <em>Optional</em>."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "namespace of the resource to port forward. Does not apply to local containers.",
+          "x-intellij-html-description": "namespace of the resource to port forward. Does not apply to local containers."
+        },
+        "port": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "description": "resource port that will be forwarded.",
+          "x-intellij-html-description": "resource port that will be forwarded."
+        },
+        "resourceName": {
+          "type": "string",
+          "description": "name of the Kubernetes resource or local container to port forward.",
+          "x-intellij-html-description": "name of the Kubernetes resource or local container to port forward."
+        },
+        "resourceType": {
+          "type": "string",
+          "description": "resource type that should be port forwarded. Acceptable resource types include kubernetes types: `Service`, `Pod` and Controller resource type that has a pod spec: `ReplicaSet`, `ReplicationController`, `Deployment`, `StatefulSet`, `DaemonSet`, `Job`, `CronJob`. Standalone `Container` is also valid for Docker deployments.",
+          "x-intellij-html-description": "resource type that should be port forwarded. Acceptable resource types include kubernetes types: <code>Service</code>, <code>Pod</code> and Controller resource type that has a pod spec: <code>ReplicaSet</code>, <code>ReplicationController</code>, <code>Deployment</code>, <code>StatefulSet</code>, <code>DaemonSet</code>, <code>Job</code>, <code>CronJob</code>. Standalone <code>Container</code> is also valid for Docker deployments."
+        }
+      },
+      "preferredOrder": [
+        "resourceType",
+        "resourceName",
+        "namespace",
+        "port",
+        "address",
+        "localPort"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "describes a resource to port forward.",
+      "x-intellij-html-description": "describes a resource to port forward."
+    },
+    "Profile": {
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "activation": {
+          "items": {
+            "$ref": "#/definitions/Activation"
+          },
+          "type": "array",
+          "description": "criteria by which a profile can be auto-activated. The profile is auto-activated if any one of the activations are triggered. An activation is triggered if all of the criteria (env, kubeContext, command) are triggered.",
+          "x-intellij-html-description": "criteria by which a profile can be auto-activated. The profile is auto-activated if any one of the activations are triggered. An activation is triggered if all of the criteria (env, kubeContext, command) are triggered."
+        },
+        "build": {
+          "$ref": "#/definitions/BuildConfig",
+          "description": "describes how images are built.",
+          "x-intellij-html-description": "describes how images are built."
+        },
+        "customActions": {
+          "items": {
+            "$ref": "#/definitions/Action"
+          },
+          "type": "array",
+          "description": "describes a list of user defined actions that can be triggered with `skaffold exec`.",
+          "x-intellij-html-description": "describes a list of user defined actions that can be triggered with <code>skaffold exec</code>."
+        },
+        "deploy": {
+          "$ref": "#/definitions/DeployConfig",
+          "description": "describes how the manifests are deployed.",
+          "x-intellij-html-description": "describes how the manifests are deployed."
+        },
+        "manifests": {
+          "$ref": "#/definitions/RenderConfig",
+          "description": "describes how the original manifests are hydrated, validated and transformed.",
+          "x-intellij-html-description": "describes how the original manifests are hydrated, validated and transformed."
+        },
+        "name": {
+          "type": "string",
+          "description": "a unique profile name.",
+          "x-intellij-html-description": "a unique profile name.",
+          "examples": [
+            "profile-prod"
+          ]
+        },
+        "patches": {
+          "items": {
+            "$ref": "#/definitions/JSONPatch"
+          },
+          "type": "array",
+          "description": "patches applied to the configuration. Patches use the JSON patch notation.",
+          "x-intellij-html-description": "patches applied to the configuration. Patches use the JSON patch notation."
+        },
+        "portForward": {
+          "items": {
+            "$ref": "#/definitions/PortForwardResource"
+          },
+          "type": "array",
+          "description": "describes user defined resources to port-forward.",
+          "x-intellij-html-description": "describes user defined resources to port-forward."
+        },
+        "requiresAllActivations": {
+          "type": "boolean",
+          "description": "activation strategy of the profile. When true, the profile is auto-activated only when all of its activations are triggered. When false, the profile is auto-activated when any one of its activations is triggered.",
+          "x-intellij-html-description": "activation strategy of the profile. When true, the profile is auto-activated only when all of its activations are triggered. When false, the profile is auto-activated when any one of its activations is triggered.",
+          "default": "false"
+        },
+        "resourceSelector": {
+          "$ref": "#/definitions/ResourceSelectorConfig",
+          "description": "describes user defined filters describing how skaffold should treat objects/fields during rendering.",
+          "x-intellij-html-description": "describes user defined filters describing how skaffold should treat objects/fields during rendering."
+        },
+        "test": {
+          "items": {
+            "$ref": "#/definitions/TestCase"
+          },
+          "type": "array",
+          "description": "describes how images are tested.",
+          "x-intellij-html-description": "describes how images are tested."
+        },
+        "verify": {
+          "items": {
+            "$ref": "#/definitions/VerifyTestCase"
+          },
+          "type": "array",
+          "description": "describes how images are verified (via verification tests).",
+          "x-intellij-html-description": "describes how images are verified (via verification tests)."
+        }
+      },
+      "preferredOrder": [
+        "name",
+        "activation",
+        "requiresAllActivations",
+        "patches",
+        "build",
+        "test",
+        "manifests",
+        "deploy",
+        "portForward",
+        "resourceSelector",
+        "verify",
+        "customActions"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "used to override any `build`, `test` or `deploy` configuration.",
+      "x-intellij-html-description": "used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
+    },
+    "ProfileDependency": {
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "activatedBy": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "describes a list of profiles in the current config that when activated will also activate the named profile in the dependency config. If empty then the named profile is always activated.",
+          "x-intellij-html-description": "describes a list of profiles in the current config that when activated will also activate the named profile in the dependency config. If empty then the named profile is always activated.",
+          "default": "[]"
+        },
+        "name": {
+          "type": "string",
+          "description": "describes name of the profile to activate in the dependency config. It should exist in the dependency config.",
+          "x-intellij-html-description": "describes name of the profile to activate in the dependency config. It should exist in the dependency config."
+        }
+      },
+      "preferredOrder": [
+        "name",
+        "activatedBy"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "describes a mapping from referenced config profiles to the current config profiles. If the current config is activated with a profile in this mapping then the dependency configs are also activated with the corresponding mapped profiles.",
+      "x-intellij-html-description": "describes a mapping from referenced config profiles to the current config profiles. If the current config is activated with a profile in this mapping then the dependency configs are also activated with the corresponding mapped profiles."
+    },
+    "RemoteManifest": {
+      "properties": {
+        "kubeContext": {
+          "type": "string",
+          "description": "Kubernetes context that Skaffold should deploy to.",
+          "x-intellij-html-description": "Kubernetes context that Skaffold should deploy to.",
+          "examples": [
+            "minikube"
+          ]
+        },
+        "manifest": {
+          "type": "string",
+          "description": "specifies the Kubernetes manifest in the remote cluster.",
+          "x-intellij-html-description": "specifies the Kubernetes manifest in the remote cluster."
+        }
+      },
+      "preferredOrder": [
+        "manifest",
+        "kubeContext"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "defines the paths to be modified with kustomize, along with extra flags to be passed to kustomize.",
+      "x-intellij-html-description": "defines the paths to be modified with kustomize, along with extra flags to be passed to kustomize."
+    },
+    "RenderConfig": {
+      "properties": {
+        "helm": {
+          "$ref": "#/definitions/Helm",
+          "description": "defines the helm charts used in the application. NOTE: Defines cherts in this section to render via helm but deployed via kubectl or kpt deployer. To use helm to deploy, please see deploy.helm section.",
+          "x-intellij-html-description": "defines the helm charts used in the application. NOTE: Defines cherts in this section to render via helm but deployed via kubectl or kpt deployer. To use helm to deploy, please see deploy.helm section."
+        },
+        "hooks": {
+          "$ref": "#/definitions/RenderHooks",
+          "description": "describes a set of lifecycle hooks that are executed before and after every render.",
+          "x-intellij-html-description": "describes a set of lifecycle hooks that are executed before and after every render."
+        },
+        "kpt": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "defines the kpt resources in the application.",
+          "x-intellij-html-description": "defines the kpt resources in the application.",
+          "default": "[]"
+        },
+        "kustomize": {
+          "$ref": "#/definitions/Kustomize",
+          "description": "defines the paths to be modified with kustomize, along with extra flags to be passed to kustomize.",
+          "x-intellij-html-description": "defines the paths to be modified with kustomize, along with extra flags to be passed to kustomize."
+        },
+        "output": {
+          "type": "string",
+          "description": "path to the hydrated directory.",
+          "x-intellij-html-description": "path to the hydrated directory."
+        },
+        "rawYaml": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "defines the raw kubernetes resources.",
+          "x-intellij-html-description": "defines the raw kubernetes resources.",
+          "default": "[]"
+        },
+        "remoteManifests": {
+          "items": {
+            "$ref": "#/definitions/RemoteManifest"
+          },
+          "type": "array",
+          "description": "Kubernetes manifests in remote clusters.",
+          "x-intellij-html-description": "Kubernetes manifests in remote clusters."
+        },
+        "transform": {
+          "description": "defines a set of transformation operations to run in series.",
+          "x-intellij-html-description": "defines a set of transformation operations to run in series."
+        },
+        "validate": {
+          "description": "defines a set of validator operations to run in series.",
+          "x-intellij-html-description": "defines a set of validator operations to run in series."
+        }
+      },
+      "preferredOrder": [
+        "rawYaml",
+        "remoteManifests",
+        "kustomize",
+        "helm",
+        "kpt",
+        "hooks",
+        "transform",
+        "validate",
+        "output"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "contains all the configuration needed by the render steps.",
+      "x-intellij-html-description": "contains all the configuration needed by the render steps."
+    },
+    "RenderHookItem": {
+      "properties": {
+        "host": {
+          "$ref": "#/definitions/HostHook",
+          "description": "describes a single lifecycle hook to run on the host machine.",
+          "x-intellij-html-description": "describes a single lifecycle hook to run on the host machine."
+        }
+      },
+      "preferredOrder": [
+        "host"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "describes a single lifecycle hook to execute before or after each deployer step.",
+      "x-intellij-html-description": "describes a single lifecycle hook to execute before or after each deployer step."
+    },
+    "RenderHooks": {
+      "properties": {
+        "after": {
+          "items": {
+            "$ref": "#/definitions/RenderHookItem"
+          },
+          "type": "array",
+          "description": "describes the list of lifecycle hooks to execute *after* each render step.",
+          "x-intellij-html-description": "describes the list of lifecycle hooks to execute <em>after</em> each render step."
+        },
+        "before": {
+          "items": {
+            "$ref": "#/definitions/RenderHookItem"
+          },
+          "type": "array",
+          "description": "describes the list of lifecycle hooks to execute *before* each render step. Container hooks will only run if the container exists from a previous deployment step (for instance the successive iterations of a dev-loop during `skaffold dev`).",
+          "x-intellij-html-description": "describes the list of lifecycle hooks to execute <em>before</em> each render step. Container hooks will only run if the container exists from a previous deployment step (for instance the successive iterations of a dev-loop during <code>skaffold dev</code>)."
+        }
+      },
+      "preferredOrder": [
+        "before",
+        "after"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "describes the list of lifecycle hooks to execute before and after each render step.",
+      "x-intellij-html-description": "describes the list of lifecycle hooks to execute before and after each render step."
+    },
+    "ResourceFilter": {
+      "required": [
+        "groupKind"
+      ],
+      "properties": {
+        "groupKind": {
+          "type": "string",
+          "description": "compact format of a resource type.",
+          "x-intellij-html-description": "compact format of a resource type."
+        },
+        "image": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "an optional slice of JSON-path-like paths of where to rewrite images.",
+          "x-intellij-html-description": "an optional slice of JSON-path-like paths of where to rewrite images.",
+          "default": "[]"
+        },
+        "labels": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "an optional slice of JSON-path-like paths of where to add a labels block if missing.",
+          "x-intellij-html-description": "an optional slice of JSON-path-like paths of where to add a labels block if missing.",
+          "default": "[]"
+        },
+        "podSpec": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "an optional slice of JSON-path-like paths of where pod spec properties can be overwritten.",
+          "x-intellij-html-description": "an optional slice of JSON-path-like paths of where pod spec properties can be overwritten.",
+          "default": "[]"
+        }
+      },
+      "preferredOrder": [
+        "groupKind",
+        "image",
+        "labels",
+        "podSpec"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "contains definition to filter which resource to transform.",
+      "x-intellij-html-description": "contains definition to filter which resource to transform."
+    },
+    "ResourceRequirement": {
+      "properties": {
+        "cpu": {
+          "type": "string",
+          "description": "the number cores to be used.",
+          "x-intellij-html-description": "the number cores to be used.",
+          "examples": [
+            "2`, `2.0` or `200m"
+          ]
+        },
+        "ephemeralStorage": {
+          "type": "string",
+          "description": "the amount of Ephemeral storage to allocate to the pod.",
+          "x-intellij-html-description": "the amount of Ephemeral storage to allocate to the pod.",
+          "examples": [
+            "1Gi` or `1000Mi"
+          ]
+        },
+        "memory": {
+          "type": "string",
+          "description": "the amount of memory to allocate to the pod.",
+          "x-intellij-html-description": "the amount of memory to allocate to the pod.",
+          "examples": [
+            "1Gi` or `1000Mi"
+          ]
+        },
+        "resourceStorage": {
+          "type": "string",
+          "description": "the amount of resource storage to allocate to the pod.",
+          "x-intellij-html-description": "the amount of resource storage to allocate to the pod.",
+          "examples": [
+            "1Gi` or `1000Mi"
+          ]
+        }
+      },
+      "preferredOrder": [
+        "cpu",
+        "memory",
+        "ephemeralStorage",
+        "resourceStorage"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "stores the CPU/Memory requirements for the pod.",
+      "x-intellij-html-description": "stores the CPU/Memory requirements for the pod."
+    },
+    "ResourceRequirements": {
+      "properties": {
+        "limits": {
+          "$ref": "#/definitions/ResourceRequirement",
+          "description": "[resource limits](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container) for the Kaniko pod.",
+          "x-intellij-html-description": "<a href=\"https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container\">resource limits</a> for the Kaniko pod."
+        },
+        "requests": {
+          "$ref": "#/definitions/ResourceRequirement",
+          "description": "[resource requests](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container) for the Kaniko pod.",
+          "x-intellij-html-description": "<a href=\"https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container\">resource requests</a> for the Kaniko pod."
+        }
+      },
+      "preferredOrder": [
+        "requests",
+        "limits"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "describes the resource requirements for the kaniko pod.",
+      "x-intellij-html-description": "describes the resource requirements for the kaniko pod."
+    },
+    "ResourceSelectorConfig": {
+      "properties": {
+        "allow": {
+          "items": {
+            "$ref": "#/definitions/ResourceFilter"
+          },
+          "type": "array",
+          "description": "configures an allowlist for transforming manifests.",
+          "x-intellij-html-description": "configures an allowlist for transforming manifests."
+        },
+        "deny": {
+          "items": {
+            "$ref": "#/definitions/ResourceFilter"
+          },
+          "type": "array",
+          "description": "configures an allowlist for transforming manifests.",
+          "x-intellij-html-description": "configures an allowlist for transforming manifests."
+        }
+      },
+      "preferredOrder": [
+        "allow",
+        "deny"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "contains all the configuration needed by the deploy steps.",
+      "x-intellij-html-description": "contains all the configuration needed by the deploy steps."
+    },
+    "ResourceType": {
+      "type": "string",
+      "description": "describes the Kubernetes resource types used for port forwarding.",
+      "x-intellij-html-description": "describes the Kubernetes resource types used for port forwarding."
+    },
+    "ShaTagger": {
+      "type": "object",
+      "description": "*beta* tags images with their sha256 digest.",
+      "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
+    },
+    "SkaffoldConfig": {
+      "required": [
+        "apiVersion",
+        "kind"
+      ],
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "version of the configuration.",
+          "x-intellij-html-description": "version of the configuration."
+        },
+        "build": {
+          "$ref": "#/definitions/BuildConfig",
+          "description": "describes how images are built.",
+          "x-intellij-html-description": "describes how images are built."
+        },
+        "customActions": {
+          "items": {
+            "$ref": "#/definitions/Action"
+          },
+          "type": "array",
+          "description": "describes a list of user defined actions that can be triggered with `skaffold exec`.",
+          "x-intellij-html-description": "describes a list of user defined actions that can be triggered with <code>skaffold exec</code>."
+        },
+        "deploy": {
+          "$ref": "#/definitions/DeployConfig",
+          "description": "describes how the manifests are deployed.",
+          "x-intellij-html-description": "describes how the manifests are deployed."
+        },
+        "kind": {
+          "type": "string",
+          "description": "always `Config`.",
+          "x-intellij-html-description": "always <code>Config</code>.",
+          "default": "Config"
+        },
+        "manifests": {
+          "$ref": "#/definitions/RenderConfig",
+          "description": "describes how the original manifests are hydrated, validated and transformed.",
+          "x-intellij-html-description": "describes how the original manifests are hydrated, validated and transformed."
+        },
+        "metadata": {
+          "$ref": "#/definitions/Metadata",
+          "description": "holds additional information about the config.",
+          "x-intellij-html-description": "holds additional information about the config."
+        },
+        "portForward": {
+          "items": {
+            "$ref": "#/definitions/PortForwardResource"
+          },
+          "type": "array",
+          "description": "describes user defined resources to port-forward.",
+          "x-intellij-html-description": "describes user defined resources to port-forward."
+        },
+        "profiles": {
+          "items": {
+            "$ref": "#/definitions/Profile"
+          },
+          "type": "array",
+          "description": "*beta* can override be used to `build`, `test` or `deploy` configuration.",
+          "x-intellij-html-description": "<em>beta</em> can override be used to <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
+        },
+        "requires": {
+          "items": {
+            "$ref": "#/definitions/ConfigDependency"
+          },
+          "type": "array",
+          "description": "describes a list of other required configs for the current config.",
+          "x-intellij-html-description": "describes a list of other required configs for the current config."
+        },
+        "resourceSelector": {
+          "$ref": "#/definitions/ResourceSelectorConfig",
+          "description": "describes user defined filters describing how skaffold should treat objects/fields during rendering.",
+          "x-intellij-html-description": "describes user defined filters describing how skaffold should treat objects/fields during rendering."
+        },
+        "test": {
+          "items": {
+            "$ref": "#/definitions/TestCase"
+          },
+          "type": "array",
+          "description": "describes how images are tested.",
+          "x-intellij-html-description": "describes how images are tested."
+        },
+        "verify": {
+          "items": {
+            "$ref": "#/definitions/VerifyTestCase"
+          },
+          "type": "array",
+          "description": "describes how images are verified (via verification tests).",
+          "x-intellij-html-description": "describes how images are verified (via verification tests)."
+        }
+      },
+      "preferredOrder": [
+        "apiVersion",
+        "kind",
+        "metadata",
+        "requires",
+        "build",
+        "test",
+        "manifests",
+        "deploy",
+        "portForward",
+        "resourceSelector",
+        "verify",
+        "customActions",
+        "profiles"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",
+      "x-intellij-html-description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml)."
+    },
+    "Sync": {
+      "properties": {
+        "auto": {
+          "type": "boolean",
+          "description": "delegates discovery of sync rules to the build system. Only available for jib and buildpacks.",
+          "x-intellij-html-description": "delegates discovery of sync rules to the build system. Only available for jib and buildpacks."
+        },
+        "hooks": {
+          "$ref": "#/definitions/SyncHooks",
+          "description": "describes a set of lifecycle hooks that are executed before and after each file sync action on the target artifact's containers.",
+          "x-intellij-html-description": "describes a set of lifecycle hooks that are executed before and after each file sync action on the target artifact's containers."
+        },
+        "infer": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "file patterns which may be synced into the container The container destination is inferred by the builder based on the instructions of a Dockerfile. Available for docker and kaniko artifacts and custom artifacts that declare dependencies on a dockerfile.",
+          "x-intellij-html-description": "file patterns which may be synced into the container The container destination is inferred by the builder based on the instructions of a Dockerfile. Available for docker and kaniko artifacts and custom artifacts that declare dependencies on a dockerfile.",
+          "default": "[]"
+        },
+        "manual": {
+          "items": {
+            "$ref": "#/definitions/SyncRule"
+          },
+          "type": "array",
+          "description": "manual sync rules indicating the source and destination.",
+          "x-intellij-html-description": "manual sync rules indicating the source and destination."
+        }
+      },
+      "preferredOrder": [
+        "manual",
+        "infer",
+        "auto",
+        "hooks"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "*beta* specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
+      "x-intellij-html-description": "<em>beta</em> specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
+      "default": "infer: [\"**/*\"]"
+    },
+    "SyncHookItem": {
+      "properties": {
+        "container": {
+          "$ref": "#/definitions/ContainerHook",
+          "description": "describes a single lifecycle hook to run on a container.",
+          "x-intellij-html-description": "describes a single lifecycle hook to run on a container."
+        },
+        "host": {
+          "$ref": "#/definitions/HostHook",
+          "description": "describes a single lifecycle hook to run on the host machine.",
+          "x-intellij-html-description": "describes a single lifecycle hook to run on the host machine."
+        }
+      },
+      "preferredOrder": [
+        "host",
+        "container"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "describes a single lifecycle hook to execute before or after each artifact sync step.",
+      "x-intellij-html-description": "describes a single lifecycle hook to execute before or after each artifact sync step."
+    },
+    "SyncHooks": {
+      "properties": {
+        "after": {
+          "items": {
+            "$ref": "#/definitions/SyncHookItem"
+          },
+          "type": "array",
+          "description": "describes the list of lifecycle hooks to execute *after* each artifact sync step.",
+          "x-intellij-html-description": "describes the list of lifecycle hooks to execute <em>after</em> each artifact sync step."
+        },
+        "before": {
+          "items": {
+            "$ref": "#/definitions/SyncHookItem"
+          },
+          "type": "array",
+          "description": "describes the list of lifecycle hooks to execute *before* each artifact sync step.",
+          "x-intellij-html-description": "describes the list of lifecycle hooks to execute <em>before</em> each artifact sync step."
+        }
+      },
+      "preferredOrder": [
+        "before",
+        "after"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "describes the list of lifecycle hooks to execute before and after each artifact sync step.",
+      "x-intellij-html-description": "describes the list of lifecycle hooks to execute before and after each artifact sync step."
+    },
+    "SyncRule": {
+      "required": [
+        "src",
+        "dest"
+      ],
+      "properties": {
+        "dest": {
+          "type": "string",
+          "description": "destination path in the container where the files should be synced to.",
+          "x-intellij-html-description": "destination path in the container where the files should be synced to.",
+          "examples": [
+            "\"app/\""
+          ]
+        },
+        "src": {
+          "type": "string",
+          "description": "a glob pattern to match local paths against. Directories should be delimited by `/` on all platforms.",
+          "x-intellij-html-description": "a glob pattern to match local paths against. Directories should be delimited by <code>/</code> on all platforms.",
+          "examples": [
+            "\"css/**/*.css\""
+          ]
+        },
+        "strip": {
+          "type": "string",
+          "description": "specifies the path prefix to remove from the source path when transplanting the files into the destination folder.",
+          "x-intellij-html-description": "specifies the path prefix to remove from the source path when transplanting the files into the destination folder.",
+          "examples": [
+            "\"css/\""
+          ]
+        }
+      },
+      "preferredOrder": [
+        "src",
+        "dest",
+        "strip"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "specifies which local files to sync to remote folders.",
+      "x-intellij-html-description": "specifies which local files to sync to remote folders."
+    },
+    "TagPolicy": {
+      "properties": {
+        "customTemplate": {
+          "$ref": "#/definitions/CustomTemplateTagger",
+          "description": "*beta* tags images with a configurable template string *composed of other taggers*.",
+          "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string <em>composed of other taggers</em>."
+        },
+        "dateTime": {
+          "$ref": "#/definitions/DateTimeTagger",
+          "description": "*beta* tags images with the build timestamp.",
+          "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
+        },
+        "envTemplate": {
+          "$ref": "#/definitions/EnvTemplateTagger",
+          "description": "*beta* tags images with a configurable template string.",
+          "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
+        },
+        "gitCommit": {
+          "$ref": "#/definitions/GitTagger",
+          "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
+          "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
+        },
+        "inputDigest": {
+          "$ref": "#/definitions/InputDigest",
+          "description": "*beta* tags images with their sha256 digest of their content.",
+          "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest of their content."
+        },
+        "sha256": {
+          "$ref": "#/definitions/ShaTagger",
+          "description": "*beta* tags images with their sha256 digest.",
+          "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
+        }
+      },
+      "preferredOrder": [
+        "gitCommit",
+        "sha256",
+        "envTemplate",
+        "dateTime",
+        "customTemplate",
+        "inputDigest"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "contains all the configuration for the tagging step.",
+      "x-intellij-html-description": "contains all the configuration for the tagging step."
+    },
+    "TaggerComponent": {
+      "type": "object",
+      "anyOf": [
+        {
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "an identifier for the component.",
+              "x-intellij-html-description": "an identifier for the component."
+            }
+          },
+          "preferredOrder": [
+            "name"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "gitCommit": {
+              "$ref": "#/definitions/GitTagger",
+              "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
+              "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
+            },
+            "name": {
+              "type": "string",
+              "description": "an identifier for the component.",
+              "x-intellij-html-description": "an identifier for the component."
+            }
+          },
+          "preferredOrder": [
+            "name",
+            "gitCommit"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "an identifier for the component.",
+              "x-intellij-html-description": "an identifier for the component."
+            },
+            "sha256": {
+              "$ref": "#/definitions/ShaTagger",
+              "description": "*beta* tags images with their sha256 digest.",
+              "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
+            }
+          },
+          "preferredOrder": [
+            "name",
+            "sha256"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "envTemplate": {
+              "$ref": "#/definitions/EnvTemplateTagger",
+              "description": "*beta* tags images with a configurable template string.",
+              "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
+            },
+            "name": {
+              "type": "string",
+              "description": "an identifier for the component.",
+              "x-intellij-html-description": "an identifier for the component."
+            }
+          },
+          "preferredOrder": [
+            "name",
+            "envTemplate"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "dateTime": {
+              "$ref": "#/definitions/DateTimeTagger",
+              "description": "*beta* tags images with the build timestamp.",
+              "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
+            },
+            "name": {
+              "type": "string",
+              "description": "an identifier for the component.",
+              "x-intellij-html-description": "an identifier for the component."
+            }
+          },
+          "preferredOrder": [
+            "name",
+            "dateTime"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "customTemplate": {
+              "$ref": "#/definitions/CustomTemplateTagger",
+              "description": "*beta* tags images with a configurable template string *composed of other taggers*.",
+              "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string <em>composed of other taggers</em>."
+            },
+            "name": {
+              "type": "string",
+              "description": "an identifier for the component.",
+              "x-intellij-html-description": "an identifier for the component."
+            }
+          },
+          "preferredOrder": [
+            "name",
+            "customTemplate"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "inputDigest": {
+              "$ref": "#/definitions/InputDigest",
+              "description": "*beta* tags images with their sha256 digest of their content.",
+              "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest of their content."
+            },
+            "name": {
+              "type": "string",
+              "description": "an identifier for the component.",
+              "x-intellij-html-description": "an identifier for the component."
+            }
+          },
+          "preferredOrder": [
+            "name",
+            "inputDigest"
+          ],
+          "additionalProperties": false
+        }
+      ],
+      "description": "*beta* a component of CustomTemplateTagger.",
+      "x-intellij-html-description": "<em>beta</em> a component of CustomTemplateTagger."
+    },
+    "TestCase": {
+      "required": [
+        "image"
+      ],
+      "properties": {
+        "context": {
+          "type": "string",
+          "description": "directory containing the test sources.",
+          "x-intellij-html-description": "directory containing the test sources.",
+          "default": "."
+        },
+        "custom": {
+          "items": {
+            "$ref": "#/definitions/CustomTest"
+          },
+          "type": "array",
+          "description": "the set of custom tests to run after an artifact is built.",
+          "x-intellij-html-description": "the set of custom tests to run after an artifact is built."
+        },
+        "image": {
+          "type": "string",
+          "description": "artifact on which to run those tests.",
+          "x-intellij-html-description": "artifact on which to run those tests.",
+          "examples": [
+            "gcr.io/k8s-skaffold/example"
+          ]
+        },
+        "structureTests": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "the [Container Structure Tests](https://github.com/GoogleContainerTools/container-structure-test) to run on that artifact.",
+          "x-intellij-html-description": "the <a href=\"https://github.com/GoogleContainerTools/container-structure-test\">Container Structure Tests</a> to run on that artifact.",
+          "default": "[]",
+          "examples": [
+            "[\"./test/*\"]"
+          ]
+        },
+        "structureTestsArgs": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "additional configuration arguments passed to `container-structure-test` binary.",
+          "x-intellij-html-description": "additional configuration arguments passed to <code>container-structure-test</code> binary.",
+          "default": "[]",
+          "examples": [
+            "[\"--driver=tar\", \"--no-color\", \"-q\"]"
+          ]
+        }
+      },
+      "preferredOrder": [
+        "image",
+        "context",
+        "custom",
+        "structureTests",
+        "structureTestsArgs"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "a list of tests to run on images that Skaffold builds.",
+      "x-intellij-html-description": "a list of tests to run on images that Skaffold builds."
+    },
+    "Transformer": {
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "configMap": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "allows users to provide additional config data to the kpt function.",
+          "x-intellij-html-description": "allows users to provide additional config data to the kpt function.",
+          "default": "[]"
+        },
+        "name": {
+          "type": "string",
+          "description": "transformer name. Can only accept skaffold whitelisted tools.",
+          "x-intellij-html-description": "transformer name. Can only accept skaffold whitelisted tools."
+        }
+      },
+      "preferredOrder": [
+        "name",
+        "configMap"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "describes the supported kpt transformers.",
+      "x-intellij-html-description": "describes the supported kpt transformers."
+    },
+    "Validator": {
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "configMap": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "allows users to provide additional config data to the kpt function.",
+          "x-intellij-html-description": "allows users to provide additional config data to the kpt function.",
+          "default": "[]"
+        },
+        "name": {
+          "type": "string",
+          "description": "Validator name. Can only accept skaffold whitelisted tools.",
+          "x-intellij-html-description": "Validator name. Can only accept skaffold whitelisted tools."
+        }
+      },
+      "preferredOrder": [
+        "name",
+        "configMap"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "describes the supported kpt validators.",
+      "x-intellij-html-description": "describes the supported kpt validators."
+    },
+    "VerifyContainer": {
+      "required": [
+        "name",
+        "image"
+      ],
+      "properties": {
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "arguments to the entrypoint. The container image's CMD is used if this is not provided.",
+          "x-intellij-html-description": "arguments to the entrypoint. The container image's CMD is used if this is not provided.",
+          "default": "[]"
+        },
+        "command": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "entrypoint array. Not executed within a shell. The container image's ENTRYPOINT is used if this is not provided.",
+          "x-intellij-html-description": "entrypoint array. Not executed within a shell. The container image's ENTRYPOINT is used if this is not provided.",
+          "default": "[]"
+        },
+        "image": {
+          "type": "string",
+          "description": "container image name.",
+          "x-intellij-html-description": "container image name."
+        },
+        "name": {
+          "type": "string",
+          "description": "name of the container.",
+          "x-intellij-html-description": "name of the container."
+        }
+      },
+      "preferredOrder": [
+        "name",
+        "image",
+        "command",
+        "args"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "a list of tests to run on images that Skaffold builds.",
+      "x-intellij-html-description": "a list of tests to run on images that Skaffold builds."
+    },
+    "VerifyEnvVar": {
+      "type": "object",
+      "description": "represents an environment variable present in a Container.",
+      "x-intellij-html-description": "represents an environment variable present in a Container."
+    },
+    "VerifyExecutionModeConfig": {
+      "properties": {
+        "kubernetesCluster": {
+          "$ref": "#/definitions/KubernetesClusterVerifier",
+          "description": "uses the `kubectl` CLI to create veriy test case container in a kubernetes cluster.",
+          "x-intellij-html-description": "uses the <code>kubectl</code> CLI to create veriy test case container in a kubernetes cluster."
+        },
+        "local": {
+          "$ref": "#/definitions/LocalVerifier",
+          "description": "uses the `docker` CLI to create verify test case containers on the host machine in Docker. This is the default execution mode.",
+          "x-intellij-html-description": "uses the <code>docker</code> CLI to create verify test case containers on the host machine in Docker. This is the default execution mode."
+        }
+      },
+      "preferredOrder": [
+        "local",
+        "kubernetesCluster"
+      ],
+      "type": "object",
+      "description": "contains all the configuration needed by the verify execution modes.",
+      "x-intellij-html-description": "contains all the configuration needed by the verify execution modes."
+    },
+    "VerifyTestCase": {
+      "required": [
+        "name",
+        "container"
+      ],
+      "properties": {
+        "container": {
+          "$ref": "#/definitions/VerifyContainer",
+          "description": "container information for the verify test.",
+          "x-intellij-html-description": "container information for the verify test."
+        },
+        "executionMode": {
+          "$ref": "#/definitions/VerifyExecutionModeConfig",
+          "description": "execution mode used to execute the verify test case.",
+          "x-intellij-html-description": "execution mode used to execute the verify test case."
+        },
+        "name": {
+          "type": "string",
+          "description": "name descriptor for the verify test.",
+          "x-intellij-html-description": "name descriptor for the verify test."
+        }
+      },
+      "preferredOrder": [
+        "name",
+        "container",
+        "executionMode"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "a list of tests to run on images that Skaffold builds.",
+      "x-intellij-html-description": "a list of tests to run on images that Skaffold builds."
+    }
+  }
+}

--- a/integration/examples/bazel/skaffold.yaml
+++ b/integration/examples/bazel/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/examples/buildpacks-java/skaffold.yaml
+++ b/integration/examples/buildpacks-java/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/examples/buildpacks-node/skaffold.yaml
+++ b/integration/examples/buildpacks-node/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/examples/buildpacks-python/skaffold.yaml
+++ b/integration/examples/buildpacks-python/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/examples/buildpacks/skaffold.yaml
+++ b/integration/examples/buildpacks/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/examples/cross-platform-builds/skaffold.yaml
+++ b/integration/examples/cross-platform-builds/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/examples/custom-buildx/skaffold.yaml
+++ b/integration/examples/custom-buildx/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   platforms: ["linux/amd64", "linux/arm64"]

--- a/integration/examples/custom-tests/skaffold.yaml
+++ b/integration/examples/custom-tests/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/examples/custom/skaffold.yaml
+++ b/integration/examples/custom/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/examples/dev-journey-buildpacks/skaffold.yaml
+++ b/integration/examples/dev-journey-buildpacks/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/examples/docker-deploy/skaffold.yaml
+++ b/integration/examples/docker-deploy/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   local:

--- a/integration/examples/gcb-kaniko/skaffold.yaml
+++ b/integration/examples/gcb-kaniko/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   googleCloudBuild:

--- a/integration/examples/generate-pipeline/skaffold.yaml
+++ b/integration/examples/generate-pipeline/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/examples/getting-started-kustomize/skaffold.yaml
+++ b/integration/examples/getting-started-kustomize/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 metadata:
   name: getting-started-kustomize

--- a/integration/examples/getting-started/skaffold.yaml
+++ b/integration/examples/getting-started/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/examples/go-integration-coverage/skaffold.yaml
+++ b/integration/examples/go-integration-coverage/skaffold.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 metadata:
   name: go-integration-coverage

--- a/integration/examples/google-cloud-build/skaffold.yaml
+++ b/integration/examples/google-cloud-build/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   googleCloudBuild:

--- a/integration/examples/grpc-e2e-tests/skaffold.yaml
+++ b/integration/examples/grpc-e2e-tests/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 metadata:
   name: visitor-counter-e2e

--- a/integration/examples/helm-deployment-dependencies/skaffold.yaml
+++ b/integration/examples/helm-deployment-dependencies/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   tagPolicy:

--- a/integration/examples/helm-deployment/skaffold.yaml
+++ b/integration/examples/helm-deployment/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/examples/helm-remote-repo/skaffold.yaml
+++ b/integration/examples/helm-remote-repo/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 deploy:
   helm:

--- a/integration/examples/helm-render/skaffold.yaml
+++ b/integration/examples/helm-render/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/examples/hot-reload/skaffold.yaml
+++ b/integration/examples/hot-reload/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/examples/jib-gradle/skaffold.yaml
+++ b/integration/examples/jib-gradle/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/examples/jib-multimodule/skaffold.yaml
+++ b/integration/examples/jib-multimodule/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/examples/jib-sync/skaffold-gradle.yaml
+++ b/integration/examples/jib-sync/skaffold-gradle.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/examples/jib-sync/skaffold-maven.yaml
+++ b/integration/examples/jib-sync/skaffold-maven.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/examples/jib/skaffold.yaml
+++ b/integration/examples/jib/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/examples/kaniko/skaffold.yaml
+++ b/integration/examples/kaniko/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/examples/ko-sync-infer/skaffold.yaml
+++ b/integration/examples/ko-sync-infer/skaffold.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/examples/ko/skaffold.yaml
+++ b/integration/examples/ko/skaffold.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/examples/kustomize/skaffold-kustomize-args.yaml
+++ b/integration/examples/kustomize/skaffold-kustomize-args.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 deploy:
   kustomize:

--- a/integration/examples/kustomize/skaffold.yaml
+++ b/integration/examples/kustomize/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 manifests:
   kustomize:

--- a/integration/examples/lifecycle-hooks/skaffold.yaml
+++ b/integration/examples/lifecycle-hooks/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 manifests:
   rawYaml:

--- a/integration/examples/microservices/skaffold.yaml
+++ b/integration/examples/microservices/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/examples/multi-config-microservices/base/skaffold.yaml
+++ b/integration/examples/multi-config-microservices/base/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/examples/multi-config-microservices/leeroy-app/skaffold.yaml
+++ b/integration/examples/multi-config-microservices/leeroy-app/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 metadata:
   name: app-config

--- a/integration/examples/multi-config-microservices/leeroy-web/skaffold.yaml
+++ b/integration/examples/multi-config-microservices/leeroy-web/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 metadata:
   name: web-config

--- a/integration/examples/multi-config-microservices/skaffold.yaml
+++ b/integration/examples/multi-config-microservices/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 requires:
 - path: ./leeroy-app

--- a/integration/examples/multiple-renderers/skaffold.yaml
+++ b/integration/examples/multiple-renderers/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 metadata:
   name: go-guestbook

--- a/integration/examples/nodejs/skaffold.yaml
+++ b/integration/examples/nodejs/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 
 build:

--- a/integration/examples/profile-patches/skaffold.yaml
+++ b/integration/examples/profile-patches/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   # only build and deploy "base-service" on main profile

--- a/integration/examples/profiles/skaffold.yaml
+++ b/integration/examples/profiles/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   # only build and deploy "world-service" on main profile

--- a/integration/examples/react-reload-docker/skaffold.yaml
+++ b/integration/examples/react-reload-docker/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   local:

--- a/integration/examples/react-reload/skaffold.yaml
+++ b/integration/examples/react-reload/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/examples/remote-multi-config-microservices/skaffold.yaml
+++ b/integration/examples/remote-multi-config-microservices/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 requires:
 - git:

--- a/integration/examples/ruby/skaffold.yaml
+++ b/integration/examples/ruby/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/examples/simple-artifact-dependency/skaffold.yaml
+++ b/integration/examples/simple-artifact-dependency/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/examples/structure-tests/skaffold.yaml
+++ b/integration/examples/structure-tests/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/examples/tagging-with-environment-variables/skaffold.yaml
+++ b/integration/examples/tagging-with-environment-variables/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/examples/templated-fields/skaffold.yaml
+++ b/integration/examples/templated-fields/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 metadata:
   name: my-app

--- a/integration/examples/typescript/skaffold.yaml
+++ b/integration/examples/typescript/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 
 build:

--- a/integration/examples/using-env-file/skaffold.yaml
+++ b/integration/examples/using-env-file/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/build-dependencies/skaffold.yaml
+++ b/integration/testdata/build-dependencies/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   tagPolicy:

--- a/integration/testdata/build/docker-with-platform-amd/skaffold.yaml
+++ b/integration/testdata/build/docker-with-platform-amd/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/build/docker-with-platform-arm/skaffold.yaml
+++ b/integration/testdata/build/docker-with-platform-arm/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/build/gcb-with-platform/skaffold.yaml
+++ b/integration/testdata/build/gcb-with-platform/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/build/secret/skaffold.yaml
+++ b/integration/testdata/build/secret/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   local:

--- a/integration/testdata/build/skaffold.yaml
+++ b/integration/testdata/build/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   local:

--- a/integration/testdata/build/squash/skaffold.yaml
+++ b/integration/testdata/build/squash/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/build/ssh/skaffold.yaml
+++ b/integration/testdata/build/ssh/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   local:

--- a/integration/testdata/custom-actions-k8s/skaffold.yaml
+++ b/integration/testdata/custom-actions-k8s/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 
 build:

--- a/integration/testdata/custom-actions-local/skaffold.yaml
+++ b/integration/testdata/custom-actions-local/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 
 build:

--- a/integration/testdata/custom-test/skaffold.yaml
+++ b/integration/testdata/custom-test/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/debug/skaffold.yaml
+++ b/integration/testdata/debug/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/deploy-cloudrun-with-hooks/module1/skaffold.yaml
+++ b/integration/testdata/deploy-cloudrun-with-hooks/module1/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 metadata:
    name: cloud-run-hooks-module1

--- a/integration/testdata/deploy-cloudrun-with-hooks/module2/skaffold.yaml
+++ b/integration/testdata/deploy-cloudrun-with-hooks/module2/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 metadata:
    name: cloud-run-hooks-module2

--- a/integration/testdata/deploy-cloudrun-with-hooks/skaffold.yaml
+++ b/integration/testdata/deploy-cloudrun-with-hooks/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 requires:
 - path: ./module1

--- a/integration/testdata/deploy-cloudrun/skaffold.yaml
+++ b/integration/testdata/deploy-cloudrun/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5 
+apiVersion: skaffold/v4beta6 
 kind: Config
 metadata:
    name: cloud-run-test

--- a/integration/testdata/deploy-hello-tail/skaffold.yaml
+++ b/integration/testdata/deploy-hello-tail/skaffold.yaml
@@ -1,2 +1,2 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config

--- a/integration/testdata/deploy-multiple/skaffold.yaml
+++ b/integration/testdata/deploy-multiple/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/dev/skaffold.yaml
+++ b/integration/testdata/dev/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/diagnose/multi-config/diagnose.tmpl
+++ b/integration/testdata/diagnose/multi-config/diagnose.tmpl
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 metadata:
   name: cfg2
@@ -19,7 +19,7 @@ deploy:
   logs:
     prefix: container
 ---
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 metadata:
   name: cfg3
@@ -40,7 +40,7 @@ deploy:
   logs:
     prefix: container
 ---
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/diagnose/multi-config/skaffold.yaml
+++ b/integration/testdata/diagnose/multi-config/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 requires:
 - path: ./skaffold2.yaml

--- a/integration/testdata/diagnose/multi-config/skaffold2.yaml
+++ b/integration/testdata/diagnose/multi-config/skaffold2.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 metadata:
   name: cfg2

--- a/integration/testdata/diagnose/multi-config/skaffold3.yaml
+++ b/integration/testdata/diagnose/multi-config/skaffold3.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 metadata:
   name: cfg3

--- a/integration/testdata/diagnose/temp-config/diagnose.tmpl
+++ b/integration/testdata/diagnose/temp-config/diagnose.tmpl
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/diagnose/temp-config/skaffold.yaml
+++ b/integration/testdata/diagnose/temp-config/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/docker-deploy/skaffold.yaml
+++ b/integration/testdata/docker-deploy/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   local:

--- a/integration/testdata/empty-dir/skaffold.yaml
+++ b/integration/testdata/empty-dir/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/file-sync/skaffold-infer.yaml
+++ b/integration/testdata/file-sync/skaffold-infer.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   tagPolicy:

--- a/integration/testdata/file-sync/skaffold-manual.yaml
+++ b/integration/testdata/file-sync/skaffold-manual.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   tagPolicy:

--- a/integration/testdata/gcb-with-location/skaffold.yaml
+++ b/integration/testdata/gcb-with-location/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/getting-started/skaffold.yaml
+++ b/integration/testdata/getting-started/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/gke_loadbalancer-render/skaffold.yaml
+++ b/integration/testdata/gke_loadbalancer-render/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/gke_loadbalancer/skaffold.yaml
+++ b/integration/testdata/gke_loadbalancer/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/hello/skaffold.yaml
+++ b/integration/testdata/hello/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/helm-namespace/skaffold.yaml
+++ b/integration/testdata/helm-namespace/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 
 deploy:

--- a/integration/testdata/helm-render-delete/skaffold.yaml
+++ b/integration/testdata/helm-render-delete/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   tagPolicy:

--- a/integration/testdata/helm-render/skaffold.yaml
+++ b/integration/testdata/helm-render/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   tagPolicy:

--- a/integration/testdata/helm/skaffold.yaml
+++ b/integration/testdata/helm/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   tagPolicy:

--- a/integration/testdata/init/compose/skaffold.yaml
+++ b/integration/testdata/init/compose/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 metadata:
   name: compose

--- a/integration/testdata/init/hello-with-manifest/skaffold.yaml
+++ b/integration/testdata/init/hello-with-manifest/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 metadata:
   name: hello-with-manifest

--- a/integration/testdata/init/helm-project/skaffold.yaml
+++ b/integration/testdata/init/helm-project/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 metadata:
   name: helm-project

--- a/integration/testdata/inspect/cluster/skaffold.add.default.yaml
+++ b/integration/testdata/inspect/cluster/skaffold.add.default.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/inspect/cluster/skaffold.add.profile.yaml
+++ b/integration/testdata/inspect/cluster/skaffold.add.profile.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/inspect/cluster/skaffold.cluster.yaml
+++ b/integration/testdata/inspect/cluster/skaffold.cluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/inspect/cluster/skaffold.local.yaml
+++ b/integration/testdata/inspect/cluster/skaffold.local.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/inspect/cluster/skaffold.modified.default.yaml
+++ b/integration/testdata/inspect/cluster/skaffold.modified.default.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/inspect/cluster/skaffold.modified.profile.yaml
+++ b/integration/testdata/inspect/cluster/skaffold.modified.profile.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/inspect/gcb/skaffold.add.default.yaml
+++ b/integration/testdata/inspect/gcb/skaffold.add.default.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/inspect/gcb/skaffold.add.profile.yaml
+++ b/integration/testdata/inspect/gcb/skaffold.add.profile.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/inspect/gcb/skaffold.gcb.yaml
+++ b/integration/testdata/inspect/gcb/skaffold.gcb.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/inspect/gcb/skaffold.local.yaml
+++ b/integration/testdata/inspect/gcb/skaffold.local.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/inspect/gcb/skaffold.modified.default.yaml
+++ b/integration/testdata/inspect/gcb/skaffold.modified.default.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/inspect/gcb/skaffold.modified.profile.yaml
+++ b/integration/testdata/inspect/gcb/skaffold.modified.profile.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/jib/skaffold.yaml
+++ b/integration/testdata/jib/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/kaniko-explicit-repo/skaffold.yaml
+++ b/integration/testdata/kaniko-explicit-repo/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/kaniko-insecure-registry/app/skaffold.yaml
+++ b/integration/testdata/kaniko-insecure-registry/app/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/kaniko-insecure-registry/skaffold.yaml
+++ b/integration/testdata/kaniko-insecure-registry/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 profiles:
   - name: build-artifact

--- a/integration/testdata/kaniko-microservices/skaffold.yaml
+++ b/integration/testdata/kaniko-microservices/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/kaniko-sub-folder/skaffold.yaml
+++ b/integration/testdata/kaniko-sub-folder/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/kaniko-target/skaffold.yaml
+++ b/integration/testdata/kaniko-target/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/modules/app1/skaffold.yaml
+++ b/integration/testdata/modules/app1/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 requires:
   - path: ../app2

--- a/integration/testdata/modules/app2/skaffold.yaml
+++ b/integration/testdata/modules/app2/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 requires:
   - path: ../app3

--- a/integration/testdata/modules/app3/skaffold.yaml
+++ b/integration/testdata/modules/app3/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   tagPolicy:

--- a/integration/testdata/modules/skaffold.yaml
+++ b/integration/testdata/modules/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 requires:
   - path: app1

--- a/integration/testdata/multi-config-pods/module1/skaffold.yaml
+++ b/integration/testdata/multi-config-pods/module1/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/multi-config-pods/module2/skaffold.yaml
+++ b/integration/testdata/multi-config-pods/module2/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/multi-config-pods/skaffold.yaml
+++ b/integration/testdata/multi-config-pods/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 requires:
   - path: ./module1

--- a/integration/testdata/tagPolicy/skaffold.yaml
+++ b/integration/testdata/tagPolicy/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/test-events/skaffold.yaml
+++ b/integration/testdata/test-events/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/integration/testdata/verify-fail-k8s/skaffold.yaml
+++ b/integration/testdata/verify-fail-k8s/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 verify:
   - name: hello-world

--- a/integration/testdata/verify-fail/skaffold.yaml
+++ b/integration/testdata/verify-fail/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 verify:
 - name: hello-world

--- a/integration/testdata/verify-no-tests/skaffold.yaml
+++ b/integration/testdata/verify-no-tests/skaffold.yaml
@@ -1,3 +1,3 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 verify:

--- a/integration/testdata/verify-succeed-k8s/skaffold.yaml
+++ b/integration/testdata/verify-succeed-k8s/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 verify:
   - name: hello-world-1

--- a/integration/testdata/verify-succeed/skaffold.yaml
+++ b/integration/testdata/verify-succeed/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 verify:
 - name: hello-world-1

--- a/pkg/skaffold/initializer/testdata/init/allcli/skaffold.yaml
+++ b/pkg/skaffold/initializer/testdata/init/allcli/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 metadata:
   name: allcli

--- a/pkg/skaffold/initializer/testdata/init/getting-started-kustomize/skaffold.yaml
+++ b/pkg/skaffold/initializer/testdata/init/getting-started-kustomize/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 metadata:
   name: getting-started-kustomize

--- a/pkg/skaffold/initializer/testdata/init/hello-no-manifest/skaffold.yaml
+++ b/pkg/skaffold/initializer/testdata/init/hello-no-manifest/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 metadata:
   name: hello

--- a/pkg/skaffold/initializer/testdata/init/hello/skaffold.yaml
+++ b/pkg/skaffold/initializer/testdata/init/hello/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 metadata:
   name: hello

--- a/pkg/skaffold/initializer/testdata/init/helm-deployment/skaffold.yaml
+++ b/pkg/skaffold/initializer/testdata/init/helm-deployment/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 metadata:
   name: "helm-deployment"

--- a/pkg/skaffold/initializer/testdata/init/ignore-tags/skaffold.yaml
+++ b/pkg/skaffold/initializer/testdata/init/ignore-tags/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 metadata:
   name: ignore-tags

--- a/pkg/skaffold/initializer/testdata/init/microservices/skaffold.yaml
+++ b/pkg/skaffold/initializer/testdata/init/microservices/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 metadata:
   name: microservices

--- a/pkg/skaffold/initializer/testdata/init/windows/skaffold.yaml
+++ b/pkg/skaffold/initializer/testdata/init/windows/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta5
+apiVersion: skaffold/v4beta6
 kind: Config
 metadata:
   name: windows

--- a/pkg/skaffold/schema/v4beta5/config.go
+++ b/pkg/skaffold/schema/v4beta5/config.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package latest
+package v4beta5
 
 import (
 	"encoding/json"
@@ -25,8 +25,8 @@ import (
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/util"
 )
 
-// This config version is not yet released, it is SAFE TO MODIFY the structs in this file.
-const Version string = "skaffold/v4beta6"
+// !!! WARNING !!! This config version is already released, please DO NOT MODIFY the structs in this file.
+const Version string = "skaffold/v4beta5"
 
 // NewSkaffoldConfig creates a SkaffoldConfig
 func NewSkaffoldConfig() util.VersionedConfig {

--- a/pkg/skaffold/schema/v4beta5/upgrade.go
+++ b/pkg/skaffold/schema/v4beta5/upgrade.go
@@ -14,16 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v4beta4
+package v4beta5
 
 import (
+	next "github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/util"
-	next "github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/v4beta5"
 	pkgutil "github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/util"
 )
 
 // Upgrade upgrades a configuration to the next version.
-// Config changes from v4beta4 to v4beta5
+// Config changes from v4beta5 to v4beta6
 func (c *SkaffoldConfig) Upgrade() (util.VersionedConfig, error) {
 	var newConfig next.SkaffoldConfig
 	pkgutil.CloneThroughJSON(c, &newConfig)

--- a/pkg/skaffold/schema/v4beta5/upgrade_test.go
+++ b/pkg/skaffold/schema/v4beta5/upgrade_test.go
@@ -14,18 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v4beta4
+package v4beta5
 
 import (
 	"testing"
 
-	next "github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/v4beta5"
+	next "github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/yaml"
 	"github.com/GoogleContainerTools/skaffold/v2/testutil"
 )
 
 func TestUpgrade(t *testing.T) {
-	yaml := `apiVersion: skaffold/v4beta4
+	yaml := `apiVersion: skaffold/v4beta5
 kind: Config
 build:
   artifacts:
@@ -121,7 +121,7 @@ profiles:
     deploy:
       kubectl: {}
 `
-	expected := `apiVersion: skaffold/v4beta5
+	expected := `apiVersion: skaffold/v4beta6
 kind: Config
 build:
   artifacts:

--- a/pkg/skaffold/schema/versions.go
+++ b/pkg/skaffold/schema/versions.go
@@ -94,6 +94,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/v4beta2"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/v4beta3"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/v4beta4"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/v4beta5"
 	misc "github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/util"
 )
 
@@ -172,6 +173,7 @@ var SchemaVersionsV1 = Versions{
 	{v4beta2.Version, v4beta2.NewSkaffoldConfig},
 	{v4beta3.Version, v4beta3.NewSkaffoldConfig},
 	{v4beta4.Version, v4beta4.NewSkaffoldConfig},
+	{v4beta5.Version, v4beta5.NewSkaffoldConfig},
 }
 
 // SchemaVersionsV2 refers to all the supported API Schemas for skaffold v2 executables. The API schema versions are


### PR DESCRIPTION
**Related**: #7366

**Description**
Upgrade schema to `v4beta6` needed for #7366. I'm splitting https://github.com/GoogleContainerTools/skaffold/pull/8801 so we can see the changes better. All the files in this PR were auto generated from running `hack/new-version.sh`.