### PR TITLE
fix: remote kustomize manifest being watched

### DIFF
--- a/pkg/skaffold/deploy/kubectl/kustomize_test.go
+++ b/pkg/skaffold/deploy/kubectl/kustomize_test.go
@@ -266,6 +266,9 @@ func TestDependenciesForKustomization(t *testing.T) {
 - path: patch1.yaml
   target:
     kind: Deployment`},
+			createFiles: map[string]string{
+				"patch1.yaml": "",
+			},
 			expected: []string{"kustomization.yaml", "patch1.yaml"},
 		},
 		{
@@ -282,7 +285,18 @@ func TestDependenciesForKustomization(t *testing.T) {
 			kustomizations: map[string]string{"kustomization.yaml": `patches: 
 - path: patch1.yaml 
 - path: path/patch2.yaml`},
+			createFiles: map[string]string{
+				"patch1.yaml":      "",
+				"path/patch2.yaml": "",
+			},
 			expected: []string{"kustomization.yaml", "patch1.yaml", "path/patch2.yaml"},
+		},
+		{
+			description: "ignore patches legacy, path doesn't exist",
+			kustomizations: map[string]string{"kustomization.yaml": `patches: 
+- path: patch1.yaml 
+- path: path/patch2.yaml`},
+			expected: []string{"kustomization.yaml"},
 		},
 		{
 			description:    "patchesStrategicMerge",
@@ -306,7 +320,18 @@ func TestDependenciesForKustomization(t *testing.T) {
 			kustomizations: map[string]string{"kustomization.yaml": `patchesJson6902:
 - path: patch1.json
 - path: path/patch2.json`},
+			createFiles: map[string]string{
+				"patch1.json":      "",
+				"path/patch2.json": "",
+			},
 			expected: []string{"kustomization.yaml", "patch1.json", "path/patch2.json"},
+		},
+		{
+			description: "ignore patches json 6902 path doesn't exist",
+			kustomizations: map[string]string{"kustomization.yaml": `patchesJson6902:
+- path: patch1.json`,
+			},
+			expected: []string{"kustomization.yaml"},
 		},
 		{
 			description: "ignore patch without path",

--- a/pkg/skaffold/render/renderer/kustomize/kustomize.go
+++ b/pkg/skaffold/render/renderer/kustomize/kustomize.go
@@ -479,12 +479,20 @@ func DependenciesForKustomization(dir string) ([]string, error) {
 
 	for _, patch := range content.Patches {
 		if patch.Path != "" {
+			local, _ := pathExistsLocally(patch.Path, dir)
+			if !local {
+				continue
+			}
 			deps = append(deps, filepath.Join(dir, patch.Path))
 		}
 	}
 
 	for _, jsonPatch := range content.PatchesJson6902 {
 		if jsonPatch.Path != "" {
+			local, _ := pathExistsLocally(jsonPatch.Path, dir)
+			if !local {
+				continue
+			}
 			deps = append(deps, filepath.Join(dir, jsonPatch.Path))
 		}
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #8976 <!-- tracking issues that this PR will close -->


**Description**
 - kustomize patch can be a url, skaffold should not watch a remote resource 
