### PR TITLE
fix: add docker to the LTS container images (#8905)

### DIFF
--- a/deploy/skaffold/Dockerfile.deps.lts
+++ b/deploy/skaffold/Dockerfile.deps.lts
@@ -103,6 +103,7 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
     openjdk-17-jdk \
     software-properties-common \
     jq \
+    docker.io \
     apt-transport-https && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=golang:1.19.10 /usr/local/go /usr/local/go


### PR DESCRIPTION
This fixes an issue where kpt functions wouldn't work in rendering since
they depend on docker to run.

(cherry picked from commit 85c478ff29905d583870496e4cf3921df21242a3)
