### PR TITLE
fix: status check connecting to the wrong k8s context

### DIFF
--- a/pkg/skaffold/kubernetes/status/resource/deployment.go
+++ b/pkg/skaffold/kubernetes/status/resource/deployment.go
@@ -219,7 +219,7 @@ func (r *Resource) checkRolloutStatus(ctx context.Context, cfg kubectl.Config) *
 		return parseKubectlRolloutError(details, r.deadline, r.tolerateFailures, err)
 	}
 
-	client, cErr := kubernetesclient.Client(cfg.GetKubeConfig())
+	client, cErr := kubernetesclient.Client(cfg.GetKubeContext())
 	if cErr != nil {
 		log.Entry(ctx).Debugf("error attempting to create kubernetes client for k8s event listing: %s", err)
 	} else {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #8970 


**Description**
 - The original way to create k8s client for status check seems a typo, not intended.
 - We should use the kubeContext to initiate kubeClient instead of kubeConfig
 - Using kubeConfig causes status check against active context that user host is connected, we should instead do the check against kube context users set up for skaffold. 

