### PR TITLE
feat: implement skaffold delete for docker deployer using docker labels

### DIFF
--- a/integration/testdata/docker-deploy/skaffold.yaml
+++ b/integration/testdata/docker-deploy/skaffold.yaml
@@ -11,3 +11,28 @@ build:
 deploy:
   docker:
     images: [bert, ernie]
+
+profiles:
+  - name: one-container
+    build:
+      local:
+        push: false
+      artifacts:
+      - image: docker-bert-img-1
+        context: bert
+    deploy:
+      docker:
+        images: [docker-bert-img-1]
+
+  - name: more-than-one-container
+    build:
+      local:
+        push: false
+      artifacts:
+      - image: docker-bert-img-2
+        context: bert
+      - image: docker-ernie-img-2
+        context: ernie
+    deploy:
+      docker:
+        images: [docker-bert-img-2, docker-ernie-img-2]

--- a/pkg/skaffold/actions/docker/exec_env.go
+++ b/pkg/skaffold/actions/docker/exec_env.go
@@ -108,7 +108,7 @@ func newExecEnv(ctx context.Context, cfg dockerutil.Config, labeller *label.Defa
 
 func (e ExecEnv) PrepareActions(ctx context.Context, out io.Writer, allbuilds, _ []graph.Artifact, acsNames []string) ([]actions.Action, error) {
 	if e.shouldCreateNetwork {
-		if err := e.client.NetworkCreate(ctx, e.network); err != nil {
+		if err := e.client.NetworkCreate(ctx, e.network, nil); err != nil {
 			return nil, fmt.Errorf("creating skaffold network %s: %w", e.network, err)
 		}
 	}

--- a/pkg/skaffold/actions/docker/exec_env_test.go
+++ b/pkg/skaffold/actions/docker/exec_env_test.go
@@ -38,7 +38,7 @@ type fakeDockerDaemon struct {
 	ImgsInDaemon map[string]string
 }
 
-func (fd *fakeDockerDaemon) NetworkCreate(ctx context.Context, name string) error {
+func (fd *fakeDockerDaemon) NetworkCreate(ctx context.Context, name string, labels map[string]string) error {
 	return nil
 }
 

--- a/pkg/skaffold/deploy/label/labeller.go
+++ b/pkg/skaffold/deploy/label/labeller.go
@@ -22,7 +22,8 @@ import (
 )
 
 const (
-	RunIDLabel = "skaffold.dev/run-id"
+	RunIDLabel          = "skaffold.dev/run-id"
+	DebugContainerLabel = "skaffold.dev/debug"
 )
 
 type Config interface {
@@ -59,6 +60,13 @@ func (d *DefaultLabeller) Labels() map[string]string {
 		}
 		labels[l[0]] = l[1]
 	}
+
+	return labels
+}
+
+func (d *DefaultLabeller) DebugLabels() map[string]string {
+	labels := d.Labels()
+	labels[DebugContainerLabel] = "true"
 
 	return labels
 }

--- a/pkg/skaffold/docker/debugger/debug.go
+++ b/pkg/skaffold/docker/debugger/debug.go
@@ -64,14 +64,10 @@ func (d *DebugManager) ConfigurationForImage(image string) types.ContainerDebugC
 	return d.configurations[image]
 }
 
-func (d *DebugManager) AddSupportMount(image, mountID string) {
+func (d *DebugManager) AddSupportMount(image string, m mount.Mount) {
 	d.mountLock.Lock()
 	defer d.mountLock.Unlock()
-	d.supportMounts[image] = mount.Mount{
-		Type:   mount.TypeVolume,
-		Source: mountID,
-		Target: "/dbg",
-	}
+	d.supportMounts[image] = m
 }
 
 func (d *DebugManager) HasMount(image string) bool {

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -73,6 +73,7 @@ type ContainerCreateOpts struct {
 	Mounts          []mount.Mount
 	ContainerConfig *container.Config
 	VerifyTestName  string
+	Labels          map[string]string
 }
 
 // LocalDaemon talks to a local Docker API.
@@ -98,7 +99,7 @@ type LocalDaemon interface {
 	ImageRemove(ctx context.Context, image string, opts types.ImageRemoveOptions) ([]types.ImageDeleteResponseItem, error)
 	ImageExists(ctx context.Context, ref string) bool
 	ImageList(ctx context.Context, ref string) ([]types.ImageSummary, error)
-	NetworkCreate(ctx context.Context, name string) error
+	NetworkCreate(ctx context.Context, name string, labels map[string]string) error
 	NetworkRemove(ctx context.Context, name string) error
 	Prune(ctx context.Context, images []string, pruneChildren bool) ([]string, error)
 	DiskUsage(ctx context.Context) (uint64, error)
@@ -242,7 +243,7 @@ func (l *localDaemon) Run(ctx context.Context, out io.Writer, opts ContainerCrea
 	return nil, nil, c.ID, nil
 }
 
-func (l *localDaemon) NetworkCreate(ctx context.Context, name string) error {
+func (l *localDaemon) NetworkCreate(ctx context.Context, name string, labels map[string]string) error {
 	nr, err := l.apiClient.NetworkList(ctx, types.NetworkListOptions{})
 	if err != nil {
 		return err
@@ -253,7 +254,7 @@ func (l *localDaemon) NetworkCreate(ctx context.Context, name string) error {
 		}
 	}
 
-	r, err := l.apiClient.NetworkCreate(ctx, name, types.NetworkCreate{})
+	r, err := l.apiClient.NetworkCreate(ctx, name, types.NetworkCreate{Labels: labels})
 	if err != nil {
 		return err
 	}

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -101,6 +101,7 @@ type LocalDaemon interface {
 	ImageList(ctx context.Context, ref string) ([]types.ImageSummary, error)
 	NetworkCreate(ctx context.Context, name string, labels map[string]string) error
 	NetworkRemove(ctx context.Context, name string) error
+	NetworkList(ctx context.Context, opts types.NetworkListOptions) ([]types.NetworkResource, error)
 	Prune(ctx context.Context, images []string, pruneChildren bool) ([]string, error)
 	DiskUsage(ctx context.Context) (uint64, error)
 	RawClient() client.CommonAPIClient
@@ -266,6 +267,10 @@ func (l *localDaemon) NetworkCreate(ctx context.Context, name string, labels map
 
 func (l *localDaemon) NetworkRemove(ctx context.Context, name string) error {
 	return l.apiClient.NetworkRemove(ctx, name)
+}
+
+func (l *localDaemon) NetworkList(ctx context.Context, opts types.NetworkListOptions) ([]types.NetworkResource, error) {
+	return l.apiClient.NetworkList(ctx, opts)
 }
 
 // ServerVersion retrieves the version information from the server.

--- a/pkg/skaffold/verify/docker/verify.go
+++ b/pkg/skaffold/verify/docker/verify.go
@@ -121,7 +121,7 @@ func (v *Verifier) Verify(ctx context.Context, out io.Writer, allbuilds []graph.
 
 	if !v.networkFlagPassed {
 		v.once.Do(func() {
-			err = v.client.NetworkCreate(ctx, v.network)
+			err = v.client.NetworkCreate(ctx, v.network, nil)
 		})
 		if err != nil {
 			return fmt.Errorf("creating skaffold network %s: %w", v.network, err)


### PR DESCRIPTION
Fixes: #6314 

**Description**
This PRs enables the `skaffold delete` command when using the Docker deployer. The logic is based in the use of Docker labels to tag the different resources created during deployment with the Docker deployer.

During a deployment different resources can be created by Skaffold: containers (`skaffold.yaml` containers and debug containers), networks, volumes (when doing `skaffold debug`). The logic deletes the resources associated with the project where the command is running.