### PR TITLE
[DRAFT] Switch helm deploy to util templating functions

### DIFF
--- a/pkg/skaffold/deploy/helm/args.go
+++ b/pkg/skaffold/deploy/helm/args.go
@@ -20,9 +20,9 @@ import (
 	"github.com/blang/semver"
 
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/constants"
-	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/helm"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/util"
 )
 
 // installOpts are options to be passed to "helm install"
@@ -40,7 +40,7 @@ type installOpts struct {
 }
 
 // installArgs calculates the correct arguments to "helm install"
-func (h *Deployer) installArgs(r latest.HelmRelease, builds []graph.Artifact, o installOpts) ([]string, error) {
+func (h *Deployer) installArgs(r latest.HelmRelease, tplr util.Templater, o installOpts) ([]string, error) {
 	var args []string
 	if o.upgrade {
 		args = append(args, "upgrade", o.releaseName)
@@ -93,7 +93,7 @@ func (h *Deployer) installArgs(r latest.HelmRelease, builds []graph.Artifact, o 
 		args = append(args, "--create-namespace")
 	}
 
-	args, err := helm.ConstructOverrideArgs(&r, builds, args, nil)
+	args, err := helm.ConstructOverrideArgs(&r, tplr, args, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/skaffold/deploy/helm/helm.go
+++ b/pkg/skaffold/deploy/helm/helm.go
@@ -256,24 +256,21 @@ func (h *Deployer) Deploy(ctx context.Context, out io.Writer, builds []graph.Art
 	nsMap := map[string]struct{}{}
 	manifests := manifest.ManifestList{}
 
-	// Deploy every release
-	for _, r := range h.Releases {
-		releaseName, err := util.ExpandEnvTemplateOrFail(r.Name, nil)
-		if err != nil {
-			return helm.UserErr(fmt.Sprintf("cannot expand release name %q", r.Name), err)
-		}
-		chartVersion, err := util.ExpandEnvTemplateOrFail(r.Version, nil)
-		if err != nil {
-			return helm.UserErr(fmt.Sprintf("cannot expand chart version %q", r.Version), err)
-		}
+	// Compute template variables from build graph
+	buildInfo := helm.BuildsToMap(builds)
 
-		repo, err := util.ExpandEnvTemplateOrFail(r.Repo, nil)
+	// template every release
+	tplr := util.NewTemplater(buildInfo)
+	releases, err := helm.TemplateReleases(tplr, h.Releases)
+	if err != nil {
+		return helm.UserErr(fmt.Sprintf("failed templating releases"), err)
+	}
+
+	// Deploy every release
+	for _, r := range releases {
+		m, results, err := h.deployRelease(ctx, out, r, builds, tplr, h.bV)
 		if err != nil {
-			return helm.UserErr(fmt.Sprintf("cannot expand repo %q", r.Repo), err)
-		}
-		m, results, err := h.deployRelease(ctx, out, releaseName, r, builds, h.bV, chartVersion, repo)
-		if err != nil {
-			return helm.UserErr(fmt.Sprintf("deploying %q", releaseName), err)
+			return helm.UserErr(fmt.Sprintf("deploying %q", r.Name), err)
 		}
 
 		manifests.Append(m)
@@ -371,27 +368,34 @@ func (h *Deployer) Cleanup(ctx context.Context, out io.Writer, dryRun bool, _ ma
 	})
 
 	var errMsgs []string
-	for _, r := range h.Releases {
-		releaseName, err := util.ExpandEnvTemplateOrFail(r.Name, nil)
-		if err != nil {
-			return fmt.Errorf("cannot parse the release name template: %w", err)
-		}
 
-		namespace, err := helm.ReleaseNamespace(h.namespace, r)
-		if err != nil {
-			return err
-		}
+	// template every release
+	tplr := util.NewTemplater(nil)
+	releases, err := helm.TemplateReleases(tplr, h.Releases)
+	if err != nil {
+		return helm.UserErr(fmt.Sprintf("failed templating releases"), err)
+	}
+
+	for _, release := range releases {
+
+		// Build up arguments
 		args := []string{}
 		if dryRun {
 			args = append(args, "get", "manifest")
 		} else {
 			args = append(args, "delete")
 		}
-		args = append(args, releaseName)
+		args = append(args, release.Name)
 
-		if namespace != "" {
-			args = append(args, "--namespace", namespace)
+		// Optionally append namespace
+		// Default to the deployer namespace
+		if h.namespace != "" {
+			args = append(args, "--namespace", h.namespace)
+		} else if release.Namespace != "" {
+			args = append(args, "--namespace", release.Namespace)
 		}
+
+		// And send it
 		if err := helm.Exec(ctx, h, out, false, nil, args...); err != nil {
 			errMsgs = append(errMsgs, err.Error())
 		}
@@ -428,17 +432,17 @@ func (h *Deployer) PostDeployHooks(ctx context.Context, out io.Writer) error {
 }
 
 // deployRelease deploys a single release; returns the deployed manifests, and the artifacts
-func (h *Deployer) deployRelease(ctx context.Context, out io.Writer, releaseName string, r latest.HelmRelease, builds []graph.Artifact, helmVersion semver.Version, chartVersion string, repo string) ([]byte, []types.Artifact, error) {
+func (h *Deployer) deployRelease(ctx context.Context, out io.Writer, r latest.HelmRelease, builds []graph.Artifact, tplr util.Templater, helmVersion semver.Version) ([]byte, []types.Artifact, error) {
 	var err error
 	opts := installOpts{
-		releaseName: releaseName,
+		releaseName: r.Name,
 		upgrade:     true,
 		flags:       h.Flags.Upgrade,
 		force:       h.forceDeploy,
 		chartPath:   helm.ChartSource(r),
 		helmVersion: helmVersion,
-		repo:        repo,
-		version:     chartVersion,
+		repo:        r.Repo,
+		version:     r.Version,
 	}
 
 	installEnv := util.OSEnviron()
@@ -455,22 +459,23 @@ func (h *Deployer) deployRelease(ctx context.Context, out io.Writer, releaseName
 	installEnv = append(installEnv, filterEnv...)
 	opts.postRenderer = skaffoldBinary
 
-	opts.namespace, err = helm.ReleaseNamespace(h.namespace, r)
-	if err != nil {
-		return nil, nil, err
+	if h.namespace != "" {
+		opts.namespace = h.namespace
+	} else {
+		opts.namespace = r.Namespace
 	}
 
-	if err := helm.Exec(ctx, h, io.Discard, false, nil, helm.GetArgs(releaseName, opts.namespace)...); err != nil {
-		output.Yellow.Fprintf(out, "Helm release %s not installed. Installing...\n", releaseName)
+	if err := helm.Exec(ctx, h, io.Discard, false, nil, helm.GetArgs(r.Name, opts.namespace)...); err != nil {
+		output.Yellow.Fprintf(out, "Helm release %s not installed. Installing...\n", r.Name)
 
 		opts.upgrade = false
 		opts.flags = h.Flags.Install
 	} else {
 		if r.UpgradeOnChange != nil && !*r.UpgradeOnChange {
-			olog.Entry(ctx).Infof("Release %s already installed...", releaseName)
+			olog.Entry(ctx).Infof("Release %s already installed...", r.Name)
 			return nil, []types.Artifact{}, nil
 		} else if r.UpgradeOnChange == nil && r.RemoteChart != "" {
-			olog.Entry(ctx).Infof("Release %s not upgraded as it is remote...", releaseName)
+			olog.Entry(ctx).Infof("Release %s not upgraded as it is remote...", r.Name)
 			return nil, []types.Artifact{}, nil
 		}
 	}
@@ -509,7 +514,7 @@ func (h *Deployer) deployRelease(ctx context.Context, out io.Writer, releaseName
 		opts.chartPath = chartPath
 	}
 
-	args, err := h.installArgs(r, builds, opts)
+	args, err := h.installArgs(r, tplr, opts)
 	if err != nil {
 		return nil, nil, helm.UserErr("release args", err)
 	}
@@ -520,7 +525,7 @@ func (h *Deployer) deployRelease(ctx context.Context, out io.Writer, releaseName
 	}
 
 	// get the kubernetes manifests deployed to the cluster
-	b, err := h.getReleaseManifest(ctx, releaseName, opts.namespace)
+	b, err := h.getReleaseManifest(ctx, r.Name, opts.namespace)
 	if err != nil {
 		return nil, nil, helm.UserErr("get release", err)
 	}
@@ -568,19 +573,11 @@ func (h *Deployer) packageChart(ctx context.Context, r latest.HelmRelease) (stri
 	args := []string{"package", r.ChartPath, "--destination", tmpDir}
 
 	if r.Packaged.Version != "" {
-		v, err := util.ExpandEnvTemplate(r.Packaged.Version, nil)
-		if err != nil {
-			return "", fmt.Errorf("packaged.version template: %w", err)
-		}
-		args = append(args, "--version", v)
+		args = append(args, "--version", r.Packaged.Version)
 	}
 
 	if r.Packaged.AppVersion != "" {
-		av, err := util.ExpandEnvTemplate(r.Packaged.AppVersion, nil)
-		if err != nil {
-			return "", fmt.Errorf("packaged.appVersion template: %w", err)
-		}
-		args = append(args, "--app-version", av)
+		args = append(args, "--app-version", r.Packaged.AppVersion)
 	}
 
 	buf := &bytes.Buffer{}

--- a/pkg/skaffold/deploy/helm/helm_test.go
+++ b/pkg/skaffold/deploy/helm/helm_test.go
@@ -1221,6 +1221,7 @@ func TestHelmRender(t *testing.T) {
 		{
 			description: "render with missing templated release name should fail",
 			shouldErr:   true,
+			commands:    testutil.CmdRunWithOutput("helm version --client", version31),
 			helm:        testDeployWithTemplatedName,
 			builds:      testBuilds,
 		},

--- a/pkg/skaffold/helm/template.go
+++ b/pkg/skaffold/helm/template.go
@@ -1,0 +1,73 @@
+package helm
+
+import (
+	"fmt"
+
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/util"
+)
+
+// templateFields turns a release containing fields with templates in them into
+// a release which has it's templates rendered.
+func templateFields(tpl util.Templater, release latest.HelmRelease) (latest.HelmRelease, error) {
+	releaseName, err := tpl.RenderNonEmpty(release.Name, release.Overrides.Values)
+	if err != nil {
+		return release, fmt.Errorf("unable to template release name: %w", err)
+	}
+	release.Name = releaseName
+
+	chartVersion, err := tpl.Render(release.Version, release.Overrides.Values)
+	if err != nil {
+		return release, fmt.Errorf("unable to template chart version: %w", err)
+	}
+	release.Version = chartVersion
+
+	repo, err := tpl.Render(release.Repo, release.Overrides.Values)
+	if err != nil {
+		return release, fmt.Errorf("unable to template repo: %w", err)
+	}
+	release.Repo = repo
+
+	namespace, err := tpl.Render(release.Namespace, release.Overrides.Values)
+	if err != nil {
+		return release, fmt.Errorf("unable to template namespace: %w", err)
+	}
+	release.Namespace = namespace
+
+	chartPath, err := tpl.Render(release.ChartPath, release.Overrides.Values)
+	if err != nil {
+		return release, fmt.Errorf("unable to template chart path: %w", err)
+	}
+	release.ChartPath = chartPath
+
+	if release.Packaged != nil {
+		packaged_version, err := tpl.Render(release.Packaged.Version, release.Overrides.Values)
+		if err != nil {
+			return release, fmt.Errorf("unable to template packaged.version: %w", err)
+		}
+		release.Packaged.Version = packaged_version
+
+		packagedAppVersion, err := tpl.Render(release.Packaged.AppVersion, release.Overrides.Values)
+		if err != nil {
+			return release, fmt.Errorf("unable to template packaged.appVersion: %w", err)
+		}
+		release.Packaged.AppVersion = packagedAppVersion
+	}
+
+	return release, nil
+}
+
+// Template all provided releases to have their fields filled
+func TemplateReleases(tpl util.Templater, releases []latest.HelmRelease) ([]latest.HelmRelease, error) {
+	rendered_releases := []latest.HelmRelease{}
+	for _, release := range releases {
+		rendered_release, err := templateFields(tpl, release)
+		if err != nil {
+			return nil, fmt.Errorf("expanding %q: %w", release.Name, err)
+		}
+		rendered_releases = append(rendered_releases, rendered_release)
+
+	}
+
+	return rendered_releases, nil
+}

--- a/pkg/skaffold/util/env_template.go
+++ b/pkg/skaffold/util/env_template.go
@@ -34,7 +34,7 @@ import (
 // For testing
 var (
 	OSEnviron = os.Environ
-	funcsMap  = template.FuncMap{
+	FuncsMap  = template.FuncMap{
 		"cmd": runCmdFunc,
 	}
 )
@@ -60,7 +60,7 @@ func ExpandEnvTemplateOrFail(s string, envMap map[string]string) (string, error)
 
 // ParseEnvTemplate is a simple wrapper to parse an env template
 func ParseEnvTemplate(t string) (*template.Template, error) {
-	return template.New("envTemplate").Funcs(funcsMap).Funcs(sprig.FuncMap()).Parse(t)
+	return template.New("envTemplate").Funcs(FuncsMap).Funcs(sprig.FuncMap()).Parse(t)
 }
 
 // ExecuteEnvTemplate executes an envTemplate based on OS environment variables and a custom map

--- a/pkg/skaffold/util/template.go
+++ b/pkg/skaffold/util/template.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"text/template"
+
+	"github.com/Masterminds/sprig"
+
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/output/log"
+)
+
+// A templater containing a base set of available variables
+// and a configured root template
+type Templater struct {
+	valueMap map[string]string
+	template *template.Template
+}
+
+// Create a new Templater with a `customMap` containing values then available
+// to templates
+func NewTemplater(customMap map[string]string) Templater {
+	// Create central templater
+	tpl := template.New("helmTemplate").Funcs(FuncsMap).Funcs(sprig.FuncMap())
+
+	valueMap := map[string]string{}
+
+	// Load environment variables
+	// TODO maybe use misc.EvaluateEnv ?
+	for _, env := range OSEnviron() {
+		kvp := strings.SplitN(env, "=", 2)
+		valueMap[kvp[0]] = kvp[1]
+	}
+
+	// Combine with custom map
+	for k, v := range customMap {
+		valueMap[k] = v
+	}
+
+	return Templater{template: tpl, valueMap: valueMap}
+}
+
+// render a single string `s` with the templater considering the provided `overrides`.
+// Overrides always take precedence.
+func (tpl *Templater) Render(s string, overrides map[string]interface{}) (string, error) {
+	// Clone to have a local template for this invocation
+	templater, err := tpl.template.Clone()
+	if err != nil {
+		return "", fmt.Errorf("unable to clone template: %q: %w", s, err)
+	}
+
+	// Parse the template
+	tmpl, err := templater.Parse(s)
+	if err != nil {
+		return "", fmt.Errorf("unable to parse template: %q: %w", s, err)
+	}
+	tmpl = tmpl.Option("missingkey=invalid")
+
+	// Compute values for this invocation from the global map and overrides
+	values := map[string]interface{}{}
+	for k, v := range tpl.valueMap {
+		values[k] = v
+	}
+
+	// Overrides added last, to take precedence
+	for k, v := range overrides {
+		values[k] = v
+	}
+
+	// Execute the actual template with t he provided values
+	var buf bytes.Buffer
+	log.Entry(context.TODO()).Debugf("Executing template %v with environment %v", tmpl, tpl.valueMap)
+	if err := tmpl.Execute(&buf, values); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// renderNonEmpty parses and executes a template with overrides and errors if
+// the resulting string is empty or only contains the "<no value>" marker.
+func (tpl *Templater) RenderNonEmpty(s string, overrides map[string]interface{}) (string, error) {
+	// Render or bail
+	templated, err := tpl.Render(s, overrides)
+	if err != nil {
+		return "", err
+	}
+
+	// Check for failing template
+	if templated == "" || strings.Contains(templated, "<no value>") {
+		return "", fmt.Errorf("field evaluates to empty")
+	}
+
+	return templated, nil
+}


### PR DESCRIPTION
**Fixes**: #9062
**Related**: #9063 

**Note** This is a raw draft. I'm extremely aware that this PR does have **no unit tests at all** and does **not contain any docs update**. It is meant as a foundation to discuss an architecture how to achieve the stated goals. As soon as the direction is clear, unit tests + docs are absolutely necessary.

# Description
The goal is to have consistent templating available for the helm renderer & deployer. This includes:

1. Be able to use all available functions when templating (especially `default`)
2. Have a consistent set of variables available for templating accros fields

## Change overview

To achieve this, a `Templater` has been added to `pkg/skaffold/util/template.go`. The intention is to have something to instantiate once which carries along all configuration and a base set of template-able values. After that, a number of templates can be rendered with optional overrides.

Helm specific templating logic can be found in `pkg/skaffold/helm/template.go`. The goal here is to have one location containing templating logic. This should avoid different stages 'drifting' away from each other (e.g. helm deploy vs. helm render).

All other changes are in `pkg/skaffold/helm/*.go` to centralize templater instantiation, passing it around and using the new rendering functions.

## Known Implementation Drawbacks

1. Currently, this implementation cannot cope with template caching. A call to render will always parse and render a template in one step. For helm this seems sufficient, but other use cases may have a problem here.
2. Performance optimize the [value looping in `Templater.Render`](https://github.com/girstenbrei/skaffold/blob/main/pkg/skaffold/util/template.go#L77-L86). Always looping over all the available values seems wasteful, I just don't know how to solve this best.

## Known Architecture Drawbacks

1. With this architecture is instantiated at least once per deployer & renderer. If those steps could receive an already configured templater, this could be centralized even more. But, this is a heavier change to those interfaces and carries the question how the templater should be configured and who is responsible to add what to the templater. 

## User facing changes

### New features
Users are now able to use every std and sprig template function in every field consistently.
Additionally, which fields are available for templating has been unified to have them all available in every already template-able field.

### UX Changes
Previously, templating was done on demand. This means, during a deploy, release of helm chart A might be deployed, but during release of helm chart B templating failed, making the whole deploy fail in the middle.

Templating of every chart has been moved in front deploying. This means in contrast to before, templating has to succeed for all releases before any deploy is attempted. IMHO this is a better solution than to fail in the middle.

### Follow-up Work

Many other parts of skaffold template, too. With the code in this PR, templating logic is now split in `pkg/skaffold/util/env_tempalte.go` and `pkg/skaffold/util/template.go` in an effort to start with one part but be able to continue switching other templating to the new structure, too.

IMHO regardless of renderer/deployer/tagger, templating should work consistently inside skaffold. To achieve this, having one central piece of templating logic might be a solution to be discussed.
