### PR TITLE
feat: enable skaffold render to track telemetry

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -87,7 +87,8 @@ func NewSkaffoldCommand(out, errOut io.Writer) *cobra.Command {
 			if cmd.Name() != cobra.ShellCompRequestCmd && cmd.Name() != cobra.ShellCompNoDescRequestCmd {
 				instrumentation.SetCommand(cmd.Name())
 				out := output.GetWriter(context.Background(), out, defaultColor, forceColors, timestamps)
-				cmd.Root().SetOutput(out)
+				cmd.Root().SetOut(out)
+				cmd.Root().SetErr(errOut)
 
 				// Setup logs
 				if err := setUpLogs(errOut, v, timestamps); err != nil {
@@ -131,21 +132,21 @@ func NewSkaffoldCommand(out, errOut io.Writer) *cobra.Command {
 				if err := config.UpdateMsgDisplayed(opts.GlobalConfig); err != nil {
 					log.Entry(context.TODO()).Debugf("could not update the 'last-prompted' config for 'update-config' section due to %s", err)
 				}
-				fmt.Fprintf(cmd.OutOrStderr(), "%s\n", msg)
+				fmt.Fprintf(cmd.ErrOrStderr(), "%s\n", msg)
 			default:
 			}
 			// check if survey prompt needs to be displayed
 			select {
 			case promptSurveyID := <-surveyPrompt:
 				if promptSurveyID != "" {
-					if err := s.DisplaySurveyPrompt(cmd.OutOrStdout(), promptSurveyID); err != nil {
+					if err := s.DisplaySurveyPrompt(cmd.ErrOrStderr(), promptSurveyID); err != nil {
 						fmt.Fprintf(cmd.OutOrStderr(), "%v\n", err)
 					}
 				}
 			default:
 			}
 			if metricsPrompt {
-				if err := prompt.DisplayMetricsPrompt(opts.GlobalConfig, cmd.OutOrStdout()); err != nil {
+				if err := prompt.DisplayMetricsPrompt(opts.GlobalConfig, cmd.ErrOrStderr()); err != nil {
 					fmt.Fprintf(cmd.OutOrStderr(), "%v\n", err)
 				}
 			}

--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -139,14 +139,14 @@ func NewSkaffoldCommand(out, errOut io.Writer) *cobra.Command {
 			select {
 			case promptSurveyID := <-surveyPrompt:
 				if promptSurveyID != "" {
-					if err := s.DisplaySurveyPrompt(cmd.ErrOrStderr(), promptSurveyID); err != nil {
+					if err := s.DisplaySurveyPrompt(output.NewColorWriter(cmd.ErrOrStderr()), promptSurveyID); err != nil {
 						fmt.Fprintf(cmd.OutOrStderr(), "%v\n", err)
 					}
 				}
 			default:
 			}
 			if metricsPrompt {
-				if err := prompt.DisplayMetricsPrompt(opts.GlobalConfig, cmd.ErrOrStderr()); err != nil {
+				if err := prompt.DisplayMetricsPrompt(opts.GlobalConfig, output.NewColorWriter(cmd.ErrOrStderr())); err != nil {
 					fmt.Fprintf(cmd.OutOrStderr(), "%v\n", err)
 				}
 			}

--- a/cmd/skaffold/app/cmd/render.go
+++ b/cmd/skaffold/app/cmd/render.go
@@ -46,6 +46,7 @@ func NewCmdRender() *cobra.Command {
 			// This "--output" flag replaces the --render-output flag, which is deprecated.
 			{Value: &opts.RenderOutput, Name: "output", Shorthand: "o", DefValue: "", Usage: "File to write rendered manifests to"},
 		}).
+		WithHouseKeepingMessages().
 		NoArgs(doRender)
 }
 

--- a/integration/housekeeping_messages_test.go
+++ b/integration/housekeeping_messages_test.go
@@ -33,7 +33,8 @@ func TestHouseKeepingMessagesNotShownForDiagnose(t *testing.T) {
 func TestHouseKeepingMessagesShownForDev(t *testing.T) {
 	MarkIntegrationTest(t, CanRunWithoutGcp)
 	file := testutil.TempFile(t, "config", nil)
-	out := skaffold.Run("-c", file, "--update-check=true").InDir("examples/getting-started").RunOrFailOutput(t)
+	out, err := skaffold.Run("-c", file, "--update-check=true").InDir("examples/getting-started").RunWithCombinedOutput(t)
+	testutil.CheckError(t, false, err)
 	testutil.CheckContains(t, "Help improve Skaffold", string(out))
 	skaffold.Delete().InDir("examples/getting-started").Run(t)
 }

--- a/pkg/skaffold/instrumentation/prompt/prompt.go
+++ b/pkg/skaffold/instrumentation/prompt/prompt.go
@@ -32,7 +32,6 @@ You may choose to opt out of this collection by running the following command:
 
 var (
 	// for testing
-	isStdOut     = output.IsStdout
 	updateConfig = config.UpdateGlobalCollectMetrics
 	getConfig    = config.GetConfigForCurrentKubectx
 	setStatus    = instrumentation.SetOnlineStatus

--- a/pkg/skaffold/instrumentation/prompt/prompt.go
+++ b/pkg/skaffold/instrumentation/prompt/prompt.go
@@ -53,9 +53,6 @@ func ShouldDisplayMetricsPrompt(configfile string) bool {
 }
 
 func DisplayMetricsPrompt(configFile string, out io.Writer) error {
-	if isStdOut(out) {
-		output.Green.Fprintf(out, Prompt)
-		return updateConfig(configFile, true)
-	}
-	return nil
+	output.Green.Fprintf(out, Prompt)
+	return updateConfig(configFile, true)
 }

--- a/pkg/skaffold/instrumentation/prompt/prompt_test.go
+++ b/pkg/skaffold/instrumentation/prompt/prompt_test.go
@@ -19,7 +19,6 @@ package prompt
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/config"
@@ -74,20 +73,16 @@ func TestShouldDisplayMetricsPrompt(t *testing.T) {
 
 func TestDisplayMetricsPrompt(t *testing.T) {
 	tests := []struct {
-		name       string
-		mockStdOut bool
-		expected   string
+		name     string
+		expected string
 	}{
 		{
-			name:       "std out",
-			mockStdOut: true,
-			expected:   Prompt,
+			name:     "std out",
+			expected: Prompt,
 		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.name, func(t *testutil.T) {
-			mock := func(io.Writer) bool { return test.mockStdOut }
-			t.Override(&isStdOut, mock)
 			t.Override(&updateConfig, func(_ string, _ bool) error { return nil })
 			var buf bytes.Buffer
 			err := DisplayMetricsPrompt("", &buf)

--- a/pkg/skaffold/instrumentation/prompt/prompt_test.go
+++ b/pkg/skaffold/instrumentation/prompt/prompt_test.go
@@ -83,9 +83,6 @@ func TestDisplayMetricsPrompt(t *testing.T) {
 			mockStdOut: true,
 			expected:   Prompt,
 		},
-		{
-			name: "not std out",
-		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.name, func(t *testutil.T) {

--- a/pkg/skaffold/output/output.go
+++ b/pkg/skaffold/output/output.go
@@ -19,7 +19,6 @@ package output
 import (
 	"context"
 	"io"
-	"os"
 	"time"
 
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/constants"
@@ -74,18 +73,6 @@ func GetWriter(ctx context.Context, out io.Writer, defaultColor int, forceColors
 		EventWriter: eventV2.NewLogger(constants.DevLoop, "-1"),
 		timestamps:  timestamps,
 	}
-}
-
-func IsStdout(out io.Writer) bool {
-	sw, isSW := out.(skaffoldWriter)
-	if isSW {
-		out = sw.MainWriter
-	}
-	cw, isCW := out.(colorableWriter)
-	if isCW {
-		out = cw.Writer
-	}
-	return out == os.Stdout
 }
 
 // GetUnderlyingWriter returns the underlying writer if out is a colorableWriter

--- a/pkg/skaffold/output/output_test.go
+++ b/pkg/skaffold/output/output_test.go
@@ -30,52 +30,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/v2/testutil"
 )
 
-func TestIsStdOut(t *testing.T) {
-	tests := []struct {
-		description string
-		out         io.Writer
-		expected    bool
-	}{
-		{
-			description: "std out passed",
-			out:         os.Stdout,
-			expected:    true,
-		},
-		{
-			description: "out nil",
-			out:         nil,
-		},
-		{
-			description: "out bytes buffer",
-			out:         new(bytes.Buffer),
-		},
-		{
-			description: "colorable std out passed",
-			out: skaffoldWriter{
-				MainWriter: NewColorWriter(os.Stdout),
-			},
-			expected: true,
-		},
-		{
-			description: "colorableWriter passed",
-			out:         NewColorWriter(os.Stdout),
-			expected:    true,
-		},
-		{
-			description: "invalid colorableWriter passed",
-			out: skaffoldWriter{
-				MainWriter: NewColorWriter(io.Discard),
-			},
-			expected: false,
-		},
-	}
-	for _, test := range tests {
-		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.CheckDeepEqual(test.expected, IsStdout(test.out))
-		})
-	}
-}
-
 func TestGetUnderlyingWriter(t *testing.T) {
 	tests := []struct {
 		description string

--- a/pkg/skaffold/survey/survey.go
+++ b/pkg/skaffold/survey/survey.go
@@ -44,7 +44,6 @@ Tip: To permanently disable the survey prompt, run:
 
 var (
 	// for testing
-	isStdOut             = output.IsStdout
 	open                 = browser.OpenURL
 	updateSurveyPrompted = sConfig.UpdateGlobalSurveyPrompted
 	parseConfig          = schema.ParseConfigAndUpgrade

--- a/pkg/skaffold/survey/survey.go
+++ b/pkg/skaffold/survey/survey.go
@@ -109,9 +109,6 @@ func recentlyPrompted(gc *sConfig.SurveyConfig) bool {
 }
 
 func (s *Runner) DisplaySurveyPrompt(out io.Writer, id string) error {
-	if !isStdOut(out) {
-		return nil
-	}
 	if sc, ok := getSurvey(id); ok {
 		output.Green.Fprintf(out, sc.prompt())
 		return updateSurveyPrompted(s.configFile)

--- a/pkg/skaffold/survey/survey_test.go
+++ b/pkg/skaffold/survey/survey_test.go
@@ -19,7 +19,6 @@ package survey
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"testing"
 	"time"
 
@@ -34,11 +33,9 @@ func TestDisplaySurveyForm(t *testing.T) {
 		description        string
 		mockSurveyPrompted func(_ string) error
 		expected           string
-		mockStdOut         bool
 	}{
 		{
 			description:        "std out",
-			mockStdOut:         true,
 			mockSurveyPrompted: func(_ string) error { return nil },
 			expected: `Help improve Skaffold with our 2-minute anonymous survey: run 'skaffold survey'
 `,
@@ -46,8 +43,6 @@ func TestDisplaySurveyForm(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			mock := func(io.Writer) bool { return test.mockStdOut }
-			t.Override(&isStdOut, mock)
 			mockOpen := func(string) error { return nil }
 			t.Override(&open, mockOpen)
 			t.Override(&updateSurveyPrompted, test.mockSurveyPrompted)

--- a/pkg/skaffold/survey/survey_test.go
+++ b/pkg/skaffold/survey/survey_test.go
@@ -43,12 +43,6 @@ func TestDisplaySurveyForm(t *testing.T) {
 			expected: `Help improve Skaffold with our 2-minute anonymous survey: run 'skaffold survey'
 `,
 		},
-		{
-			description: "not std out",
-			mockSurveyPrompted: func(_ string) error {
-				return fmt.Errorf("not expected to call")
-			},
-		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {


### PR DESCRIPTION
**Related**: https://github.com/GoogleContainerTools/skaffold/pull/9013

**Description**
This PR configures the `skaffold render` command to start tracking telemetry data when it is used. Currently the logic for emitting metrics is related to the logic for displaying the Skaffold survey URL, the opt-out message, and the version upgrade. These messages were corrupting the output when used, e.g, like `skaffold render > manifest.yaml`, due to everything was printed using stdout. Now we are changing from stdout to stderr to print those messages.
