### PR TITLE
docs: add example to use cloudrun deployer + local build

### DIFF
--- a/docs-v2/content/en/samples/deployers/cloud-run/local-build-image.yaml
+++ b/docs-v2/content/en/samples/deployers/cloud-run/local-build-image.yaml
@@ -1,0 +1,22 @@
+apiVersion: skaffold/v4beta6
+kind: Config
+
+build:
+  local:
+    push: true # <- We need to push the images so Cloud Run can deploy them
+
+  platforms: ["linux/amd64"] # <- Specific platform supported by Cloud Run
+
+  artifacts:
+    - image: my-img # <- Should match the image name in the Cloud Run service.yaml
+      docker:
+        dockerfile: ./Dockerfile
+
+manifests:
+  rawYaml:
+    - resources/service.yaml
+
+deploy:
+  cloudrun:
+    projectid: YOUR-GCP-PROJECT
+    region: GCP-REGION


### PR DESCRIPTION
Fixes: #8289

**Description**
This PR is to show an example of how to configure a Skaffold project to use the Cloud Run deployer with a local built image. It shows how to configure the project and what important things to keep in mind for that.