### PR TITLE
fix: save runtime type in artifact json

### DIFF
--- a/cmd/skaffold/app/cmd/build_test.go
+++ b/cmd/skaffold/app/cmd/build_test.go
@@ -40,20 +40,35 @@ type mockRunner struct {
 
 func (r *mockRunner) Build(ctx context.Context, out io.Writer, artifacts []*latest.Artifact) ([]graph.Artifact, error) {
 	out.Write([]byte("Build Completed"))
-	return []graph.Artifact{{
-		ImageName: "gcr.io/skaffold/example",
-		Tag:       "test",
-	}}, nil
+	graphArtifacts := make([]graph.Artifact, len(artifacts))
+	for i, a := range artifacts {
+		graphArtifacts[i] = graph.Artifact{
+			ImageName:   a.ImageName,
+			Tag:         "test",
+			RuntimeType: a.RuntimeType,
+		}
+	}
+	return graphArtifacts, nil
 }
 
 func (r *mockRunner) Stop() error {
 	return nil
 }
 
-func TestTagFlag(t *testing.T) {
-	mockCreateRunner := func(context.Context, io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
-		return &mockRunner{}, []util.VersionedConfig{&latest.SkaffoldConfig{}}, nil, nil
+func newMockCreateRunner(artifacts []*latest.Artifact) func(context.Context, io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
+	return func(context.Context, io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
+		return &mockRunner{}, []util.VersionedConfig{&latest.SkaffoldConfig{
+			Pipeline: latest.Pipeline{
+				Build: latest.BuildConfig{
+					Artifacts: artifacts,
+				},
+			},
+		}}, nil, nil
 	}
+}
+
+func TestTagFlag(t *testing.T) {
+	mockCreateRunner := newMockCreateRunner([]*latest.Artifact{{ImageName: "gcr.io/skaffold/example"}})
 
 	testutil.Run(t, "override tag with argument", func(t *testutil.T) {
 		t.Override(&quietFlag, true)
@@ -70,9 +85,7 @@ func TestTagFlag(t *testing.T) {
 }
 
 func TestQuietFlag(t *testing.T) {
-	mockCreateRunner := func(context.Context, io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
-		return &mockRunner{}, []util.VersionedConfig{&latest.SkaffoldConfig{}}, nil, nil
-	}
+	mockCreateRunner := newMockCreateRunner([]*latest.Artifact{{ImageName: "gcr.io/skaffold/example"}})
 
 	tests := []struct {
 		description    string
@@ -116,9 +129,7 @@ func TestQuietFlag(t *testing.T) {
 }
 
 func TestFileOutputFlag(t *testing.T) {
-	mockCreateRunner := func(context.Context, io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
-		return &mockRunner{}, []util.VersionedConfig{&latest.SkaffoldConfig{}}, nil, nil
-	}
+	mockCreateRunner := newMockCreateRunner([]*latest.Artifact{{ImageName: "gcr.io/skaffold/example"}})
 
 	tests := []struct {
 		description         string
@@ -182,9 +193,7 @@ func TestRunBuild(t *testing.T) {
 	errRunner := func(context.Context, io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
 		return nil, nil, nil, errors.New("some error")
 	}
-	mockCreateRunner := func(context.Context, io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
-		return &mockRunner{}, []util.VersionedConfig{&latest.SkaffoldConfig{}}, nil, nil
-	}
+	mockCreateRunner := newMockCreateRunner([]*latest.Artifact{{ImageName: "gcr.io/skaffold/example"}})
 
 	tests := []struct {
 		description string
@@ -211,4 +220,23 @@ func TestRunBuild(t *testing.T) {
 			t.CheckError(test.shouldErr, err)
 		})
 	}
+}
+
+func TestRuntimeType(t *testing.T) {
+	mockCreateRunner := newMockCreateRunner([]*latest.Artifact{{
+		ImageName:   "gcr.io/skaffold/example",
+		RuntimeType: "go",
+	}})
+
+	testutil.Run(t, "set runtime type on artifact", func(t *testutil.T) {
+		t.Override(&quietFlag, true)
+		t.Override(&createRunner, mockCreateRunner)
+
+		var output bytes.Buffer
+
+		err := doBuild(context.Background(), &output)
+
+		t.CheckNoError(err)
+		t.CheckDeepEqual(string([]byte(`{"builds":[{"imageName":"gcr.io/skaffold/example","tag":"test","runtimeType":"go"}]}`)), output.String())
+	})
 }

--- a/pkg/skaffold/graph/artifact_graph.go
+++ b/pkg/skaffold/graph/artifact_graph.go
@@ -24,7 +24,7 @@ import (
 type Artifact struct {
 	ImageName   string `json:"imageName"`
 	Tag         string `json:"tag"`
-	RuntimeType string `json:"-"`
+	RuntimeType string `json:"runtimeType,omitempty"`
 }
 
 // ArtifactGraph is a map of [artifact image : artifact definition]


### PR DESCRIPTION
**Description**
This PR changes build artifact generation to save an artifact's runtime type, making it accessible when using `--build-artifacts`.

This also allows the Helm deployer to use the runtime type (as it invokes `skaffold filter` with `--build-artifacts`).

**User facing changes (remove if N/A)**
`runtimeType` is now present in build artifact JSON if set in configuration.

Before (for an artifact with `runtimeType: go`):
```JSON
{"builds":[{"imageName":"gcr.io/skaffold/example","tag":"gcr.io/skaffold/example:latest"}]}
```

After (for an artifact with `runtimeType: go`):
```JSON
{"builds":[{"imageName":"gcr.io/skaffold/example","tag":"gcr.io/skaffold/example:latest","runtimeType":"go"}]}
```