### PR TITLE
fix: kpt force named "false" in schema

### DIFF
--- a/docs-v2/content/en/schemas/v4beta8.json
+++ b/docs-v2/content/en/schemas/v4beta8.json
@@ -2982,12 +2982,6 @@
           "description": "equivalent to the dir in `kpt live apply <dir>`. If not provided, skaffold deploys from the default hydrated path `<WORKDIR>/.kpt-pipeline`.",
           "x-intellij-html-description": "equivalent to the dir in <code>kpt live apply &lt;dir&gt;</code>. If not provided, skaffold deploys from the default hydrated path <code>&lt;WORKDIR&gt;/.kpt-pipeline</code>."
         },
-        "false": {
-          "type": "boolean",
-          "description": "used in `kpt live init`, which forces the inventory values to be updated, even if they are already set.",
-          "x-intellij-html-description": "used in <code>kpt live init</code>, which forces the inventory values to be updated, even if they are already set.",
-          "default": "false"
-        },
         "flags": {
           "items": {
             "type": "string"
@@ -2996,6 +2990,12 @@
           "description": "kpt global flags.",
           "x-intellij-html-description": "kpt global flags.",
           "default": "[]"
+        },
+        "force": {
+          "type": "boolean",
+          "description": "used in `kpt live init`, which forces the inventory values to be updated, even if they are already set.",
+          "x-intellij-html-description": "used in <code>kpt live init</code>, which forces the inventory values to be updated, even if they are already set.",
+          "default": "false"
         },
         "inventoryID": {
           "type": "string",
@@ -3020,7 +3020,7 @@
         "name",
         "inventoryID",
         "namespace",
-        "false",
+        "force",
         "defaultNamespace"
       ],
       "additionalProperties": false,

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -807,7 +807,7 @@ type KptDeploy struct {
 	InventoryNamespace string `yaml:"namespace,omitempty"`
 
 	// Force is used in `kpt live init`, which forces the inventory values to be updated, even if they are already set.
-	Force bool `yaml:"false,omitempty"`
+	Force bool `yaml:"force,omitempty"`
 
 	// LifecycleHooks describes a set of lifecycle hooks that are executed before and after every deploy.
 	LifecycleHooks DeployHooks `yaml:"-"`


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: None
**Related**: None
**Merge before/after**: None
^ I didn't create an issue, I just edited directly on github 🥲

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
I think the intent for the current schema at `skaffold.yaml:deploy.kpt.false` was meant to be `deploy.kpt.force`.
https://skaffold.dev/docs/references/yaml/#deploy-kpt-false

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
Users using `deploy.kpt.false` will need to change to `deploy.kpt.force`.

<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->

**Follow-up Work (remove if N/A)**
<!-- Mention any related follow up work to this PR. -->
- I don't know how skaffold fix works, this could be auto fixed.

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
