### PR TITLE
chore: push scanning marker tag to remote v2.0

### DIFF
--- a/deploy/cloudbuild-release-lts.yaml
+++ b/deploy/cloudbuild-release-lts.yaml
@@ -61,6 +61,7 @@ steps:
 
 images:
   - 'gcr.io/$PROJECT_ID/skaffold:$TAG_NAME-lts'
+  - 'gcr.io/$PROJECT_ID/skaffold:$_SCANNING_MARKER-lts'
   - 'us-east1-docker.pkg.dev/$PROJECT_ID/scanning/skaffold:$TAG_NAME-lts'
 
 options:


### PR DESCRIPTION
 - tracked internal 
 - We need use a tag with public-image prefix for skaffold images so vulnerabilities scanner can scan those.
 - That tag is added to the image but never gets pushed to remote repo.
 - so configuring it to push the tag to remote.