### PR TITLE
fix: Fix typo in Cloud Run log tailing

### DIFF
--- a/pkg/skaffold/deploy/cloudrun/log.go
+++ b/pkg/skaffold/deploy/cloudrun/log.go
@@ -108,7 +108,7 @@ func (r *LogAggregator) AddResource(resource RunResourceName) {
 
 func (r *LogAggregator) addServiceColor(serviceName string) {
 	if _, present := r.serviceColors[serviceName]; !present {
-		r.serviceColors[serviceName] = output.DefaultColorCodes[(len(r.serviceColors))&len(output.DefaultColorCodes)]
+		r.serviceColors[serviceName] = output.DefaultColorCodes[(len(r.serviceColors))%len(output.DefaultColorCodes)]
 	}
 }
 


### PR DESCRIPTION
Switch & to % so we properly rotate through all of the colors. This matches the behavior in https://github.com/GoogleContainerTools/skaffold/blob/453b101d70ccbf75c98f945516589950c87f63a0/pkg/skaffold/output/colorpicker.go#L52
