### PR TITLE
Ignore unset variables from minikube docker-env

### DIFF
--- a/pkg/skaffold/docker/client.go
+++ b/pkg/skaffold/docker/client.go
@@ -222,6 +222,9 @@ func getMinikubeDockerEnv(ctx context.Context, minikubeProfile string) (map[stri
 		if len(kv) != 2 {
 			return nil, fmt.Errorf("unable to parse minikube docker-env keyvalue: %s, line: %s, output: %s", kv, line, string(out))
 		}
+		if kv[1] == "" {
+			continue
+		}
 		env[kv[0]] = kv[1]
 	}
 


### PR DESCRIPTION
**Description**
In case shell is set to `none`, `minikube docker-env` returns `SSH_AUTH_SOCK=`.
 This conflicts with the `SSH_AUTH_SOCK` variable set by the shell [here](https://github.com/GoogleContainerTools/skaffold/blob/58f3d4a663ddfdd284af809e49379b1d17b612e4/pkg/skaffold/build/docker/docker.go#L124).
 Effectively, this allows users to use `ssh: default` again when building docker containers for minikube with skaffold.