### PR TITLE
fix: increase progressDeadlineSeconds for TestRunUnstable test and change in baseRef

### DIFF
--- a/hack/versions/pkg/schema/check.go
+++ b/hack/versions/pkg/schema/check.go
@@ -28,7 +28,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/v2/hack/versions/pkg/diff"
 )
 
-const baseRef = "origin/main"
+const baseRef = "origin/release/v2.5"
 
 func RunSchemaCheckOnChangedFiles() error {
 	git, err := newGit(baseRef)

--- a/integration/testdata/unstable-deployment/incorrect-deployment.yaml
+++ b/integration/testdata/unstable-deployment/incorrect-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: unstable-deployment
 spec:
-  progressDeadlineSeconds: 10
+  progressDeadlineSeconds: 20
   replicas: 1
   selector:
     matchLabels:


### PR DESCRIPTION
This is a cherry pick + a change to make the tests in `release/v2.5` branch to pass:

- Cherry pick to increase progressDeadlineSeconds timeout to make TestRunUnstable test to pass, PR: #8833
- Change baseRef from origin/main to release/v2.5 to make tests pass