### PR TITLE
cp v1.39 85c478ff29905d583870496e4cf3921df21242a3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,7 @@ release-build:
 		-f deploy/skaffold/Dockerfile \
 		--target release \
 		-t gcr.io/$(GCP_PROJECT)/skaffold:edge \
+		-t gcr.io/$(GCP_PROJECT)/skaffold:public-image-edge \
 		-t gcr.io/$(GCP_PROJECT)/skaffold:$(COMMIT) \
 		.
 
@@ -170,6 +171,7 @@ release-lts: $(BUILD_DIR)/VERSION
 		--target release \
 		-t gcr.io/$(GCP_PROJECT)/skaffold:lts \
 		-t gcr.io/$(GCP_PROJECT)/skaffold:$(VERSION)-lts \
+		-t gcr.io/$(GCP_PROJECT)/skaffold:$(SCANNING_MARKER)-lts \
 		.
 
 .PHONY: release-lts-build

--- a/deploy/cloudbuild-release-lts.yaml
+++ b/deploy/cloudbuild-release-lts.yaml
@@ -49,6 +49,7 @@ steps:
       - 'make'
       - 'release-lts'
       - 'VERSION=$TAG_NAME'
+      - 'SCANNING_MARKER=$_SCANNING_MARKER'
       - 'RELEASE_BUCKET=$_RELEASE_BUCKET'
       - 'GCP_PROJECT=$PROJECT_ID'
 

--- a/deploy/cloudbuild.yaml
+++ b/deploy/cloudbuild.yaml
@@ -45,6 +45,7 @@ steps:
 images:
 - 'gcr.io/$PROJECT_ID/build_deps:latest'
 - 'gcr.io/$PROJECT_ID/skaffold:edge'
+- 'gcr.io/$PROJECT_ID/skaffold:public-image-edge'
 - 'gcr.io/$PROJECT_ID/skaffold:$COMMIT_SHA'
 
 options:

--- a/deploy/skaffold/Dockerfile.deps
+++ b/deploy/skaffold/Dockerfile.deps
@@ -157,5 +157,5 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
     jq \
     apt-transport-https && \
     rm -rf /var/lib/apt/lists/*
-COPY --from=golang:1.19.9 /usr/local/go /usr/local/go
+COPY --from=golang:1.19.10 /usr/local/go /usr/local/go
 ENV PATH /usr/local/go/bin:/root/go/bin:$PATH

--- a/deploy/skaffold/Dockerfile.deps.lts
+++ b/deploy/skaffold/Dockerfile.deps.lts
@@ -99,6 +99,7 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
     openjdk-11-jdk \
     software-properties-common \
     jq \
+    docker.io \
     apt-transport-https && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=golang:1.19.10 /usr/local/go /usr/local/go

--- a/deploy/skaffold/Dockerfile.deps.lts
+++ b/deploy/skaffold/Dockerfile.deps.lts
@@ -101,5 +101,5 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
     jq \
     apt-transport-https && \
     rm -rf /var/lib/apt/lists/*
-COPY --from=golang:1.19.9 /usr/local/go /usr/local/go
+COPY --from=golang:1.19.10 /usr/local/go /usr/local/go
 ENV PATH /usr/local/go/bin:/root/go/bin:$PATH

--- a/deploy/skaffold/Dockerfile.deps.lts
+++ b/deploy/skaffold/Dockerfile.deps.lts
@@ -101,9 +101,5 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
     jq \
     apt-transport-https && \
     rm -rf /var/lib/apt/lists/*
-<<<<<<< HEAD
-COPY --from=golang:1.19.6 /usr/local/go /usr/local/go
-=======
 COPY --from=golang:1.19.9 /usr/local/go /usr/local/go
->>>>>>> 140f4ff75 (chore: update various container deps. (#8810))
 ENV PATH /usr/local/go/bin:/root/go/bin:$PATH

--- a/integration/testdata/unstable-deployment/incorrect-deployment.yaml
+++ b/integration/testdata/unstable-deployment/incorrect-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: unstable-deployment
 spec:
-  progressDeadlineSeconds: 10
+  progressDeadlineSeconds: 20
   replicas: 1
   selector:
     matchLabels:


### PR DESCRIPTION
- fix: broken merge (#8828)
- test: increase progressDeadlineSeconds timeout to make TestRunUnstableChecked pass (#8833) (#8835)
- chore: add scanning marker for vulns scanning (#8840)
- chore: upgrade go version (#8896)
- fix: add docker to the LTS container images (#8905)
