### PR TITLE
fix: clean-up-images-in-devloop

### DIFF
--- a/pkg/skaffold/build/local/local.go
+++ b/pkg/skaffold/build/local/local.go
@@ -89,6 +89,11 @@ func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, a *latest.Ar
 	}
 
 	imageID := digestOrImageID
+	artifacts, err := b.artifactStore.GetArtifacts([]*latest.Artifact{a})
+	// delete previous built images asynchronously
+	if b.mode == config.RunModes.Dev && len(artifacts) > 0 {
+		go b.localDocker.Prune(ctx, []string{artifacts[0].Tag}, b.pruneChildren)
+	}
 	b.builtImages = append(b.builtImages, imageID)
 	return build.TagWithImageID(ctx, tag, imageID, b.localDocker)
 }

--- a/pkg/skaffold/build/local/local.go
+++ b/pkg/skaffold/build/local/local.go
@@ -89,10 +89,15 @@ func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, a *latest.Ar
 	}
 
 	imageID := digestOrImageID
-	artifacts, err := b.artifactStore.GetArtifacts([]*latest.Artifact{a})
 	// delete previous built images asynchronously
-	if b.mode == config.RunModes.Dev && len(artifacts) > 0 {
-		go b.localDocker.Prune(ctx, []string{artifacts[0].Tag}, b.pruneChildren)
+	if b.mode == config.RunModes.Dev {
+		go func() {
+			artifacts, err := b.artifactStore.GetArtifacts([]*latest.Artifact{a})
+			log.Entry(ctx).Warn("failed to get artifacts from store, err: %v", err)
+			if len(artifacts) > 0 {
+				b.localDocker.Prune(ctx, []string{artifacts[0].Tag}, b.pruneChildren)
+			}
+		}()
 	}
 	b.builtImages = append(b.builtImages, imageID)
 	return build.TagWithImageID(ctx, tag, imageID, b.localDocker)

--- a/pkg/skaffold/build/local/local.go
+++ b/pkg/skaffold/build/local/local.go
@@ -93,7 +93,7 @@ func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, a *latest.Ar
 	if b.mode == config.RunModes.Dev {
 		go func() {
 			artifacts, err := b.artifactStore.GetArtifacts([]*latest.Artifact{a})
-			log.Entry(ctx).Warn("failed to get artifacts from store, err: %v", err)
+			log.Entry(ctx).Warnf("failed to get artifacts from store, err: %v", err)
 			if len(artifacts) > 0 {
 				b.localDocker.Prune(ctx, []string{artifacts[0].Tag}, b.pruneChildren)
 			}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #8545 <!-- tracking issues that this PR will close -->

**Description**
 - Clean up all images created during skaffold dev loop except the last one in local environment.  

**Test Plan**
 - Run `skaffold dev` then modify some file to trigger a few rebuilds, check your built images with `docker image ls` or `minikube image ls` if you're using minikube


