### PR TITLE
fix: verify hangs if event-logs-file does not exist (#7613)

### DIFF
--- a/pkg/skaffold/event/event.go
+++ b/pkg/skaffold/event/event.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sync"
 
 	//nolint:golint,staticcheck
@@ -830,6 +831,11 @@ func InititializationFailed(err error) {
 // SaveEventsToFile saves the current event log to the filepath provided
 func SaveEventsToFile(fp string) error {
 	handler.logLock.Lock()
+	// Ensure that the filepath provided has the directories available when attemping to save the file.
+	dir := filepath.Dir(fp)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("unable to create directory %q: %w", dir, err)
+	}
 	f, err := os.OpenFile(fp, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
 	if err != nil {
 		return fmt.Errorf("opening %s: %w", fp, err)

--- a/pkg/skaffold/event/v2/event.go
+++ b/pkg/skaffold/event/v2/event.go
@@ -312,6 +312,11 @@ func (ev *eventHandler) handleExec(event *proto.Event) {
 // SaveEventsToFile saves the current event log to the filepath provided
 func SaveEventsToFile(fp string) error {
 	handler.logLock.Lock()
+	// Ensure that the filepath provided has the directories available when attemping to save the file.
+	dir := filepath.Dir(fp)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("unable to create directory %q: %w", dir, err)
+	}
 	f, err := os.OpenFile(fp, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
 	if err != nil {
 		return fmt.Errorf("opening %s: %w", fp, err)
@@ -340,6 +345,11 @@ func SaveLastLog(fp string) error {
 	fp, err := lastLogFile(fp)
 	if err != nil {
 		return fmt.Errorf("getting last log file %w", err)
+	}
+	// Ensure that the filepath provided has the directories available when attemping to save the file.
+	dir := filepath.Dir(fp)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("unable to create directory %q: %w", dir, err)
 	}
 	f, err := os.OpenFile(fp, os.O_TRUNC|os.O_WRONLY|os.O_CREATE, 0600)
 	if err != nil {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #7613 <!-- tracking issues that this PR will close -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
When running `skaffold verify` with rpc-port and --event-log-file, if the event-log-file references a path to a file where the directory doesn't exist, the command hangs indefinitely. The changes I am proposing ensure that the directories to event-log-file exists before attempting to create the file and dump the logs. The relevant unit tests are also adjusted with the assumption that the directory does not exist. 

In addition, SaveLastLog seems to follow the same issue, which is also fixed in this PR.   

0700 is used since 'execute' permission is needed on the directories. Execute permissions on directory are so that files can be accessed in those nested directories.

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
