### PR TITLE
fix: flaky verify tests

### DIFF
--- a/integration/exec_k8s_actions_test.go
+++ b/integration/exec_k8s_actions_test.go
@@ -73,7 +73,7 @@ func TestExec_K8SActions(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			MarkIntegrationTest(t.T, NeedsGcp)
+			MarkIntegrationTest(t.T, CanRunWithoutGcp)
 			args := []string{test.action}
 
 			if test.envFile != "" {

--- a/integration/testdata/verify-succeed-k8s/skaffold.yaml
+++ b/integration/testdata/verify-succeed-k8s/skaffold.yaml
@@ -19,9 +19,9 @@ verify:
       image: docker.io/hello-world:latest
     executionMode:
       kubernetesCluster: {}
-  - name: alpine-1
+  - name: verify-succeed-k8s-1
     container:
-      name: alpine-1
+      name: verify-succeed-k8s-1
       image: alpine:3.15.4
       command: ["/bin/sh"]
       args: ["-c", "echo $FOO; sleep 10; echo bye"]
@@ -39,11 +39,11 @@ verify:
 profiles:
   - name: no-duplicated-logs
     verify:
-      - name: alpine-1
+      - name: no-duplicated-logs-1
         executionMode:
           kubernetesCluster: {}
         container:
-          name: alpine-1
+          name: no-duplicated-logs-1
           image: alpine:3.15.4
           command: ["/bin/sh"]
           args: ["-c", "echo alpine-1; sleep 1; echo bye alpine-1"]
@@ -91,11 +91,11 @@ profiles:
 
   - name: local-built-artifact
     verify:
-      - name: alpine-123
+      - name: local-built-artifact-1
         executionMode:
           kubernetesCluster: {}
         container:
-          name: alpine-123
+          name: local-built-artifact-1
           image: alpine:3.15.4
           command: ["/bin/sh"]
           args: ["-c", "echo alpine-1; sleep 2; echo bye alpine-1"]

--- a/integration/testdata/verify-succeed-k8s/skaffold.yaml
+++ b/integration/testdata/verify-succeed-k8s/skaffold.yaml
@@ -91,11 +91,11 @@ profiles:
 
   - name: local-built-artifact
     verify:
-      - name: alpine-1
+      - name: alpine-123
         executionMode:
           kubernetesCluster: {}
         container:
-          name: alpine-1
+          name: alpine-123
           image: alpine:3.15.4
           command: ["/bin/sh"]
           args: ["-c", "echo alpine-1; sleep 2; echo bye alpine-1"]

--- a/integration/verify_test.go
+++ b/integration/verify_test.go
@@ -237,7 +237,7 @@ func TestNoDuplicateLogsK8SJobs(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			MarkIntegrationTest(t.T, NeedsGcp)
+			MarkIntegrationTest(t.T, CanRunWithoutGcp)
 
 			args := []string{"-p", test.profile}
 			out, err := skaffold.Verify(args...).InDir(test.dir).RunWithCombinedOutput(t.T)


### PR DESCRIPTION

**Description**
 - We've been seeing some verify and custom actions related flaky tests on Kokoro tests
 - The root cause is that some integration tests contaminate each other, and this is more likely to happen on gcp tests, as we're running tests against shared remote clusters concurrently-- 4 worker nodes running tests against one shared remote cluster. 
 - Github CI should provide better isolation , each worker runs tests against its dedicated minikube -- not 100% sure , but we should also isolate these tests by providing unique names as job names so when skaffold run query to watch resources  it can watch the correct resource. 

