### PR TITLE
fix: edit original file if the given skaffold path is a symlink

### DIFF
--- a/cmd/skaffold/app/cmd/fix.go
+++ b/cmd/skaffold/app/cmd/fix.go
@@ -121,12 +121,16 @@ func fix(out io.Writer, configFile, outFile string, toVersion string, overwrite 
 	if outFile != "" {
 		var mvErr error
 		if overwrite {
-			outFile, err := getTrueLocation(outFile)
 			if err != nil {
-				return fmt.Errorf("Reading config file: %w", err)
+				return fmt.Errorf("reading config file: %w", err)
+			}
+			oldCfg, readErr := os.ReadFile(configFile)
+			if readErr != nil {
+				fmt.Errorf("reading config file: %w", readErr)
 			}
 			mvFile := fmt.Sprintf("%s.v2", outFile)
-			mvErr = os.Rename(outFile, mvFile)
+
+			mvErr = os.WriteFile(mvFile, oldCfg, 0644)
 			if mvErr == nil {
 				output.Default.Fprintln(out, "Backed up previous skaffold.yaml at ", mvFile)
 			}

--- a/cmd/skaffold/app/cmd/fix_test.go
+++ b/cmd/skaffold/app/cmd/fix_test.go
@@ -508,7 +508,7 @@ profiles:
 			cfgFile := t.TempFile("config", []byte(test.inputYaml))
 
 			var b bytes.Buffer
-			err := fix(&b, cfgFile, "", test.targetVersion)
+			err := fix(&b, cfgFile, "", test.targetVersion, false)
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.output, b.String(), test.cmpOptions)
 		})
 	}
@@ -553,11 +553,69 @@ deploy:
 		cfgFile := t.TempFile("config", []byte(inputYaml))
 
 		var b bytes.Buffer
-		err := fix(&b, cfgFile, cfgFile, latest.Version)
+		err := fix(&b, cfgFile, cfgFile, latest.Version, true)
 
 		output, _ := os.ReadFile(cfgFile)
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual(expectedOutput, string(output), testutil.YamlObj(t.T))
+
+		original, err := os.ReadFile(fmt.Sprintf("%s.v2", cfgFile))
+		t.CheckNoError(err)
+		t.CheckDeepEqual(inputYaml, string(original), testutil.YamlObj(t.T))
+	})
+}
+
+func TestFixToSymlinkedFileOverwrite(t *testing.T) {
+	inputYaml := `apiVersion: skaffold/v1alpha4
+kind: Config
+build:
+  artifacts:
+  - image: docker/image
+    docker:
+      dockerfile: dockerfile.test
+test:
+- image: docker/image
+  structureTests:
+  - ./test/*
+deploy:
+  kubectl:
+    manifests:
+    - k8s/deployment.yaml
+`
+	expectedOutput := fmt.Sprintf(`apiVersion: %s
+kind: Config
+build:
+  artifacts:
+  - image: docker/image
+    docker:
+      dockerfile: dockerfile.test
+test:
+- image: docker/image
+  structureTests:
+  - ./test/*
+manifests:
+  rawYaml:
+  - k8s/deployment.yaml
+deploy:
+  kubectl: {}
+`, latest.Version)
+
+	testutil.Run(t, "", func(t *testutil.T) {
+		tempDir := t.NewTempDir()
+		tempDir.Write("config", inputYaml)
+		cfgFile := tempDir.Path("config")
+		symlinkFile := tempDir.Path("symlinks/config_link")
+		tempDir.Symlink("config", "symlinks/config_link")
+		var b bytes.Buffer
+		err := fix(&b, symlinkFile, symlinkFile, latest.Version, true)
+
+		output, _ := os.ReadFile(cfgFile)
+		t.CheckNoError(err)
+		t.CheckDeepEqual(expectedOutput, string(output), testutil.YamlObj(t.T))
+
+		original, err := os.ReadFile(tempDir.Path("config.v2"))
+		t.CheckNoError(err)
+		t.CheckDeepEqual(inputYaml, string(original), testutil.YamlObj(t.T))
 	})
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #8489
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**

This PR fixes issue where skaffold fix --overwrite  command doesn't overwrite the contents of a symlink

First we make a backup of original file by copying the contents of symlink to new file (in same directory as symlink, if applicable)

Then we overwrite config file with new contents

This also accounts for case where symlink of symlink is provided.


**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->

Setup:
$ $HOME/skaffold/out/skaffold fix --overwrite
Backed up previous skaffold.yaml at  skaffold.yaml.v2
New config at version skaffold/v4beta6 generated and written to skaffold.yaml


