### PR TITLE
fix: Clean up dev images except the last

### DIFF
--- a/integration/dev_test.go
+++ b/integration/dev_test.go
@@ -368,6 +368,50 @@ func TestDevPortForward(t *testing.T) {
 	}
 }
 
+func TestDevDeletePreviousBuiltImages(t *testing.T) {
+	tests := []struct {
+		name string
+		dir  string
+	}{
+		{
+			name: "microservices",
+			dir:  "examples/microservices"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			MarkIntegrationTest(t, CanRunWithoutGcp)
+			// Run skaffold build first to fail quickly on a build failure
+			skaffold.Build().InDir(test.dir).RunOrFail(t)
+
+			ns, k8sClient := SetupNamespace(t)
+
+			rpcAddr := randomPort()
+			skaffold.Dev("--status-check=false", "--port-forward", "--rpc-port", rpcAddr).InDir(test.dir).InNs(ns.Name).RunBackground(t)
+
+			_, entries := apiEvents(t, rpcAddr)
+
+			waitForPortForwardEvent(t, entries, "leeroy-app", "service", ns.Name, "leeroooooy app!!\n")
+			deployment := k8sClient.GetDeployment("leeroy-app")
+			image := deployment.Spec.Template.Spec.Containers[0].Image
+
+			original, perms, fErr := replaceInFile("leeroooooy app!!", "test string", fmt.Sprintf("%s/leeroy-app/app.go", test.dir))
+			failNowIfError(t, fErr)
+			defer func() {
+				if original != nil {
+					os.WriteFile(fmt.Sprintf("%s/leeroy-app/app.go", test.dir), original, perms)
+				}
+			}()
+
+			waitForPortForwardEvent(t, entries, "leeroy-app", "service", ns.Name, "test string\n")
+			client := SetupDockerClient(t)
+			ctx := context.TODO()
+			wait.Poll(3*time.Second, time.Minute*1, func() (done bool, err error) {
+				return !client.ImageExists(ctx, image), nil
+			})
+		})
+	}
+}
+
 func TestDevPortForwardDefaultNamespace(t *testing.T) {
 	MarkIntegrationTest(t, CanRunWithoutGcp)
 

--- a/integration/dev_test.go
+++ b/integration/dev_test.go
@@ -405,7 +405,7 @@ func TestDevDeletePreviousBuiltImages(t *testing.T) {
 			waitForPortForwardEvent(t, entries, "leeroy-app", "service", ns.Name, "test string\n")
 			client := SetupDockerClient(t)
 			ctx := context.TODO()
-			wait.Poll(3*time.Second, time.Minute*1, func() (done bool, err error) {
+			wait.Poll(3*time.Second, time.Minute*2, func() (done bool, err error) {
 				return !client.ImageExists(ctx, image), nil
 			})
 		})

--- a/pkg/skaffold/build/local/local.go
+++ b/pkg/skaffold/build/local/local.go
@@ -89,6 +89,11 @@ func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, a *latest.Ar
 	}
 
 	imageID := digestOrImageID
+	artifacts, err := b.artifactStore.GetArtifacts([]*latest.Artifact{a})
+	// delete previous built images asynchronously
+	if b.mode == config.RunModes.Dev && len(artifacts) > 0 {
+		go b.localDocker.Prune(ctx, []string{artifacts[0].Tag}, b.pruneChildren)
+	}
 	b.builtImages = append(b.builtImages, imageID)
 	return build.TagWithImageID(ctx, tag, imageID, b.localDocker)
 }

--- a/pkg/skaffold/build/local/local.go
+++ b/pkg/skaffold/build/local/local.go
@@ -114,7 +114,7 @@ func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, a *latest.Ar
 			if len(artifacts) > 0 {
 				bgCtx := context.Background()
 				id, _ := b.getImageIDForTag(bgCtx, artifacts[0].Tag)
-				b.localDocker.Prune(bgCtx, []string{id}, b.pruneChildren)
+				b.localPruner.runPrune(bgCtx, []string{id})
 			}
 		}()
 	}

--- a/pkg/skaffold/build/local/local.go
+++ b/pkg/skaffold/build/local/local.go
@@ -89,10 +89,15 @@ func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, a *latest.Ar
 	}
 
 	imageID := digestOrImageID
-	artifacts, err := b.artifactStore.GetArtifacts([]*latest.Artifact{a})
 	// delete previous built images asynchronously
-	if b.mode == config.RunModes.Dev && len(artifacts) > 0 {
-		go b.localDocker.Prune(ctx, []string{artifacts[0].Tag}, b.pruneChildren)
+	if b.mode == config.RunModes.Dev {
+		go func() {
+			artifacts, err := b.artifactStore.GetArtifacts([]*latest.Artifact{a})
+			log.Entry(ctx).Warn("failed to get artifacts from store, err: %v", err)
+			if len(artifacts) > 0 {
+				b.localDocker.Prune(ctx, []string{artifacts[0].Tag}, b.pruneChildren)
+			}
+		}()
 	}
 	b.builtImages = append(b.builtImages, imageID)
 	return build.TagWithImageID(ctx, tag, imageID, b.localDocker)

--- a/pkg/skaffold/build/local/local.go
+++ b/pkg/skaffold/build/local/local.go
@@ -93,7 +93,7 @@ func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, a *latest.Ar
 	if b.mode == config.RunModes.Dev {
 		go func() {
 			artifacts, err := b.artifactStore.GetArtifacts([]*latest.Artifact{a})
-			log.Entry(ctx).Warn("failed to get artifacts from store, err: %v", err)
+			log.Entry(ctx).Warnf("failed to get artifacts from store, err: %v", err)
 			if len(artifacts) > 0 {
 				b.localDocker.Prune(ctx, []string{artifacts[0].Tag}, b.pruneChildren)
 			}

--- a/pkg/skaffold/build/local/types.go
+++ b/pkg/skaffold/build/local/types.go
@@ -123,21 +123,6 @@ func NewBuilder(ctx context.Context, bCtx BuilderContext, buildCfg *latest.Local
 	}, nil
 }
 
-// Prune uses the docker API client to remove all images built with Skaffold
-func (b *Builder) Prune(ctx context.Context, _ io.Writer) error {
-	var toPrune []string
-	seen := make(map[string]bool)
-
-	for _, img := range b.builtImages {
-		if !seen[img] && !b.localPruner.isPruned(img) {
-			toPrune = append(toPrune, img)
-			seen[img] = true
-		}
-	}
-	_, err := b.localDocker.Prune(ctx, toPrune, b.pruneChildren)
-	return err
-}
-
 // artifactBuilder represents a per artifact builder interface
 type artifactBuilder interface {
 	Build(ctx context.Context, out io.Writer, a *latest.Artifact, tag string, platforms platform.Matcher) (string, error)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #8545 <!-- tracking issues that this PR will close -->

**Description**
 - Clean up all images created during skaffold dev loop except the last one in local environment.  

**Test Plan**
 - Run `skaffold dev` then modify some file to trigger a few rebuilds, check your built images with `docker image ls` or `minikube image ls` if you're using minikube

