### PR TITLE
fix: logic to interrupt a k8sjob logs as soon as it fails (#8847)

### DIFF
--- a/integration/testdata/custom-actions-k8s/skaffold.yaml
+++ b/integration/testdata/custom-actions-k8s/skaffold.yaml
@@ -39,25 +39,6 @@ customActions:
           - name: FOO
             value: from-task4
   
-  - name: action-fail-fast-logs
-    executionMode:
-      kubernetesCluster: {}
-    containers:
-      - name: task3l
-        image: alpine:3.15.4
-        command: ["/bin/sh"]
-        args: ["-c", "echo hello-$FOO && sleep 1 && echo bye-$FOO"]
-        env:
-          - name: FOO
-            value: from-task3l
-      - name: task4l
-        image: alpine:3.15.4
-        command: ["/bin/sh"]
-        args: ["-c", "echo hello-$FOO && exit 1"]
-        env:
-          - name: FOO
-            value: from-task4l
-  
   - name: action-fail-safe
     executionMode:
       kubernetesCluster: {}


### PR DESCRIPTION
This is a cherry pick to fix #8839 in`v2.5`:

- Change in k8s custom actions delete and logger, PR: https://github.com/GoogleContainerTools/skaffold/pull/8847