### PR TITLE
fix: verify flaky tests

### DIFF
--- a/integration/exec_k8s_actions_test.go
+++ b/integration/exec_k8s_actions_test.go
@@ -73,7 +73,7 @@ func TestExec_K8SActions(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			MarkIntegrationTest(t.T, NeedsGcp)
+			MarkIntegrationTest(t.T, CanRunWithoutGcp)
 			args := []string{test.action}
 
 			if test.envFile != "" {

--- a/integration/exec_k8s_actions_test.go
+++ b/integration/exec_k8s_actions_test.go
@@ -79,8 +79,9 @@ func TestExec_K8SActions(t *testing.T) {
 			if test.envFile != "" {
 				args = append(args, "--env-file", test.envFile)
 			}
+			ns, _ := SetupNamespace(t.T)
 
-			out, err := skaffold.Exec(args...).InDir("testdata/custom-actions-k8s").RunWithCombinedOutput(t.T)
+			out, err := skaffold.Exec(args...).InNs(ns.Name).InDir("testdata/custom-actions-k8s").RunWithCombinedOutput(t.T)
 			t.CheckError(test.shouldErr, err)
 			logs := string(out)
 
@@ -123,17 +124,17 @@ func TestExec_K8SActionWithLocalArtifact(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			MarkIntegrationTest(t.T, NeedsGcp)
+			MarkIntegrationTest(t.T, CanRunWithoutGcp)
 			dir := "testdata/custom-actions-k8s"
 			args := []string{test.action}
-
+			ns, _ := SetupNamespace(t.T)
 			if test.shouldBuild {
 				tmpfile := testutil.TempFile(t.T, "", []byte{})
-				skaffold.Build("--file-output", tmpfile, "--tag", uuid.New().String(), "--check-cluster-node-platforms=true").InDir(dir).RunOrFail(t.T)
+				skaffold.Build("--file-output", tmpfile, "--tag", uuid.New().String(), "--check-cluster-node-platforms=true").InNs(ns.Name).InDir(dir).RunOrFail(t.T)
 				args = append(args, "--build-artifacts", tmpfile)
 			}
 
-			out, err := skaffold.Exec(args...).InDir(dir).RunWithCombinedOutput(t.T)
+			out, err := skaffold.Exec(args...).InNs(ns.Name).InDir(dir).RunWithCombinedOutput(t.T)
 			t.CheckError(test.shouldErr, err)
 
 			for _, expectedMsg := range test.expectedMsgs {
@@ -193,14 +194,15 @@ func TestExec_K8SActionsEvents(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			MarkIntegrationTest(t.T, NeedsGcp)
+			MarkIntegrationTest(t.T, CanRunWithoutGcp)
+			ns, _ := SetupNamespace(t.T)
 			rpcAddr := randomPort()
 			tmp := t.TempDir()
 			logFile := filepath.Join(tmp, uuid.New().String()+"logs.json")
 
 			args := []string{test.action, "--rpc-port", rpcAddr, "--event-log-file", logFile}
 
-			_, err := skaffold.Exec(args...).InDir("testdata/custom-actions-k8s").RunWithCombinedOutput(t.T)
+			_, err := skaffold.Exec(args...).InNs(ns.Name).InDir("testdata/custom-actions-k8s").RunWithCombinedOutput(t.T)
 
 			t.CheckError(test.shouldErr, err)
 

--- a/integration/testdata/verify-succeed-k8s/skaffold.yaml
+++ b/integration/testdata/verify-succeed-k8s/skaffold.yaml
@@ -19,9 +19,9 @@ verify:
       image: docker.io/hello-world:latest
     executionMode:
       kubernetesCluster: {}
-  - name: alpine-1
+  - name: verify-succeed-k8s-1
     container:
-      name: alpine-1
+      name: verify-succeed-k8s-1
       image: alpine:3.15.4
       command: ["/bin/sh"]
       args: ["-c", "echo $FOO; sleep 10; echo bye"]
@@ -39,11 +39,11 @@ verify:
 profiles:
   - name: no-duplicated-logs
     verify:
-      - name: alpine-1
+      - name: no-duplicated-logs-1
         executionMode:
           kubernetesCluster: {}
         container:
-          name: alpine-1
+          name: no-duplicated-logs-1
           image: alpine:3.15.4
           command: ["/bin/sh"]
           args: ["-c", "echo alpine-1; sleep 1; echo bye alpine-1"]
@@ -91,11 +91,11 @@ profiles:
 
   - name: local-built-artifact
     verify:
-      - name: alpine-123
+      - name: local-built-artifact-1
         executionMode:
           kubernetesCluster: {}
         container:
-          name: alpine-123
+          name: local-built-artifact-1
           image: alpine:3.15.4
           command: ["/bin/sh"]
           args: ["-c", "echo alpine-1; sleep 2; echo bye alpine-1"]

--- a/integration/testdata/verify-succeed-k8s/skaffold.yaml
+++ b/integration/testdata/verify-succeed-k8s/skaffold.yaml
@@ -91,11 +91,11 @@ profiles:
 
   - name: local-built-artifact
     verify:
-      - name: alpine-1
+      - name: alpine-123
         executionMode:
           kubernetesCluster: {}
         container:
-          name: alpine-1
+          name: alpine-123
           image: alpine:3.15.4
           command: ["/bin/sh"]
           args: ["-c", "echo alpine-1; sleep 2; echo bye alpine-1"]

--- a/integration/verify_test.go
+++ b/integration/verify_test.go
@@ -116,7 +116,7 @@ func TestKubernetesJobVerifyPassingTestsWithEnvVar(t *testing.T) {
 	testutil.CheckError(t, false, err)
 	testutil.CheckContains(t, "Hello from Docker!", logs)
 	testutil.CheckContains(t, "foo-var", logs)
-	testutil.CheckContains(t, "alpine-1", logs)
+	testutil.CheckContains(t, "verify-succeed-k8s-1", logs)
 	testutil.CheckContains(t, "alpine-2", logs)
 
 	// verify logs are in the event output as well

--- a/integration/verify_test.go
+++ b/integration/verify_test.go
@@ -109,8 +109,9 @@ func TestKubernetesJobVerifyPassingTestsWithEnvVar(t *testing.T) {
 
 	rpcPort := randomPort()
 	// `--default-repo=` is used to cancel the default repo that is set by default.
+	ns, _ := SetupNamespace(t)
 	out, err := skaffold.Verify("--default-repo=", "--rpc-port", rpcPort,
-		"--event-log-file", logFile, "--env-file", "verify.env").InDir("testdata/verify-succeed-k8s").RunWithCombinedOutput(t)
+		"--event-log-file", logFile, "--env-file", "verify.env").InNs(ns.Name).InDir("testdata/verify-succeed-k8s").RunWithCombinedOutput(t)
 	logs := string(out)
 
 	testutil.CheckError(t, false, err)
@@ -138,8 +139,9 @@ func TestKubernetesJobVerifyOneTestFailsWithEnvVar(t *testing.T) {
 
 	rpcPort := randomPort()
 	// `--default-repo=` is used to cancel the default repo that is set by default.
+	ns, _ := SetupNamespace(t)
 	out, err := skaffold.Verify("--default-repo=", "--rpc-port", rpcPort,
-		"--event-log-file", logFile, "--env-file", "verify.env").InDir("testdata/verify-fail-k8s").RunWithCombinedOutput(t)
+		"--event-log-file", logFile, "--env-file", "verify.env").InNs(ns.Name).InDir("testdata/verify-fail-k8s").RunWithCombinedOutput(t)
 	logs := string(out)
 
 	testutil.CheckError(t, true, err)
@@ -217,8 +219,8 @@ func TestNoDuplicateLogsK8SJobs(t *testing.T) {
 			dir:         "testdata/verify-succeed-k8s",
 			profile:     "no-duplicated-logs",
 			expectedUniqueLogs: []string{
-				"[alpine-1] alpine-1",
-				"[alpine-1] bye alpine-1",
+				"[no-duplicated-logs-1] alpine-1",
+				"[no-duplicated-logs-1] bye alpine-1",
 			},
 		},
 		{
@@ -240,7 +242,8 @@ func TestNoDuplicateLogsK8SJobs(t *testing.T) {
 			MarkIntegrationTest(t.T, CanRunWithoutGcp)
 
 			args := []string{"-p", test.profile}
-			out, err := skaffold.Verify(args...).InDir(test.dir).RunWithCombinedOutput(t.T)
+			ns, _ := SetupNamespace(t.T)
+			out, err := skaffold.Verify(args...).InNs(ns.Name).InDir(test.dir).RunWithCombinedOutput(t.T)
 
 			t.CheckError(test.shouldErr, err)
 
@@ -339,7 +342,8 @@ func TestTimeoutK8s(t *testing.T) {
 			MarkIntegrationTest(t.T, CanRunWithoutGcp)
 
 			args := []string{"-p", test.profile}
-			out, err := skaffold.Verify(args...).InDir(test.dir).RunWithCombinedOutput(t.T)
+			ns, _ := SetupNamespace(t.T)
+			out, err := skaffold.Verify(args...).InNs(ns.Name).InDir(test.dir).RunWithCombinedOutput(t.T)
 			logs := string(out)
 
 			t.CheckError(test.shouldErr, err)

--- a/integration/verify_test.go
+++ b/integration/verify_test.go
@@ -237,7 +237,7 @@ func TestNoDuplicateLogsK8SJobs(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			MarkIntegrationTest(t.T, NeedsGcp)
+			MarkIntegrationTest(t.T, CanRunWithoutGcp)
 
 			args := []string{"-p", test.profile}
 			out, err := skaffold.Verify(args...).InDir(test.dir).RunWithCombinedOutput(t.T)


### PR DESCRIPTION
**Description**
 - We've been seeing some verify and custom actions related flaky tests on Kokoro tests
 - The cause is that some integration tests contaminate each other, and this is more likely to happen on gcp tests, as we're running tests against shared remote clusters concurrently-- 4 worker nodes running tests against one shared remote cluster, adding namespace for integration tests should provide the isolation but namespace flag is not added in verify and exec command. #9051 
 - Github CI should provide better isolation , each worker runs tests against its dedicated minikube -- not 100% sure , but we should also isolate these tests by providing unique names as job names so when skaffold run query to watch resources  it can watch the correct resource. 
 

