### PR TITLE
feat: configure render, verify, and exec commands to emit metrics

### DIFF
--- a/cmd/skaffold/app/cmd/exec.go
+++ b/cmd/skaffold/app/cmd/exec.go
@@ -39,6 +39,7 @@ func NewCmdExec() *cobra.Command {
 		WithExample("Execute a defined action that uses an image built from Skaffold. First, build the images", "build --file-output=build.json").
 		WithExample("Then use the built artifacts", "exec <action-name> --build-artifacts=build.json").
 		WithCommonFlags().
+		WithHouseKeepingMessages().
 		WithArgs(func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				log.Entry(context.TODO()).Errorf("`exec` requires exactly one action to execute")

--- a/cmd/skaffold/app/cmd/render.go
+++ b/cmd/skaffold/app/cmd/render.go
@@ -46,6 +46,7 @@ func NewCmdRender() *cobra.Command {
 			// This "--output" flag replaces the --render-output flag, which is deprecated.
 			{Value: &opts.RenderOutput, Name: "output", Shorthand: "o", DefValue: "", Usage: "File to write rendered manifests to"},
 		}).
+		WithHouseKeepingMessages().
 		NoArgs(doRender)
 }
 

--- a/pkg/skaffold/instrumentation/meter.go
+++ b/pkg/skaffold/instrumentation/meter.go
@@ -66,7 +66,7 @@ var (
 )
 
 func init() {
-	MeteredCommands.Insert("apply", "build", "delete", "deploy", "dev", "debug", "filter", "generate_pipeline", "render", "run", "test")
+	MeteredCommands.Insert("apply", "build", "delete", "deploy", "dev", "debug", "filter", "generate_pipeline", "render", "run", "test", "verify", "exec")
 	doesBuild.Insert("build", "render", "dev", "debug", "run")
 	doesDeploy.Insert("apply", "deploy", "dev", "debug", "run")
 }


### PR DESCRIPTION
**Description**
This PR configures the `render`, `verify`, and `exec` commands to start emitting metrics when are used. Right now the logic to make a command to emit metrics is related with the logic that decides if a command should show the Skaffold survey.