### PR TITLE
chore: update the release script

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -20,17 +20,17 @@ DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 EXAMPLES_DIR=${DIR}/../examples
 INTEGRATION_EXAMPLES_DIR=${DIR}/../integration/examples
 
-go run hack/release/main.go
+go run hack/release/main.go "$1"
 
 if ! [[ -x "${DIR}/release-notes" ]]; then
   echo >&2 'Installing release-notes'
   cd "${DIR}/tools"
-  GOBIN="$DIR" GO111MODULE=on go install github.com/corneliusweig/release-notes
+  GOBIN="$DIR" GO111MODULE=on go install github.com/corneliusweig/release-notes@v0.1.4
   cd -
 fi
 
 # you can pass your github token with --token here if you run out of requests
-"${DIR}/release-notes" GoogleContainerTools skaffold
+"${DIR}/release-notes" --since minor GoogleContainerTools skaffold
 # remove binary when done
 rm "${DIR}/release-notes"
 

--- a/hack/release/main.go
+++ b/hack/release/main.go
@@ -47,11 +47,20 @@ type versionNote struct {
 
 // TODO(marlongamez): do some autosorting of `release-notes` binary output
 func main() {
-	var skaffoldVersion string
-	// Get skaffold version from user
-	if err := survey.AskOne(&survey.Input{Message: "Input skaffold version:"}, &skaffoldVersion); err != nil {
-		fmt.Printf("failed to get skaffold version from input: %v\n", err)
+	if len(os.Args) > 2 {
+		fmt.Printf("Only one argument allowed.")
 		os.Exit(1)
+	}
+
+	var skaffoldVersion string
+	if len(os.Args) == 1 {
+		// Get skaffold version from user
+		if err := survey.AskOne(&survey.Input{Message: "Input skaffold version:"}, &skaffoldVersion); err != nil {
+			fmt.Printf("failed to get skaffold version from input: %v\n", err)
+			os.Exit(1)
+		}
+	} else {
+		skaffoldVersion = os.Args[1]
 	}
 
 	// Add extra string if new schema version is being released


### PR DESCRIPTION
* allow passing in a version number on the command line
* use `--since minor` to generate the release notes. The constant LTS
  releases confuses the release note generator, this makes it better.