### PR TITLE
chore: port apply-setter krm function over to skaffold

### DIFF
--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -1151,41 +1151,6 @@ spec:
     image: skaffold-example
 `,
 		},
-		{
-			description: "kubectl set manifest label with --set flag overrides transform in manifest",
-			args:        []string{"--offline=true", "--set", "app1=from-command-line"},
-			config: `apiVersion: skaffold/v4beta2
-kind: Config
-manifests:
-  rawYaml:
-  - k8s-pod.yaml
-  transform:
-    - name: apply-setters
-      configMap:
-        - "app1:from-apply-setters-1"
-`,
-			input: map[string]string{
-				"k8s-pod.yaml": `apiVersion: v1
-kind: Pod
-metadata:
-  name: getting-started
-  labels:
-    a: hhhh # kpt-set: ${app1}
-  spec:
-    containers:
-      - name: getting-started
-        image: skaffold-example`},
-			expectedOut: `apiVersion: v1
-kind: Pod
-metadata:
-  name: getting-started
-  labels:
-    a: from-command-line
-  spec:
-    containers:
-      - name: getting-started
-        image: skaffold-example`,
-		},
 		{description: "kustomize set annotation with set-annotations transformer",
 			args: []string{"--offline=true"},
 			config: `apiVersion: skaffold/v4beta2
@@ -1275,7 +1240,7 @@ manifests:
     paths:
     - overlays/dev
 `, input: map[string]string{
-				"base/kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
+			"base/kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
@@ -1285,7 +1250,7 @@ kind: Deployment
 metadata:
   name: skaffold-kustomize
   labels:
-    app: skaffold-kustomize # kpt-set: ${app1}
+    app: skaffold-kustomize # from-param: ${app1}
 spec:
   selector:
     matchLabels:
@@ -1314,7 +1279,7 @@ kind: Deployment
 metadata:
   name: skaffold-kustomize
   labels:
-    env: dev # kpt-set: ${env2}
+    env: dev # from-param: ${env2}
 `}, expectedOut: `
 apiVersion: apps/v1
 kind: Deployment
@@ -1345,10 +1310,6 @@ kind: Config
 manifests:
   rawYaml:
     - k8s-pod.yaml
-  transform:
-    - name: apply-setters
-      configMap:
-        - "app1:from-apply-setters-1"
 `,
 			input: map[string]string{
 				"k8s-pod.yaml": `
@@ -1357,7 +1318,7 @@ kind: Pod
 metadata:
   name: getting-started
   labels:
-    a: hhhh # kpt-set: ${app1}
+    a: hhhh # from-param: ${app1}
 spec:
   containers:
     - name: getting-started
@@ -1396,8 +1357,8 @@ kind: Pod
 metadata:
   name: getting-started
   labels:
-    a: hhhh # kpt-set: ${app1}
-    b: hhhh # kpt-set: ${app2}
+    a: hhhh # from-param: ${app1}
+    b: hhhh # from-param: ${app2}
 spec:
   containers:
     - name: getting-started
@@ -1436,7 +1397,7 @@ kind: Pod
 metadata:
   name: getting-started
   labels:
-    a: hhhh # kpt-set: ${app1}
+    a: hhhh # from-param: ${app1}
 spec:
   containers:
     - name: getting-started

--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -1240,7 +1240,7 @@ manifests:
     paths:
     - overlays/dev
 `, input: map[string]string{
-			"base/kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
+				"base/kustomization.yaml": `apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:

--- a/pkg/skaffold/render/applysetters/LICENSE
+++ b/pkg/skaffold/render/applysetters/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkg/skaffold/render/applysetters/apply_setters.go
+++ b/pkg/skaffold/render/applysetters/apply_setters.go
@@ -1,216 +1,25 @@
-// Package applysetters /*
-// https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/master/functions/go/apply-setters
 /*
+Copyright 2023 The Skaffold Authors
 
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+    http://www.apache.org/licenses/LICENSE-2.0
 
-   1. Definitions.
-
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
+
 package applysetters
 
 import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/kubernetes/manifest"
 	"os"
 	"regexp"
 	"strings"
@@ -219,6 +28,8 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
+
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/kubernetes/manifest"
 )
 
 const SetterCommentIdentifier = "# from-param: "
@@ -274,6 +85,7 @@ func (as *ApplySetters) Filter(nodes []*yaml.RNode) ([]*yaml.RNode, error) {
 	return nodes, nil
 }
 
+// Apply Transform manifestList with Filter
 func (as *ApplySetters) Apply(ctx context.Context, ml manifest.ManifestList) (manifest.ManifestList, error) {
 	reader := ml.Reader()
 	byteReader := kio.ByteReader{Reader: reader, OmitReaderAnnotations: true}
@@ -283,12 +95,16 @@ func (as *ApplySetters) Apply(ctx context.Context, ml manifest.ManifestList) (ma
 		return updated, err
 	}
 	nodes, err = as.Filter(nodes)
+	if err != nil {
+		return updated, err
+	}
 	for i := range nodes {
 		updated.Append([]byte(nodes[i].MustString()))
 	}
 	return updated, nil
 }
 
+// ApplyPath Transform a yaml file with Filter
 func (as *ApplySetters) ApplyPath(path string) error {
 	content, err := os.ReadFile(path)
 	if err != nil {

--- a/pkg/skaffold/render/applysetters/apply_setters.go
+++ b/pkg/skaffold/render/applysetters/apply_setters.go
@@ -221,7 +221,7 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
-const SetterCommentIdentifier = "# kpt-set: "
+const SetterCommentIdentifier = "# from-param: "
 
 var _ kio.Filter = &ApplySetters{}
 
@@ -319,13 +319,13 @@ replaces the existing sequence node with the new values provided by user
 
 e.g. for input of Mapping node
 
-environments: # kpt-set: ${env}
+environments: # from-param: ${env}
 - dev
 - stage
 
 For input ApplySetters [name: env, value: "[stage, prod]"], qthe yaml node is transformed to
 
-environments: # kpt-set: ${env}
+environments: # from-param: ${env}
 - stage
 - prod
 */
@@ -344,7 +344,7 @@ func (as *ApplySetters) visitMapping(object *yaml.RNode, path string) error {
 
 		lineComment := node.Key.YNode().LineComment
 		if node.Value.YNode().Style == yaml.FlowStyle {
-			// if node is FlowStyle e.g. env: [foo, bar] # kpt-set: ${env}
+			// if node is FlowStyle e.g. env: [foo, bar] # from-param: ${env}
 			// the setter comment will be on value node
 			lineComment = node.Value.YNode().LineComment
 		}
@@ -374,7 +374,7 @@ func (as *ApplySetters) visitMapping(object *yaml.RNode, path string) error {
 
 		if sv == "" {
 			node.Value.YNode().Content = []*yaml.Node{}
-			// empty sequence must be FlowStyle e.g. env: [] # kpt-set: ${env}
+			// empty sequence must be FlowStyle e.g. env: [] # from-param: ${env}
 			node.Value.YNode().Style = yaml.FlowStyle
 			// setter pattern comment must be on value node
 			node.Value.YNode().LineComment = lineComment
@@ -401,7 +401,7 @@ func (as *ApplySetters) visitMapping(object *yaml.RNode, path string) error {
 		node.Value.YNode().Content = rn.YNode().Content
 		node.Key.YNode().LineComment = lineComment
 		// non-empty sequences should be standardized to FoldedStyle
-		// env: # kpt-set: ${env}
+		// env: # from-param: ${env}
 		//  - foo
 		//  - bar
 		node.Value.YNode().Style = yaml.FoldedStyle
@@ -421,12 +421,12 @@ checks if the line comment of input scalar node has prefix SetterCommentIdentifi
 resolves the setter values for the setter name in the comment
 replaces the existing value of the scalar node with the new value
 
-e.g.for input of scalar node 'nginx:1.7.1 # kpt-set: ${image}:${tag}' in the yaml node
+e.g.for input of scalar node 'nginx:1.7.1 # from-param: ${image}:${tag}' in the yaml node
 
 apiVersion: v1
 ...
 
-	image: nginx:1.7.1 # kpt-set: ${image}:${tag}
+	image: nginx:1.7.1 # from-param: ${image}:${tag}
 
 and for input ApplySetters [[name: image, value: ubuntu], [name: tag, value: 1.8.0]]
 The yaml node is transformed to
@@ -434,7 +434,7 @@ The yaml node is transformed to
 apiVersion: v1
 ...
 
-	image: ubuntu:1.8.0 # kpt-set: ${image}:${tag}
+	image: ubuntu:1.8.0 # from-param: ${image}:${tag}
 */
 func (as *ApplySetters) visitScalar(object *yaml.RNode, path string) error {
 	if object.IsNil() {

--- a/pkg/skaffold/render/applysetters/apply_setters.go
+++ b/pkg/skaffold/render/applysetters/apply_setters.go
@@ -207,9 +207,11 @@
 package applysetters
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/kubernetes/manifest"
+	"os"
 	"regexp"
 	"strings"
 
@@ -285,6 +287,27 @@ func (as *ApplySetters) Apply(ctx context.Context, ml manifest.ManifestList) (ma
 		updated.Append([]byte(nodes[i].MustString()))
 	}
 	return updated, nil
+}
+
+func (as *ApplySetters) ApplyPath(path string) error {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	nodes, err := kio.FromBytes(content)
+	if err != nil {
+		return err
+	}
+	nodes, err = as.Filter(nodes)
+	if err != nil {
+		return err
+	}
+	var b bytes.Buffer
+	err = (&kio.ByteWriter{Writer: &b}).Write(nodes)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, b.Bytes(), 0600)
 }
 
 /*

--- a/pkg/skaffold/render/applysetters/apply_setters.go
+++ b/pkg/skaffold/render/applysetters/apply_setters.go
@@ -1,0 +1,588 @@
+// Package applysetters /*
+// https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/master/functions/go/apply-setters
+/*
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package applysetters
+
+import (
+	"context"
+	"fmt"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/kubernetes/manifest"
+	"regexp"
+	"strings"
+
+	"sigs.k8s.io/kustomize/kyaml/errors"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+const SetterCommentIdentifier = "# kpt-set: "
+
+var _ kio.Filter = &ApplySetters{}
+
+// ApplySetters applies the setter values to the resource fields which are tagged
+// by the setter reference comments
+type ApplySetters struct {
+	// Setters holds the user provided values for all the setters
+	Setters []Setter
+
+	// Results are the results of applying setter values
+	Results []*Result
+
+	// filePath file path of resource
+	filePath string
+}
+
+type Setter struct {
+	// Name is the name of the setter
+	Name string
+
+	// Value is the input value for setter
+	Value string
+}
+
+// Result holds result of search and replace operation
+type Result struct {
+	// FilePath is the file path of the matching field
+	FilePath string
+
+	// FieldPath is field path of the matching field
+	FieldPath string
+
+	// Value of the matching field
+	Value string
+}
+
+// Filter implements Set as a yaml.Filter
+func (as *ApplySetters) Filter(nodes []*yaml.RNode) ([]*yaml.RNode, error) {
+	for i := range nodes {
+		filePath, _, err := kioutil.GetFileAnnotations(nodes[i])
+		if err != nil {
+			return nodes, err
+		}
+		as.filePath = filePath
+		err = accept(as, nodes[i])
+		if err != nil {
+			return nil, errors.Wrap(err)
+		}
+	}
+	return nodes, nil
+}
+
+func (as *ApplySetters) Apply(ctx context.Context, ml manifest.ManifestList) (manifest.ManifestList, error) {
+	reader := ml.Reader()
+	byteReader := kio.ByteReader{Reader: reader, OmitReaderAnnotations: true}
+	nodes, err := byteReader.Read()
+	var updated manifest.ManifestList
+	if err != nil {
+		return updated, err
+	}
+	nodes, err = as.Filter(nodes)
+	for i := range nodes {
+		updated.Append([]byte(nodes[i].MustString()))
+	}
+	return updated, nil
+}
+
+/*
+visitMapping takes input mapping node, and performs following steps
+checks if the key node of the input mapping node has line comment with SetterCommentIdentifier
+checks if the value node is of sequence node type
+if yes to both, resolves the setter value for the setter name in the line comment
+replaces the existing sequence node with the new values provided by user
+
+e.g. for input of Mapping node
+
+environments: # kpt-set: ${env}
+- dev
+- stage
+
+For input ApplySetters [name: env, value: "[stage, prod]"], qthe yaml node is transformed to
+
+environments: # kpt-set: ${env}
+- stage
+- prod
+*/
+func (as *ApplySetters) visitMapping(object *yaml.RNode, path string) error {
+	return object.VisitFields(func(node *yaml.MapNode) error {
+		if node == nil || node.Key.IsNil() || node.Value.IsNil() {
+			// don't do IsNilOrEmpty check as empty sequences are allowed
+			return nil
+		}
+
+		// the aim of this method is to apply-setter for sequence nodes
+		if node.Value.YNode().Kind != yaml.SequenceNode {
+			// return if it is not a sequence node
+			return nil
+		}
+
+		lineComment := node.Key.YNode().LineComment
+		if node.Value.YNode().Style == yaml.FlowStyle {
+			// if node is FlowStyle e.g. env: [foo, bar] # kpt-set: ${env}
+			// the setter comment will be on value node
+			lineComment = node.Value.YNode().LineComment
+		}
+
+		setterPattern := extractSetterPattern(lineComment)
+		if setterPattern == "" {
+			// the node is not tagged with setter pattern
+			return nil
+		}
+
+		if !shouldSet(setterPattern, as.Setters) {
+			// this means there is no intent from user to modify this setter tagged resources
+			return nil
+		}
+
+		// since this setter pattern is found on sequence node, make sure that it is
+		// not interpolation of setters, it should be simple setter e.g. ${environments}
+		if !validArraySetterPattern(setterPattern) {
+			return errors.Errorf("invalid setter pattern for array node: %q", setterPattern)
+		}
+
+		// get the setter value for the setter name in the comment
+		sv := setterValue(as.Setters, setterPattern)
+
+		// add the key to the field path
+		fieldPath := strings.TrimPrefix(fmt.Sprintf("%s.%s", path, node.Key.YNode().Value), ".")
+
+		if sv == "" {
+			node.Value.YNode().Content = []*yaml.Node{}
+			// empty sequence must be FlowStyle e.g. env: [] # kpt-set: ${env}
+			node.Value.YNode().Style = yaml.FlowStyle
+			// setter pattern comment must be on value node
+			node.Value.YNode().LineComment = lineComment
+			node.Key.YNode().LineComment = ""
+			as.Results = append(as.Results, &Result{
+				FilePath:  as.filePath,
+				FieldPath: fieldPath,
+				Value:     sv,
+			})
+			return nil
+		}
+
+		// parse the setter value as yaml node
+		rn, err := yaml.Parse(sv)
+		if err != nil {
+			return errors.Errorf("input to array setter must be an array of values, but found %q", sv)
+		}
+
+		// the setter value must parse as sequence node
+		if rn.YNode().Kind != yaml.SequenceNode {
+			return errors.Errorf("input to array setter must be an array of values, but found %q", sv)
+		}
+
+		node.Value.YNode().Content = rn.YNode().Content
+		node.Key.YNode().LineComment = lineComment
+		// non-empty sequences should be standardized to FoldedStyle
+		// env: # kpt-set: ${env}
+		//  - foo
+		//  - bar
+		node.Value.YNode().Style = yaml.FoldedStyle
+
+		as.Results = append(as.Results, &Result{
+			FilePath:  as.filePath,
+			FieldPath: fieldPath,
+			Value:     sv,
+		})
+		return nil
+	})
+}
+
+/*
+visitScalar accepts the input scalar node and performs following steps,
+checks if the line comment of input scalar node has prefix SetterCommentIdentifier
+resolves the setter values for the setter name in the comment
+replaces the existing value of the scalar node with the new value
+
+e.g.for input of scalar node 'nginx:1.7.1 # kpt-set: ${image}:${tag}' in the yaml node
+
+apiVersion: v1
+...
+
+	image: nginx:1.7.1 # kpt-set: ${image}:${tag}
+
+and for input ApplySetters [[name: image, value: ubuntu], [name: tag, value: 1.8.0]]
+The yaml node is transformed to
+
+apiVersion: v1
+...
+
+	image: ubuntu:1.8.0 # kpt-set: ${image}:${tag}
+*/
+func (as *ApplySetters) visitScalar(object *yaml.RNode, path string) error {
+	if object.IsNil() {
+		return nil
+	}
+
+	if object.YNode().Kind != yaml.ScalarNode {
+		// return if it is not a scalar node
+		return nil
+	}
+
+	// perform a direct set of the field if it matches
+	setterPattern := extractSetterPattern(object.YNode().LineComment)
+	if setterPattern == "" {
+		// the node is not tagged with setter pattern
+		return nil
+	}
+
+	curPattern := setterPattern
+	if !shouldSet(setterPattern, as.Setters) {
+		// this means there is no intent from user to modify this setter tagged resources
+		return nil
+	}
+
+	// replace the setter names in comment pattern with provided values
+	for _, setter := range as.Setters {
+		setterPattern = strings.ReplaceAll(
+			setterPattern,
+			fmt.Sprintf("${%s}", setter.Name),
+			fmt.Sprintf("%v", setter.Value),
+		)
+	}
+
+	// replace the remaining setter names in comment pattern with values derived from current
+	// field value, these values are not provided by user
+	currentSetterValues := currentSetterValues(curPattern, object.YNode().Value)
+	for setterName, setterValue := range currentSetterValues {
+		setterPattern = strings.ReplaceAll(
+			setterPattern,
+			fmt.Sprintf("${%s}", setterName),
+			fmt.Sprintf("%v", setterValue),
+		)
+	}
+
+	// check if there are unresolved setters and throw error
+	urs := unresolvedSetters(setterPattern)
+	if len(urs) > 0 {
+		return errors.Errorf("values for setters %v must be provided", urs)
+	}
+
+	object.YNode().Value = setterPattern
+	if setterPattern == "" {
+		object.YNode().Style = yaml.DoubleQuotedStyle
+	}
+	object.YNode().Tag = yaml.NodeTagEmpty
+	as.Results = append(as.Results, &Result{
+		FilePath:  as.filePath,
+		FieldPath: strings.TrimPrefix(path, "."),
+		Value:     object.YNode().Value,
+	})
+	return nil
+}
+
+// shouldSet takes the setter pattern comment and setter values map and returns true
+// iff at least one of the setter names in the pattern match with the setter names
+// in input setterValues map
+func shouldSet(pattern string, setters []Setter) bool {
+	for _, s := range setters {
+		if strings.Contains(pattern, fmt.Sprintf("${%s}", s.Name)) {
+			return true
+		}
+	}
+	return false
+}
+
+// currentSetterValues takes pattern and value and returns setter names to values
+// derived using pattern matching
+// e.g. pattern = my-app-layer.${stage}.${domain}.${tld}, value = my-app-layer.dev.example.com
+// returns {"stage":"dev", "domain":"example", "tld":"com"}
+func currentSetterValues(pattern, value string) map[string]string {
+	res := make(map[string]string)
+	// get all setter names enclosed in ${}
+	// e.g. value: my-app-layer.dev.example.com
+	// pattern: my-app-layer.${stage}.${domain}.${tld}
+	// urs: [${stage}, ${domain}, ${tld}]
+	urs := unresolvedSetters(pattern)
+	// and escape pattern
+	pattern = regexp.QuoteMeta(pattern)
+	// escaped pattern: my-app-layer\.\$\{stage\}\.\$\{domain\}\.\$\{tld\}
+
+	for _, setterName := range urs {
+		// escape setter name
+		// we need to escape the setterName as well to replace it in the escaped pattern string later
+		setterName = regexp.QuoteMeta(setterName)
+		pattern = strings.ReplaceAll(
+			pattern,
+			setterName,
+			`(?P<x>.*)`) // x is just a place holder, it could be any alphanumeric string
+	}
+	// pattern: my-app-layer\.(?P<x>.*)\.(?P<x>.*)\.(?P<x>.*)
+	r, err := regexp.Compile(pattern)
+	if err != nil {
+		// just return empty map if values can't be derived from pattern
+		return res
+	}
+	setterValues := r.FindStringSubmatch(value)
+	if len(setterValues) == 0 {
+		return res
+	}
+	// setterValues: [ "my-app-layer.dev.example.com", "dev", "example", "com"]
+	setterValues = setterValues[1:]
+	// setterValues: [ "dev", "example", "com"]
+	if len(urs) != len(setterValues) {
+		// just return empty map if values can't be derived
+		return res
+	}
+	for i := range setterValues {
+		if setterValues[i] == "" {
+			// if any of the value is unresolved return empty map
+			// and expect users to provide all values
+			return make(map[string]string)
+		}
+		res[clean(urs[i])] = setterValues[i]
+	}
+	return res
+}
+
+// setterValue returns the value for the setter
+func setterValue(setters []Setter, setterName string) string {
+	for _, setter := range setters {
+		if setter.Name == clean(setterName) {
+			return setter.Value
+		}
+	}
+	return ""
+}
+
+// extractSetterPattern extracts the setter pattern from the line comment of the
+// yaml RNode. If the the line comment doesn't contain SetterCommentIdentifier
+// prefix, then it returns empty string
+func extractSetterPattern(lineComment string) string {
+	if !strings.HasPrefix(lineComment, SetterCommentIdentifier) {
+		return ""
+	}
+	return strings.TrimSpace(strings.TrimPrefix(lineComment, SetterCommentIdentifier))
+}
+
+// validArraySetterPattern returns true if the array setter pattern is valid
+// pattern must not interpolation of setters, it should be simple setter e.g. ${environments}
+func validArraySetterPattern(pattern string) bool {
+	return len(unresolvedSetters(pattern)) == 1 &&
+		strings.HasPrefix(pattern, "${") &&
+		strings.HasSuffix(pattern, "}")
+}
+
+// unresolvedSetters returns the list of values enclosed in ${} present within given
+// pattern e.g. pattern = foo-${image}:${tag}-bar return ["${image}", "${tag}"]
+func unresolvedSetters(pattern string) []string {
+	re := regexp.MustCompile(`\$\{([^}]*)\}`)
+	return re.FindAllString(pattern, -1)
+}
+
+// clean extracts value enclosed in ${}
+func clean(input string) string {
+	input = strings.TrimSpace(input)
+	return strings.TrimSuffix(strings.TrimPrefix(input, "${"), "}")
+}
+
+// Decode decodes the input yaml node into Set struct
+func Decode(rn *yaml.RNode, fcd *ApplySetters) {
+	for k, v := range rn.GetDataMap() {
+		fcd.Setters = append(fcd.Setters, Setter{Name: k, Value: v})
+	}
+}

--- a/pkg/skaffold/render/applysetters/apply_setters_test.go
+++ b/pkg/skaffold/render/applysetters/apply_setters_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package applysetters
 
 import (

--- a/pkg/skaffold/render/applysetters/apply_setters_test.go
+++ b/pkg/skaffold/render/applysetters/apply_setters_test.go
@@ -1,0 +1,570 @@
+package applysetters
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+func TestApplySettersFilter(t *testing.T) {
+	var tests = []struct {
+		name              string
+		config            string
+		input             string
+		expectedResources string
+		errMsg            string
+	}{
+		{
+			name: "set name and label",
+			input: `apiVersion: v1
+kind: Service
+metadata:
+  name: myService # kpt-set: ${app}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: mungebot # kpt-set: ${app}
+  name: mungebot
+`,
+			config: `
+data:
+  app: my-app
+`,
+			expectedResources: `apiVersion: v1
+kind: Service
+metadata:
+  name: my-app # kpt-set: ${app}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: my-app # kpt-set: ${app}
+  name: mungebot
+`,
+		},
+		{
+			name: "set name and label",
+			input: `apiVersion: v1
+kind: Service
+metadata:
+  name: myService # kpt-set: ${app}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: mungebot # kpt-set: ${app}
+  name: mungebot
+`,
+			config: `
+data:
+  app: my-app
+`,
+			expectedResources: `apiVersion: v1
+kind: Service
+metadata:
+  name: my-app # kpt-set: ${app}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: my-app # kpt-set: ${app}
+  name: mungebot
+`,
+		},
+		{
+			name: "set setter pattern",
+			config: `
+data:
+  image: ubuntu
+  tag: 1.8.0
+`,
+			input: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.7.9 # kpt-set: ${image}:${tag}
+`,
+			expectedResources: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+        - name: nginx
+          image: ubuntu:1.8.0 # kpt-set: ${image}:${tag}
+`,
+		},
+		{
+			name: "derive missing values from pattern",
+			config: `
+data:
+  image: ubuntu
+`,
+			input: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.7.9 # kpt-set: ${image}:${tag}`,
+			expectedResources: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+        - name: nginx
+          image: ubuntu:1.7.9 # kpt-set: ${image}:${tag}
+`,
+		},
+		{
+			name: "derive missing values from pattern - special characters in name and value",
+			config: `
+data:
+  image-~!@#$%^&*()<>?"|: ubuntu-~!@#$%^&*()<>?"|
+`,
+			input: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.7.9 # kpt-set: ${image-~!@#$%^&*()<>?"|}:${tag}`,
+			expectedResources: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+        - name: nginx
+          image: ubuntu-~!@#$%^&*()<>?"|:1.7.9 # kpt-set: ${image-~!@#$%^&*()<>?"|}:${tag}
+`,
+		},
+		{
+			name: "don't set if no relevant setter values are provided",
+			config: `
+data:
+  project: my-project-foo
+`,
+			input: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.7.9 # kpt-set: ${image}:${tag}
+ `,
+			expectedResources: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.7.9 # kpt-set: ${image}:${tag}
+`,
+		},
+		{
+			name: "error if values not provided and can't be derived",
+			config: `
+data:
+  image: ubuntu
+`,
+			input: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+        - image: irrelevant_value # kpt-set: ${image}:${tag}
+          name: nginx
+ `,
+			expectedResources: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+        - image: irrelevant_value # kpt-set: ${image}:${tag}
+          name: nginx
+ `,
+			errMsg: `values for setters [${tag}] must be provided`,
+		},
+		{
+			name: "apply array setter",
+			config: `
+data:
+  images: |
+    - ubuntu
+    - hbase
+`,
+			input: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  images: # kpt-set: ${images}
+    - nginx
+    - ubuntu
+ `,
+			expectedResources: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  images: # kpt-set: ${images}
+    - ubuntu
+    - hbase
+`,
+		},
+		{
+			name: "apply array setter with scalar error",
+			config: `
+data:
+  images: ubuntu
+`,
+			input: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  images: # kpt-set: ${images}
+    - nginx
+    - ubuntu
+`,
+			expectedResources: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  images: # kpt-set: ${images}
+    - nginx
+    - ubuntu
+`,
+			errMsg: `input to array setter must be an array of values`,
+		},
+		{
+			name: "apply array setter interpolation error",
+			config: `
+data:
+  images: |
+    [ubuntu, hbase]
+`,
+			input: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  images: # kpt-set: ${images}:${tag}
+    - nginx
+    - ubuntu
+`,
+			expectedResources: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  images: # kpt-set: ${images}:${tag}
+    - nginx
+    - ubuntu
+`,
+			errMsg: `invalid setter pattern for array node: "${images}:${tag}"`,
+		},
+		{
+			name: "scalar partial setter using dots",
+			config: `
+data:
+  domain: demo
+  tld: io
+`,
+			input: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-app-layer
+spec:
+  host: my-app-layer.dev.example.com # kpt-set: my-app-layer.${stage}.${domain}.${tld}
+`,
+			expectedResources: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-app-layer
+spec:
+  host: my-app-layer.dev.demo.io # kpt-set: my-app-layer.${stage}.${domain}.${tld}
+`,
+		},
+		{
+			name: "do not error if no input",
+			config: `
+data: {}
+`,
+			input: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.7.9 # kpt-set: ${image}:${tag}
+`,
+			expectedResources: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.7.9 # kpt-set: ${image}:${tag}
+`,
+		},
+		{
+			name: "set empty values",
+			input: `apiVersion: v1
+kind: Service
+metadata:
+  name: myService # kpt-set: ${app}
+  namespace: "foo" # kpt-set: ${ns}
+image: nginx:1.7.1 # kpt-set: ${image}:${tag}
+env: # kpt-set: ${env}
+  - foo
+  - bar
+roles: [dev, prod] # kpt-set: ${roles}
+`,
+			config: `
+data:
+  app: ""
+  ns: ~
+  image: ''
+  env: ""
+  roles: ''
+`,
+			expectedResources: `apiVersion: v1
+kind: Service
+metadata:
+  name: "" # kpt-set: ${app}
+  namespace: "" # kpt-set: ${ns}
+image: :1.7.1 # kpt-set: ${image}:${tag}
+env: [] # kpt-set: ${env}
+roles: [] # kpt-set: ${roles}
+`,
+		},
+		{
+			name: "set non-empty values from empty values",
+			input: `apiVersion: v1
+kind: Service
+metadata:
+  name: "" # kpt-set: ${app}
+  namespace: "" # kpt-set: ${ns}
+image: :1.7.1 # kpt-set: ${image}:${tag}
+env: [] # kpt-set: ${env}
+roles: [] # kpt-set: ${roles}
+`,
+			config: `
+data:
+  app: myService
+  ns: foo
+  image: nginx
+  tag: 1.7.1
+  env: "[foo, bar]"
+  roles: |
+    - dev
+    - prod
+`,
+			expectedResources: `apiVersion: v1
+kind: Service
+metadata:
+  name: "myService" # kpt-set: ${app}
+  namespace: "foo" # kpt-set: ${ns}
+image: nginx:1.7.1 # kpt-set: ${image}:${tag}
+env: # kpt-set: ${env}
+  - foo
+  - bar
+roles: # kpt-set: ${roles}
+  - dev
+  - prod
+`,
+		},
+	}
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.name, func(t *testing.T) {
+			baseDir, err := os.MkdirTemp("", "")
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+			defer os.RemoveAll(baseDir)
+
+			r, err := os.CreateTemp(baseDir, "k8s-cli-*.yaml")
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+			defer os.Remove(r.Name())
+			err = os.WriteFile(r.Name(), []byte(test.input), 0600)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			s := &ApplySetters{}
+			node, err := kyaml.Parse(test.config)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+			Decode(node, s)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+			inout := &kio.LocalPackageReadWriter{
+				PackagePath:     baseDir,
+				NoDeleteFiles:   true,
+				PackageFileName: "Kptfile",
+			}
+			err = kio.Pipeline{
+				Inputs:  []kio.Reader{inout},
+				Filters: []kio.Filter{s},
+				Outputs: []kio.Writer{inout},
+			}.Execute()
+			if test.errMsg != "" {
+				if !assert.NotNil(t, err) {
+					t.FailNow()
+				}
+				if !assert.Contains(t, err.Error(), test.errMsg) {
+					t.FailNow()
+				}
+			}
+
+			if test.errMsg == "" && !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			actualResources, err := os.ReadFile(r.Name())
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+			if !assert.Equal(t,
+				test.expectedResources,
+				string(actualResources)) {
+				t.FailNow()
+			}
+		})
+	}
+}
+
+type patternTest struct {
+	name     string
+	value    string
+	pattern  string
+	expected map[string]string
+}
+
+var resolvePatternCases = []patternTest{
+	{
+		name:    "setter values from pattern 1",
+		value:   "foo-dev-bar-us-east-1-baz",
+		pattern: `foo-${environment}-bar-${region}-baz`,
+		expected: map[string]string{
+			"environment": "dev",
+			"region":      "us-east-1",
+		},
+	},
+	{
+		name:    "setter values from pattern 2",
+		value:   "foo-dev-bar-us-east-1-baz",
+		pattern: `foo-${environment}-bar-${region}-baz`,
+		expected: map[string]string{
+			"environment": "dev",
+			"region":      "us-east-1",
+		},
+	},
+	{
+		name:    "setter values from pattern 3",
+		value:   "gcr.io/my-app/my-app-backend:1.0.0",
+		pattern: `${registry}/${app~!@#$%^&*()<>?:"|}/${app-image-name}:${app-image-tag}`,
+		expected: map[string]string{
+			"registry":             "gcr.io",
+			`app~!@#$%^&*()<>?:"|`: "my-app",
+			"app-image-name":       "my-app-backend",
+			"app-image-tag":        "1.0.0",
+		},
+	},
+	{
+		name:     "setter values from pattern unresolved",
+		value:    "foo-dev-bar-us-east-1-baz",
+		pattern:  `${image}:${tag}`,
+		expected: map[string]string{},
+	},
+	{
+		name:     "setter values from pattern unresolved 2",
+		value:    "nginx:1.2",
+		pattern:  `${image}${tag}`,
+		expected: map[string]string{},
+	},
+	{
+		name:     "setter values from pattern unresolved 3",
+		value:    "my-project/nginx:1.2",
+		pattern:  `${project-id}/${image}${tag}`,
+		expected: map[string]string{},
+	},
+}
+
+func TestCurrentSetterValues(t *testing.T) {
+	for _, tests := range [][]patternTest{resolvePatternCases} {
+		for i := range tests {
+			test := tests[i]
+			t.Run(test.name, func(t *testing.T) {
+				res := currentSetterValues(test.pattern, test.value)
+				if !assert.Equal(t, test.expected, res) {
+					t.FailNow()
+				}
+			})
+		}
+	}
+}

--- a/pkg/skaffold/render/applysetters/apply_setters_test.go
+++ b/pkg/skaffold/render/applysetters/apply_setters_test.go
@@ -22,13 +22,13 @@ func TestApplySettersFilter(t *testing.T) {
 			input: `apiVersion: v1
 kind: Service
 metadata:
-  name: myService # kpt-set: ${app}
+  name: myService # from-param: ${app}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: mungebot # kpt-set: ${app}
+    app: mungebot # from-param: ${app}
   name: mungebot
 `,
 			config: `
@@ -38,13 +38,13 @@ data:
 			expectedResources: `apiVersion: v1
 kind: Service
 metadata:
-  name: my-app # kpt-set: ${app}
+  name: my-app # from-param: ${app}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: my-app # kpt-set: ${app}
+    app: my-app # from-param: ${app}
   name: mungebot
 `,
 		},
@@ -53,13 +53,13 @@ metadata:
 			input: `apiVersion: v1
 kind: Service
 metadata:
-  name: myService # kpt-set: ${app}
+  name: myService # from-param: ${app}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: mungebot # kpt-set: ${app}
+    app: mungebot # from-param: ${app}
   name: mungebot
 `,
 			config: `
@@ -69,13 +69,13 @@ data:
 			expectedResources: `apiVersion: v1
 kind: Service
 metadata:
-  name: my-app # kpt-set: ${app}
+  name: my-app # from-param: ${app}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: my-app # kpt-set: ${app}
+    app: my-app # from-param: ${app}
   name: mungebot
 `,
 		},
@@ -96,7 +96,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:1.7.9 # kpt-set: ${image}:${tag}
+          image: nginx:1.7.9 # from-param: ${image}:${tag}
 `,
 			expectedResources: `apiVersion: apps/v1
 kind: Deployment
@@ -108,7 +108,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: ubuntu:1.8.0 # kpt-set: ${image}:${tag}
+          image: ubuntu:1.8.0 # from-param: ${image}:${tag}
 `,
 		},
 		{
@@ -127,7 +127,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:1.7.9 # kpt-set: ${image}:${tag}`,
+          image: nginx:1.7.9 # from-param: ${image}:${tag}`,
 			expectedResources: `apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -138,7 +138,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: ubuntu:1.7.9 # kpt-set: ${image}:${tag}
+          image: ubuntu:1.7.9 # from-param: ${image}:${tag}
 `,
 		},
 		{
@@ -157,7 +157,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:1.7.9 # kpt-set: ${image-~!@#$%^&*()<>?"|}:${tag}`,
+          image: nginx:1.7.9 # from-param: ${image-~!@#$%^&*()<>?"|}:${tag}`,
 			expectedResources: `apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -168,7 +168,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: ubuntu-~!@#$%^&*()<>?"|:1.7.9 # kpt-set: ${image-~!@#$%^&*()<>?"|}:${tag}
+          image: ubuntu-~!@#$%^&*()<>?"|:1.7.9 # from-param: ${image-~!@#$%^&*()<>?"|}:${tag}
 `,
 		},
 		{
@@ -187,7 +187,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:1.7.9 # kpt-set: ${image}:${tag}
+          image: nginx:1.7.9 # from-param: ${image}:${tag}
  `,
 			expectedResources: `apiVersion: apps/v1
 kind: Deployment
@@ -199,7 +199,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:1.7.9 # kpt-set: ${image}:${tag}
+          image: nginx:1.7.9 # from-param: ${image}:${tag}
 `,
 		},
 		{
@@ -217,7 +217,7 @@ spec:
   template:
     spec:
       containers:
-        - image: irrelevant_value # kpt-set: ${image}:${tag}
+        - image: irrelevant_value # from-param: ${image}:${tag}
           name: nginx
  `,
 			expectedResources: `apiVersion: apps/v1
@@ -229,7 +229,7 @@ spec:
   template:
     spec:
       containers:
-        - image: irrelevant_value # kpt-set: ${image}:${tag}
+        - image: irrelevant_value # from-param: ${image}:${tag}
           name: nginx
  `,
 			errMsg: `values for setters [${tag}] must be provided`,
@@ -247,7 +247,7 @@ kind: Deployment
 metadata:
   name: nginx-deployment
 spec:
-  images: # kpt-set: ${images}
+  images: # from-param: ${images}
     - nginx
     - ubuntu
  `,
@@ -256,7 +256,7 @@ kind: Deployment
 metadata:
   name: nginx-deployment
 spec:
-  images: # kpt-set: ${images}
+  images: # from-param: ${images}
     - ubuntu
     - hbase
 `,
@@ -272,7 +272,7 @@ kind: Deployment
 metadata:
   name: nginx-deployment
 spec:
-  images: # kpt-set: ${images}
+  images: # from-param: ${images}
     - nginx
     - ubuntu
 `,
@@ -281,7 +281,7 @@ kind: Deployment
 metadata:
   name: nginx-deployment
 spec:
-  images: # kpt-set: ${images}
+  images: # from-param: ${images}
     - nginx
     - ubuntu
 `,
@@ -299,7 +299,7 @@ kind: Deployment
 metadata:
   name: nginx-deployment
 spec:
-  images: # kpt-set: ${images}:${tag}
+  images: # from-param: ${images}:${tag}
     - nginx
     - ubuntu
 `,
@@ -308,7 +308,7 @@ kind: Deployment
 metadata:
   name: nginx-deployment
 spec:
-  images: # kpt-set: ${images}:${tag}
+  images: # from-param: ${images}:${tag}
     - nginx
     - ubuntu
 `,
@@ -326,14 +326,14 @@ kind: ConfigMap
 metadata:
   name: my-app-layer
 spec:
-  host: my-app-layer.dev.example.com # kpt-set: my-app-layer.${stage}.${domain}.${tld}
+  host: my-app-layer.dev.example.com # from-param: my-app-layer.${stage}.${domain}.${tld}
 `,
 			expectedResources: `apiVersion: v1
 kind: ConfigMap
 metadata:
   name: my-app-layer
 spec:
-  host: my-app-layer.dev.demo.io # kpt-set: my-app-layer.${stage}.${domain}.${tld}
+  host: my-app-layer.dev.demo.io # from-param: my-app-layer.${stage}.${domain}.${tld}
 `,
 		},
 		{
@@ -351,7 +351,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:1.7.9 # kpt-set: ${image}:${tag}
+          image: nginx:1.7.9 # from-param: ${image}:${tag}
 `,
 			expectedResources: `apiVersion: apps/v1
 kind: Deployment
@@ -363,7 +363,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: nginx:1.7.9 # kpt-set: ${image}:${tag}
+          image: nginx:1.7.9 # from-param: ${image}:${tag}
 `,
 		},
 		{
@@ -371,13 +371,13 @@ spec:
 			input: `apiVersion: v1
 kind: Service
 metadata:
-  name: myService # kpt-set: ${app}
-  namespace: "foo" # kpt-set: ${ns}
-image: nginx:1.7.1 # kpt-set: ${image}:${tag}
-env: # kpt-set: ${env}
+  name: myService # from-param: ${app}
+  namespace: "foo" # from-param: ${ns}
+image: nginx:1.7.1 # from-param: ${image}:${tag}
+env: # from-param: ${env}
   - foo
   - bar
-roles: [dev, prod] # kpt-set: ${roles}
+roles: [dev, prod] # from-param: ${roles}
 `,
 			config: `
 data:
@@ -390,11 +390,11 @@ data:
 			expectedResources: `apiVersion: v1
 kind: Service
 metadata:
-  name: "" # kpt-set: ${app}
-  namespace: "" # kpt-set: ${ns}
-image: :1.7.1 # kpt-set: ${image}:${tag}
-env: [] # kpt-set: ${env}
-roles: [] # kpt-set: ${roles}
+  name: "" # from-param: ${app}
+  namespace: "" # from-param: ${ns}
+image: :1.7.1 # from-param: ${image}:${tag}
+env: [] # from-param: ${env}
+roles: [] # from-param: ${roles}
 `,
 		},
 		{
@@ -402,11 +402,11 @@ roles: [] # kpt-set: ${roles}
 			input: `apiVersion: v1
 kind: Service
 metadata:
-  name: "" # kpt-set: ${app}
-  namespace: "" # kpt-set: ${ns}
-image: :1.7.1 # kpt-set: ${image}:${tag}
-env: [] # kpt-set: ${env}
-roles: [] # kpt-set: ${roles}
+  name: "" # from-param: ${app}
+  namespace: "" # from-param: ${ns}
+image: :1.7.1 # from-param: ${image}:${tag}
+env: [] # from-param: ${env}
+roles: [] # from-param: ${roles}
 `,
 			config: `
 data:
@@ -422,13 +422,13 @@ data:
 			expectedResources: `apiVersion: v1
 kind: Service
 metadata:
-  name: "myService" # kpt-set: ${app}
-  namespace: "foo" # kpt-set: ${ns}
-image: nginx:1.7.1 # kpt-set: ${image}:${tag}
-env: # kpt-set: ${env}
+  name: "myService" # from-param: ${app}
+  namespace: "foo" # from-param: ${ns}
+image: nginx:1.7.1 # from-param: ${image}:${tag}
+env: # from-param: ${env}
   - foo
   - bar
-roles: # kpt-set: ${roles}
+roles: # from-param: ${roles}
   - dev
   - prod
 `,

--- a/pkg/skaffold/render/applysetters/walk.go
+++ b/pkg/skaffold/render/applysetters/walk.go
@@ -1,0 +1,69 @@
+package applysetters
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/kustomize/kyaml/errors"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+// visitor is implemented by structs which need to walk the configuration.
+// visitor is provided to accept to walk configuration
+type visitor interface {
+	// visitScalar is called for each scalar field value on a resource
+	// node is the scalar field value
+	// path is the path to the field; path elements are separated by '.'
+	visitScalar(node *yaml.RNode, path string) error
+
+	// visitMapping is called for each Mapping field value on a resource
+	// node is the mapping field value
+	// path is the path to the field
+	visitMapping(node *yaml.RNode, path string) error
+}
+
+// accept invokes the appropriate function on v for each field in object
+func accept(v visitor, object *yaml.RNode) error {
+	// get the OpenAPI for the type if it exists
+	return acceptImpl(v, object, "")
+}
+
+// acceptImpl implements accept using recursion
+func acceptImpl(v visitor, object *yaml.RNode, p string) error {
+	switch object.YNode().Kind {
+	case yaml.DocumentNode:
+		// Traverse the child of the document
+		return accept(v, yaml.NewRNode(object.YNode()))
+	case yaml.MappingNode:
+		if err := v.visitMapping(object, p); err != nil {
+			return err
+		}
+		return object.VisitFields(func(node *yaml.MapNode) error {
+			// Traverse each field value
+			return acceptImpl(v, node.Value, p+"."+node.Key.YNode().Value)
+		})
+	case yaml.SequenceNode:
+		return VisitElements(object, func(node *yaml.RNode, i int) error {
+			// Traverse each list element
+			return acceptImpl(v, node, p+fmt.Sprintf("[%d]", i))
+		})
+	case yaml.ScalarNode:
+		// Visit the scalar field
+		return v.visitScalar(object, p)
+	}
+	return nil
+}
+
+// VisitElements calls fn for each element in a SequenceNode.
+// Returns an error for non-SequenceNodes
+func VisitElements(rn *yaml.RNode, fn func(node *yaml.RNode, i int) error) error {
+	elements, err := rn.Elements()
+	if err != nil {
+		return errors.Wrap(err)
+	}
+	for i := range elements {
+		if err := fn(elements[i], i); err != nil {
+			return errors.Wrap(err)
+		}
+	}
+	return nil
+}

--- a/pkg/skaffold/render/applysetters/walk.go
+++ b/pkg/skaffold/render/applysetters/walk.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package applysetters
 
 import (

--- a/pkg/skaffold/render/renderer/kustomize/kustomize.go
+++ b/pkg/skaffold/render/renderer/kustomize/kustomize.go
@@ -26,6 +26,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"gopkg.in/yaml.v3"
+	apimachinery "k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/kustomize/api/types"
+
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/constants"
 	sErrors "github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/errors"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/graph"
@@ -41,9 +45,6 @@ import (
 	sUtil "github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/util/stringset"
 	"github.com/GoogleContainerTools/skaffold/v2/proto/v1"
-	"gopkg.in/yaml.v3"
-	apimachinery "k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/kustomize/api/types"
 )
 
 type Kustomize struct {
@@ -316,7 +317,7 @@ func (k Kustomize) mirrorFile(kusDir string, fs TmpFS, path string) error {
 
 	err = k.applySetters.ApplyPath(fsPath)
 	if err != nil {
-		return fmt.Errorf("failed to apply setter to file %s, err: %v\n", pFile, err)
+		return fmt.Errorf("failed to apply setter to file %s, err: %v", pFile, err)
 	}
 	return nil
 }

--- a/pkg/skaffold/render/renderer/kustomize/kustomize.go
+++ b/pkg/skaffold/render/renderer/kustomize/kustomize.go
@@ -19,7 +19,6 @@ package kustomize
 import (
 	"context"
 	"fmt"
-	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/render/applysetters"
 	"io"
 	"io/ioutil"
 	"os"
@@ -33,6 +32,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/kubernetes/manifest"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/render"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/render/applysetters"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/render/generate"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/render/renderer/util"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/render/transform"


### PR DESCRIPTION
 Fixes: #8901  

 - port over  https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/master/functions/go/apply-setters to skaffold to avoid external calls for parameterization
 - rename kpt-set to from-param
 - the change only support for rawmanifest and kustomizer render, template commenter doesn't work for helm for now it will be done in a separate pr. 