### PR TITLE
feat: Add global build pre- and post-hooks 

### DIFF
--- a/docs-v2/content/en/schemas/v4beta7.json
+++ b/docs-v2/content/en/schemas/v4beta7.json
@@ -725,6 +725,11 @@
               "description": "the images you're going to be building.",
               "x-intellij-html-description": "the images you're going to be building."
             },
+            "hooks": {
+              "$ref": "#/definitions/BuildHooks",
+              "description": "describes a set of lifecycle hooks that are executed before and after the build phase of the Pipeline, where the artifacts are built.",
+              "x-intellij-html-description": "describes a set of lifecycle hooks that are executed before and after the build phase of the Pipeline, where the artifacts are built."
+            },
             "insecureRegistries": {
               "items": {
                 "type": "string"
@@ -750,6 +755,7 @@
             }
           },
           "preferredOrder": [
+            "hooks",
             "artifacts",
             "insecureRegistries",
             "tagPolicy",
@@ -766,6 +772,11 @@
               "type": "array",
               "description": "the images you're going to be building.",
               "x-intellij-html-description": "the images you're going to be building."
+            },
+            "hooks": {
+              "$ref": "#/definitions/BuildHooks",
+              "description": "describes a set of lifecycle hooks that are executed before and after the build phase of the Pipeline, where the artifacts are built.",
+              "x-intellij-html-description": "describes a set of lifecycle hooks that are executed before and after the build phase of the Pipeline, where the artifacts are built."
             },
             "insecureRegistries": {
               "items": {
@@ -797,6 +808,7 @@
             }
           },
           "preferredOrder": [
+            "hooks",
             "artifacts",
             "insecureRegistries",
             "tagPolicy",
@@ -820,6 +832,11 @@
               "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/).",
               "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/\">Google Cloud Build</a>."
             },
+            "hooks": {
+              "$ref": "#/definitions/BuildHooks",
+              "description": "describes a set of lifecycle hooks that are executed before and after the build phase of the Pipeline, where the artifacts are built.",
+              "x-intellij-html-description": "describes a set of lifecycle hooks that are executed before and after the build phase of the Pipeline, where the artifacts are built."
+            },
             "insecureRegistries": {
               "items": {
                 "type": "string"
@@ -845,6 +862,7 @@
             }
           },
           "preferredOrder": [
+            "hooks",
             "artifacts",
             "insecureRegistries",
             "tagPolicy",
@@ -868,6 +886,11 @@
               "description": "*beta* describes how to do an on-cluster build.",
               "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
             },
+            "hooks": {
+              "$ref": "#/definitions/BuildHooks",
+              "description": "describes a set of lifecycle hooks that are executed before and after the build phase of the Pipeline, where the artifacts are built.",
+              "x-intellij-html-description": "describes a set of lifecycle hooks that are executed before and after the build phase of the Pipeline, where the artifacts are built."
+            },
             "insecureRegistries": {
               "items": {
                 "type": "string"
@@ -893,6 +916,7 @@
             }
           },
           "preferredOrder": [
+            "hooks",
             "artifacts",
             "insecureRegistries",
             "tagPolicy",

--- a/integration/examples/lifecycle-hooks/skaffold.yaml
+++ b/integration/examples/lifecycle-hooks/skaffold.yaml
@@ -11,6 +11,11 @@ manifests:
       - host:
           command: ["sh", "-c", "echo post-render host hook running on $(hostname)!"]
 build:
+  hooks:
+    before:
+      - command: ["sh", "-c", "echo pre-build hook running"]
+    after:
+      - command: ["sh", "-c", "echo post-build hook running"]
   artifacts:
   - image: hooks-example
     hooks:
@@ -26,7 +31,7 @@ build:
           os: [darwin, linux]
         - command: ["cmd.exe", "/C", "docker images %SKAFFOLD_IMAGE% --digests"]
           os: [windows]
-    sync: 
+    sync:
       manual:
         - src: 'hello.txt'
           dest: .
@@ -49,7 +54,7 @@ deploy:
             command: ["sh", "-c", "echo pre-deploy host hook running on $(hostname)!"]
             os: [darwin, linux]
         - container:
-            # this will only run when there's a matching container from a previous deploy iteration like in `skaffold dev` 
+            # this will only run when there's a matching container from a previous deploy iteration like in `skaffold dev`
             command: ["sh", "-c", "echo pre-deploy container hook running on $(hostname)!"]
             containerName: hooks-example*
             podName: hooks-example-deployment*

--- a/pkg/skaffold/runner/builder.go
+++ b/pkg/skaffold/runner/builder.go
@@ -19,12 +19,14 @@ package runner
 import (
 	"context"
 	"fmt"
+	"io"
 
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/build/cluster"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/build/gcb"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/build/local"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/graph"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/hooks"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/output/log"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/latest"
@@ -72,5 +74,45 @@ func GetBuilder(ctx context.Context, r *runcontext.RunContext, s build.ArtifactS
 
 	default:
 		return nil, fmt.Errorf("unknown builder for config %+v", p.Build)
+	}
+}
+
+type pipelineBuilderWithHooks struct {
+	build.PipelineBuilder
+	hooksRunner hooks.Runner
+}
+
+// PreBuild executes any one-time setup required prior to starting any build on this builder,
+// followed by any Build pre-hooks set for the pipeline.
+func (b pipelineBuilderWithHooks) PreBuild(ctx context.Context, out io.Writer) error {
+	if err := b.PipelineBuilder.PreBuild(ctx, out); err != nil {
+		return err
+	}
+
+	if err := b.hooksRunner.RunPreHooks(ctx, out); err != nil {
+		return fmt.Errorf("running builder pre-hooks: %w", err)
+	}
+
+	return nil
+}
+
+// PostBuild executes any one-time teardown required after all builds on this builder are complete,
+// followed by any Build post-hooks set for the pipeline.
+func (b pipelineBuilderWithHooks) PostBuild(ctx context.Context, out io.Writer) error {
+	if err := b.PipelineBuilder.PostBuild(ctx, out); err != nil {
+		return err
+	}
+
+	if err := b.hooksRunner.RunPostHooks(ctx, out); err != nil {
+		return fmt.Errorf("running builder post-hooks: %w", err)
+	}
+
+	return nil
+}
+
+func withPipelineBuildHooks(pb build.PipelineBuilder, buildHooks latest.BuildHooks) build.PipelineBuilder {
+	return pipelineBuilderWithHooks{
+		PipelineBuilder: pb,
+		hooksRunner:     hooks.BuildRunner(buildHooks, hooks.BuildEnvOpts{}),
 	}
 }

--- a/pkg/skaffold/runner/builder.go
+++ b/pkg/skaffold/runner/builder.go
@@ -84,7 +84,7 @@ type pipelineBuilderWithHooks struct {
 
 // PreBuild executes any one-time setup required prior to starting any build on this builder,
 // followed by any Build pre-hooks set for the pipeline.
-func (b pipelineBuilderWithHooks) PreBuild(ctx context.Context, out io.Writer) error {
+func (b *pipelineBuilderWithHooks) PreBuild(ctx context.Context, out io.Writer) error {
 	if err := b.PipelineBuilder.PreBuild(ctx, out); err != nil {
 		return err
 	}
@@ -98,7 +98,7 @@ func (b pipelineBuilderWithHooks) PreBuild(ctx context.Context, out io.Writer) e
 
 // PostBuild executes any one-time teardown required after all builds on this builder are complete,
 // followed by any Build post-hooks set for the pipeline.
-func (b pipelineBuilderWithHooks) PostBuild(ctx context.Context, out io.Writer) error {
+func (b *pipelineBuilderWithHooks) PostBuild(ctx context.Context, out io.Writer) error {
 	if err := b.PipelineBuilder.PostBuild(ctx, out); err != nil {
 		return err
 	}
@@ -111,7 +111,7 @@ func (b pipelineBuilderWithHooks) PostBuild(ctx context.Context, out io.Writer) 
 }
 
 func withPipelineBuildHooks(pb build.PipelineBuilder, buildHooks latest.BuildHooks) build.PipelineBuilder {
-	return pipelineBuilderWithHooks{
+	return &pipelineBuilderWithHooks{
 		PipelineBuilder: pb,
 		hooksRunner:     hooks.BuildRunner(buildHooks, hooks.BuildEnvOpts{}),
 	}

--- a/pkg/skaffold/runner/builder_test.go
+++ b/pkg/skaffold/runner/builder_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package runner
 
 import (

--- a/pkg/skaffold/runner/builder_test.go
+++ b/pkg/skaffold/runner/builder_test.go
@@ -1,0 +1,177 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/build"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/platform"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/v2/testutil"
+)
+
+func TestPipelineBuilderWithHooks(t *testing.T) {
+	type testcase struct {
+		name             string
+		hooks            latest.BuildHooks
+		expected         []byte
+		wantPreHooksErr  bool
+		wantPostHooksErr bool
+	}
+
+	testcases := []testcase{
+		{
+			name:             "no hooks to execute",
+			hooks:            latest.BuildHooks{},
+			expected:         nil,
+			wantPreHooksErr:  false,
+			wantPostHooksErr: false,
+		},
+		{
+			name: "execute pre-hooks in order",
+			hooks: latest.BuildHooks{
+				PreHooks: []latest.HostHook{
+					{
+						Command: []string{
+							"sh", "-c", "echo hello world 1",
+						},
+					},
+					{
+						Command: []string{
+							"sh", "-c", "echo hello world 2",
+						},
+					},
+				},
+				PostHooks: nil,
+			},
+			expected: []byte(
+				"Starting pre-build hooks...\n" +
+					"hello world 1\n" +
+					"hello world 2\n" +
+					"Completed pre-build hooks\n",
+			),
+		},
+		{
+			name: "execute post-hooks in order",
+			hooks: latest.BuildHooks{
+				PreHooks: nil,
+				PostHooks: []latest.HostHook{
+					{
+						Command: []string{
+							"sh", "-c", "echo hello world 1",
+						},
+					},
+					{
+						Command: []string{
+							"sh", "-c", "echo hello world 2",
+						},
+					},
+				},
+			},
+			expected: []byte(
+				"Starting post-build hooks...\n" +
+					"hello world 1\n" +
+					"hello world 2\n" +
+					"Completed post-build hooks\n",
+			),
+		},
+		{
+			name: "execute pre-hooks before post-hooks in order",
+			hooks: latest.BuildHooks{
+				PreHooks: []latest.HostHook{
+					{
+						Command: []string{
+							"sh", "-c", "echo hello world 1",
+						},
+					},
+				},
+				PostHooks: []latest.HostHook{
+					{
+						Command: []string{
+							"sh", "-c", "echo hello world 2",
+						},
+					},
+				},
+			},
+			expected: []byte(
+				"Starting pre-build hooks...\n" +
+					"hello world 1\n" +
+					"Completed pre-build hooks\n" +
+					"Starting post-build hooks...\n" +
+					"hello world 2\n" +
+					"Completed post-build hooks\n",
+			),
+		},
+		{
+			name: "executing pre-hooks returns an error if one of the commands fail",
+			hooks: latest.BuildHooks{
+				PreHooks: []latest.HostHook{
+					{
+						Command: []string{
+							"sh", "-c", "exit 1",
+						},
+					},
+				},
+				PostHooks: nil,
+			},
+			wantPreHooksErr: true,
+		},
+		{
+			name: "executing post-hooks returns an error if one of the commands fail",
+			hooks: latest.BuildHooks{
+				PreHooks: nil,
+				PostHooks: []latest.HostHook{
+					{
+						Command: []string{
+							"sh", "-c", "exit 1",
+						},
+					},
+				},
+			},
+			wantPostHooksErr: true,
+		},
+	}
+
+	pipelineBuilder := &mockPipelineBuilder{}
+
+	for _, tc := range testcases {
+		tc := tc
+
+		testutil.Run(t, tc.name, func(t *testutil.T) {
+			ctx := context.Background()
+			buf := new(bytes.Buffer)
+
+			pb := withPipelineBuildHooks(pipelineBuilder, tc.hooks)
+
+			err := pb.PreBuild(ctx, buf)
+			t.CheckError(tc.wantPreHooksErr, err)
+
+			err = pb.PostBuild(ctx, buf)
+			t.CheckError(tc.wantPostHooksErr, err)
+
+			if !tc.wantPreHooksErr && !tc.wantPostHooksErr {
+				t.CheckDeepEqual(tc.expected, buf.Bytes())
+			}
+		})
+	}
+}
+
+type mockPipelineBuilder struct{}
+
+func (m *mockPipelineBuilder) PreBuild(ctx context.Context, out io.Writer) error { return nil }
+
+func (m *mockPipelineBuilder) Build(ctx context.Context, out io.Writer, artifact *latest.Artifact) build.ArtifactBuilder {
+	return nil
+}
+
+func (m *mockPipelineBuilder) PostBuild(ctx context.Context, out io.Writer) error { return nil }
+
+func (m *mockPipelineBuilder) Concurrency() *int { return nil }
+
+func (m *mockPipelineBuilder) Prune(context.Context, io.Writer) error { return nil }
+
+func (m *mockPipelineBuilder) PushImages() bool { return false }
+
+func (m *mockPipelineBuilder) SupportedPlatforms() platform.Matcher { return platform.All }

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -189,6 +189,11 @@ type ResourceSelectorConfig struct {
 
 // BuildConfig contains all the configuration for the build steps.
 type BuildConfig struct {
+	// Hooks describes a set of lifecycle hooks that are executed
+	// before and after the build phase of the Pipeline, where the
+	// artifacts are built.
+	Hooks BuildHooks `yaml:"hooks,omitempty"`
+
 	// Artifacts lists the images you're going to be building.
 	Artifacts []*Artifact `yaml:"artifacts,omitempty"`
 
@@ -690,7 +695,6 @@ type VerifyEnvVar struct {
 
 // RenderConfig contains all the configuration needed by the render steps.
 type RenderConfig struct {
-
 	// Generate defines the dry manifests from a variety of sources.
 	Generate `yaml:",inline"`
 
@@ -1357,7 +1361,6 @@ type DockerfileDependency struct {
 // KanikoArtifact describes an artifact built from a Dockerfile,
 // with kaniko.
 type KanikoArtifact struct {
-
 	// Cleanup to clean the filesystem at the end of the build.
 	Cleanup bool `yaml:"cleanup,omitempty"`
 
@@ -1741,7 +1744,6 @@ func (clusterDetails *ClusterDetails) UnmarshalYAML(value *yaml.Node) error {
 	type ClusterDetailsForUnmarshaling ClusterDetails
 
 	volumes, remaining, err := util.UnmarshalClusterVolumes(value)
-
 	if err != nil {
 		return err
 	}
@@ -1769,7 +1771,6 @@ func (ka *KanikoArtifact) UnmarshalYAML(value *yaml.Node) error {
 	type KanikoArtifactForUnmarshaling KanikoArtifact
 
 	mounts, remaining, err := util.UnmarshalKanikoArtifact(value)
-
 	if err != nil {
 		return err
 	}
@@ -1803,7 +1804,6 @@ func (clusterDetails *ClusterDetails) MarshalYAML() (interface{}, error) {
 	volumes := clusterDetails.Volumes
 
 	j, err := json.Marshal(volumes)
-
 	if err != nil {
 		return err, nil
 	}
@@ -1819,7 +1819,6 @@ func (clusterDetails *ClusterDetails) MarshalYAML() (interface{}, error) {
 	aux := &ClusterDetailsForUnmarshaling{}
 
 	b, err := json.Marshal(clusterDetails)
-
 	if err != nil {
 		return nil, err
 	}
@@ -1831,7 +1830,6 @@ func (clusterDetails *ClusterDetails) MarshalYAML() (interface{}, error) {
 	aux.Volumes = nil
 
 	marshaled, err := yaml.Marshal(aux)
-
 	if err != nil {
 		return nil, err
 	}
@@ -1863,7 +1861,6 @@ func (ka *KanikoArtifact) MarshalYAML() (interface{}, error) {
 	volumeMounts := ka.VolumeMounts
 
 	j, err := json.Marshal(volumeMounts)
-
 	if err != nil {
 		return err, nil
 	}
@@ -1879,7 +1876,6 @@ func (ka *KanikoArtifact) MarshalYAML() (interface{}, error) {
 	aux := &KanikoArtifactForUnmarshaling{}
 
 	b, err := json.Marshal(ka)
-
 	if err != nil {
 		return nil, err
 	}
@@ -1890,7 +1886,6 @@ func (ka *KanikoArtifact) MarshalYAML() (interface{}, error) {
 	aux.VolumeMounts = nil
 
 	marshaled, err := yaml.Marshal(aux)
-
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**Description**
This PR adds the possibility of running pre- and post-hooks for the Build phase of a Pipeline.

The implementation is done by leveraging the pre-existing `build.PipelineBuilder` interface, using a wrapper that extends `PreBuild` and `PostBuild` methods, to avoid significant changes to the pre-existing code.

**User facing changes**

This PR adds the new functionality by introducing a new `build.hooks` field in the configuration.

Due to the new configuration field, I've created a new version, `v4beta7`, as specified in the [contribution guidelines](https://github.com/GoogleContainerTools/skaffold/blob/main/DEVELOPMENT.md#making-a-config-change).

This is a `skaffold build` run from a slightly modified version of `examples/getting-started/skaffold.yaml`:
```yaml
# skaffold.yaml
apiVersion: skaffold/v4beta7
kind: Config
build:
  hooks:
    before:
      - command: [echo, "hello from pre-hook!"]
    after:
      - command: [echo, "hello from post-hook!"]
  artifacts:
    - image: skaffold-example
  local:
    push: false
manifests:
  rawYaml:
  - k8s-pod.yaml

```
Here is the output, which shows how the new `build.hooks` is behaving:
```shell
> ./out/skaffold build
Generating tags...
 - skaffold-example -> skaffold-example:740d30e8f-dirty
Checking cache...
 - skaffold-example: Not found. Building
Starting build...
Starting pre-build hooks...
hello from pre-hook!
Completed pre-build hooks
Building [skaffold-example]...
Sending build context to Docker daemon  4.096kB
time="2023-08-27T18:06:54+02:00" level=warning msg="missing \"SKAFFOLD_GO_GCFLAGS\" build argument. Try adding \"--build-arg SKAFFOLD_GO_GCFLAGS=<VALUE>\" to the command line"
[1/2] STEP 1/6: FROM golang:1.18 AS builder
[1/2] STEP 2/6: WORKDIR /code
--> Using cache bffc72dc309d959a859d59a0aae3975abb0369b1420fc66551dbee53abe9670c
--> bffc72dc309d
[1/2] STEP 3/6: COPY main.go .
--> Using cache e9ae2def9ed085da743cddbb2dcc092a7302dc8dff53955dbd9508f166290bbe
--> e9ae2def9ed0
[1/2] STEP 4/6: COPY go.mod .
--> Using cache a22d7afc1bd669d99500bbbadd550343c390f8460a7b0767ff2c48b47de4961d
--> a22d7afc1bd6
[1/2] STEP 5/6: ARG SKAFFOLD_GO_GCFLAGS
--> Using cache 3c1e21609fff4dc761893cac7e2087705c05dc57ed84acbe4a00d13d56164f72
--> 3c1e21609fff
[1/2] STEP 6/6: RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app main.go
--> Using cache c082cefdd6ef749c854636c91f03c3098f98c13db26e81471d8461ad73a86cea
--> c082cefdd6ef
[2/2] STEP 1/4: FROM alpine:3
[2/2] STEP 2/4: ENV GOTRACEBACK=single
--> Using cache 3df39876b4561aff7cf01adab4e0535b52b7b686bea9954c77c1d4923d9f5388
--> 3df39876b456
[2/2] STEP 3/4: CMD ["./app"]
--> Using cache 4fd318e64452faa0c2461f254ee15b2bd35b9ded3439f21db8bdd9296f73c189
--> 4fd318e64452
[2/2] STEP 4/4: COPY --from=builder /app .
--> Using cache 80a5e519d652de8a28d5466706eaf6cc77be7a64ffdb358189245370f8605ca1
[2/2] COMMIT docker.io/library/skaffold-example:740d30e8f-dirty
--> 80a5e519d652
Successfully tagged docker.io/library/skaffold-example:740d30e8f-dirty
80a5e519d652de8a28d5466706eaf6cc77be7a64ffdb358189245370f8605ca1
Successfully built 80a5e519d652
Successfully tagged skaffold-example:740d30e8f-dirty
Build [skaffold-example] succeeded
Starting post-build hooks...
hello from post-hook!
Completed post-build hooks
```

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
