### PR TITLE
chore: upgrade go 1.19.10 -> 1.21.0

### DIFF
--- a/deploy/skaffold/Dockerfile.deps
+++ b/deploy/skaffold/Dockerfile.deps
@@ -157,5 +157,5 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
     jq \
     apt-transport-https && \
     rm -rf /var/lib/apt/lists/*
-COPY --from=golang:1.19.10 /usr/local/go /usr/local/go
+COPY --from=golang:1.20.7 /usr/local/go /usr/local/go
 ENV PATH /usr/local/go/bin:/root/go/bin:$PATH

--- a/deploy/skaffold/Dockerfile.deps
+++ b/deploy/skaffold/Dockerfile.deps
@@ -157,5 +157,5 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
     jq \
     apt-transport-https && \
     rm -rf /var/lib/apt/lists/*
-COPY --from=golang:1.20.7 /usr/local/go /usr/local/go
+COPY --from=golang:1.21.0 /usr/local/go /usr/local/go
 ENV PATH /usr/local/go/bin:/root/go/bin:$PATH


### PR DESCRIPTION
- chore: upgrade go 1.19.10 -> 1.20.7 (#8992)
- chore: upgrade go to 1.21.0 (#8999)
