### PR TITLE
feat: logic to only emit the tags related with verify on `skaffold verify`

### DIFF
--- a/cmd/skaffold/app/cmd/exec.go
+++ b/cmd/skaffold/app/cmd/exec.go
@@ -66,7 +66,7 @@ func getBuildArtifactsAndSetTagsForAction(configs []util.VersionedConfig, defaul
 		return nil, nil
 	}
 
-	fromBuildArtifactsFile := getArtifactsFromBuildArtifactsFile(imgs)
+	fromBuildArtifactsFile := joinWithArtifactsFromBuildArtifactsFile(imgs)
 
 	// We only use the images from previous builds, read from the --build-artifacts flag.
 	// `exec` itself does not perform a build, so we don't care about the configuration in the build stanza.
@@ -78,11 +78,11 @@ func getBuildArtifactsAndSetTagsForAction(configs []util.VersionedConfig, defaul
 	return applyDefaultRepoToArtifacts(buildArtifacts, defaulterFn)
 }
 
-func getArtifactsFromBuildArtifactsFile(actionImgs map[string]bool) (artifacts []graph.Artifact) {
+func joinWithArtifactsFromBuildArtifactsFile(imgs map[string]bool) (artifacts []graph.Artifact) {
 	allArtifacts := fromBuildOutputFile.BuildArtifacts()
 
 	for _, a := range allArtifacts {
-		if actionImgs[a.ImageName] {
+		if imgs[a.ImageName] {
 			artifacts = append(artifacts, a)
 		}
 	}

--- a/integration/testdata/verify-succeed/app/Dockerfile
+++ b/integration/testdata/verify-succeed/app/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.15 as builder
+COPY main.go .
+
+# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
+ARG SKAFFOLD_GO_GCFLAGS
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app main.go
+
+FROM alpine:3
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
+CMD ["./app"]
+COPY --from=builder /app .

--- a/integration/testdata/verify-succeed/app/main.go
+++ b/integration/testdata/verify-succeed/app/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+func main() {
+	seconds := 0
+	env := os.Getenv("FOO")
+	for seconds < 5 {
+		fmt.Printf("Hello world %v! %v\n", env, seconds)
+		seconds++
+		time.Sleep(time.Second * 1)
+	}
+}

--- a/integration/testdata/verify-succeed/skaffold.yaml
+++ b/integration/testdata/verify-succeed/skaffold.yaml
@@ -31,3 +31,26 @@ profiles:
           image: alpine:3.15.4
           command: ["/bin/sh"]
           args: ["-c", "echo alpine-1; sleep 2; echo bye alpine-1"]
+  
+  - name: local-built-artifact
+
+    build:
+      artifacts:
+        - image: localtask
+          context: ./app
+        - image: img-not-used-in-verify
+          context: ./app
+      
+
+    verify:
+      - name: alpine-1
+        container:
+          name: alpine-1
+          image: alpine:3.15.4
+          command: ["/bin/sh"]
+          args: ["-c", "echo alpine-1; sleep 2; echo bye alpine-1"]
+      
+      - name: localtask
+        container:
+          name: localtask
+          image: localtask

--- a/pkg/skaffold/runner/verify.go
+++ b/pkg/skaffold/runner/verify.go
@@ -56,11 +56,13 @@ func (r *SkaffoldRunner) Verify(ctx context.Context, out io.Writer, artifacts []
 
 	out, ctx = output.WithEventContext(ctx, out, constants.Verify, constants.SubtaskIDNone)
 
-	output.Default.Fprintln(out, "Tags used in verification:")
+	if len(artifacts) > 0 {
+		output.Default.Fprintln(out, "Tags used in verification:")
 
-	for _, artifact := range artifacts {
-		output.Default.Fprintf(out, " - %s -> ", artifact.ImageName)
-		fmt.Fprintln(out, artifact.Tag)
+		for _, artifact := range artifacts {
+			output.Default.Fprintf(out, " - %s -> ", artifact.ImageName)
+			fmt.Fprintln(out, artifact.Tag)
+		}
 	}
 
 	var localImages []graph.Artifact


### PR DESCRIPTION
Fixes: #8671

**Description**
This PR adds the logic to only output the artifacts tags related with verify when running `skaffold verify` instead of printing all the artifacts detected in the given `--build-artifacts=build.json` file.