### PR TITLE
chore: disable edge image scanning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,6 @@ release-build:
 		-f deploy/skaffold/Dockerfile \
 		--target release \
 		-t gcr.io/$(GCP_PROJECT)/skaffold:edge \
-		-t gcr.io/$(GCP_PROJECT)/skaffold:public-image-edge \
 		-t gcr.io/$(GCP_PROJECT)/skaffold:$(COMMIT) \
 		.
 

--- a/deploy/cloudbuild.yaml
+++ b/deploy/cloudbuild.yaml
@@ -57,7 +57,6 @@ steps:
 images:
 - 'gcr.io/$PROJECT_ID/build_deps:latest'
 - 'gcr.io/$PROJECT_ID/skaffold:edge'
-- 'gcr.io/$PROJECT_ID/skaffold:public-image-edge'
 - 'gcr.io/$PROJECT_ID/skaffold:$COMMIT_SHA'
 - 'us-east1-docker.pkg.dev/$PROJECT_ID/scanning/skaffold:edge'
 


### PR DESCRIPTION
-  As team discussed, we would like to disable edge image vulnerabilities scanning due to the scope is too large and proper scope has already been covered by lts images. 