### PR TITLE
chore: verify should preserve job manifest envs

### DIFF
--- a/examples/getting-started/skaffold.yaml
+++ b/examples/getting-started/skaffold.yaml
@@ -3,6 +3,8 @@ kind: Config
 build:
   artifacts:
   - image: skaffold-example
+  local:
+    push: false
 manifests:
   rawYaml:
   - k8s-pod.yaml

--- a/examples/getting-started/skaffold.yaml
+++ b/examples/getting-started/skaffold.yaml
@@ -3,8 +3,6 @@ kind: Config
 build:
   artifacts:
   - image: skaffold-example
-  local:
-    push: false
 manifests:
   rawYaml:
   - k8s-pod.yaml

--- a/integration/testdata/verify-succeed-k8s/job.yaml
+++ b/integration/testdata/verify-succeed-k8s/job.yaml
@@ -10,5 +10,5 @@ spec:
           image: alpine:latest
           env:
             - name: FOO
-              value: foo
+              value: ZZZ
       restartPolicy: Never

--- a/integration/testdata/verify-succeed-k8s/job.yaml
+++ b/integration/testdata/verify-succeed-k8s/job.yaml
@@ -1,0 +1,14 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: foo
+spec:
+  template:
+    spec:
+      containers:
+        - name: foo
+          image: alpine:latest
+          env:
+            - name: FOO
+              value: foo
+      restartPolicy: Never

--- a/integration/testdata/verify-succeed-k8s/skaffold.yaml
+++ b/integration/testdata/verify-succeed-k8s/skaffold.yaml
@@ -89,6 +89,18 @@ profiles:
           command: ["/bin/sh"]
           args: ["-c", "echo alpine-11; sleep 15; echo bye alpine-11"]
 
+  - name: with-manifest-env
+    verify:
+      - name: alpine-10
+        executionMode:
+          kubernetesCluster:
+            jobManifestPath: job.yaml
+        container:
+          name: foo
+          image: alpine:3.15.4
+          command: [ "/bin/sh" ]
+          args: [ "-c", "echo $FOO 22;" ]
+
   - name: local-built-artifact
     verify:
       - name: alpine-1

--- a/integration/testdata/verify-succeed-k8s/skaffold.yaml
+++ b/integration/testdata/verify-succeed-k8s/skaffold.yaml
@@ -100,6 +100,10 @@ profiles:
           image: alpine:3.15.4
           command: [ "/bin/sh" ]
           args: [ "-c", "echo $FOO 22;" ]
+          env:
+            - name: FOO
+              value: sss
+
 
   - name: local-built-artifact
     verify:

--- a/integration/testdata/verify-succeed-k8s/skaffold.yaml
+++ b/integration/testdata/verify-succeed-k8s/skaffold.yaml
@@ -122,3 +122,14 @@ profiles:
         container:
           name: localtask
           image: not-built-localtask
+  - name: with-job-manifest
+    verify:
+      - name: with-job-manifest
+        executionMode:
+          kubernetesCluster:
+            jobManifestPath: job.yaml
+        container:
+          name: foo
+          image: alpine:3.15.4
+          command: ["/bin/sh"]
+          args: ["-c", "echo $FOO with-job-manifest; sleep 2; echo bye"]

--- a/integration/testdata/verify-succeed-k8s/skaffold.yaml
+++ b/integration/testdata/verify-succeed-k8s/skaffold.yaml
@@ -89,22 +89,6 @@ profiles:
           command: ["/bin/sh"]
           args: ["-c", "echo alpine-11; sleep 15; echo bye alpine-11"]
 
-  - name: with-manifest-env
-    verify:
-      - name: alpine-10
-        executionMode:
-          kubernetesCluster:
-            jobManifestPath: job.yaml
-        container:
-          name: foo
-          image: alpine:3.15.4
-          command: [ "/bin/sh" ]
-          args: [ "-c", "echo $FOO 22;" ]
-          env:
-            - name: FOO
-              value: sss
-
-
   - name: local-built-artifact
     verify:
       - name: alpine-1

--- a/integration/verify_test.go
+++ b/integration/verify_test.go
@@ -131,6 +131,21 @@ func TestKubernetesJobVerifyPassingTestsWithEnvVar(t *testing.T) {
 	// TODO(aaron-prindle) verify that SUCCEEDED event is found where expected
 }
 
+func TestKubernetesJobVerifyEnvVarFromJobManifest(t *testing.T) {
+	MarkIntegrationTest(t, CanRunWithoutGcp)
+	tmp := t.TempDir()
+	logFile := filepath.Join(tmp, uuid.New().String()+"logs.json")
+
+	rpcPort := randomPort()
+	// `--default-repo=` is used to cancel the default repo that is set by default.
+	out, err := skaffold.Verify("--default-repo=", "--rpc-port", rpcPort,
+		"--event-log-file", logFile, "-p", "with-job-manifest").InDir("testdata/verify-succeed-k8s").RunWithCombinedOutput(t)
+	logs := string(out)
+
+	testutil.CheckError(t, false, err)
+	testutil.CheckContains(t, "ZZZ with-job-manifest", logs)
+}
+
 func TestKubernetesJobVerifyOneTestFailsWithEnvVar(t *testing.T) {
 	MarkIntegrationTest(t, CanRunWithoutGcp)
 	tmp := t.TempDir()

--- a/pkg/skaffold/verify/k8sjob/verify_test.go
+++ b/pkg/skaffold/verify/k8sjob/verify_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2023 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8sjob
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/v2/testutil"
+)
+
+func TestPatchToK8sContainer(t *testing.T) {
+	tests := []struct {
+		description     string
+		verifyContainer latest.VerifyContainer
+		k8sContainer    corev1.Container
+		expected        corev1.Container
+	}{
+		{
+			description: "update all fields",
+			verifyContainer: latest.VerifyContainer{
+				Image:   "my-image:latest",
+				Command: []string{"/bin/bash"},
+				Args:    []string{"-c", "echo hello world"},
+				Name:    "my-container",
+				Env: []latest.VerifyEnvVar{
+					{Name: "FOO", Value: "BAR"},
+				},
+			},
+			k8sContainer: corev1.Container{},
+			expected: corev1.Container{
+				Image:   "my-image:latest",
+				Command: []string{"/bin/bash"},
+				Args:    []string{"-c", "echo hello world"},
+				Name:    "my-container",
+				Env: []corev1.EnvVar{
+					{Name: "FOO", Value: "BAR"},
+				},
+			},
+		},
+		{
+			description: "update image",
+			verifyContainer: latest.VerifyContainer{
+				Image: "my-new-image:latest",
+			},
+			k8sContainer: corev1.Container{
+				Image: "my-image:latest",
+			},
+			expected: corev1.Container{
+				Image: "my-new-image:latest",
+			},
+		},
+		{
+			description: "update command",
+			verifyContainer: latest.VerifyContainer{
+				Command: []string{"/bin/ls"},
+			},
+			k8sContainer: corev1.Container{
+				Command: []string{"/bin/bash"},
+			},
+			expected: corev1.Container{
+				Command: []string{"/bin/ls"},
+			},
+		},
+		{
+			description: "update args",
+			verifyContainer: latest.VerifyContainer{
+				Args: []string{"-l"},
+			},
+			k8sContainer: corev1.Container{
+				Args: []string{"-c", "echo hello world"},
+			},
+			expected: corev1.Container{
+				Args: []string{"-l"},
+			},
+		},
+		{
+			description: "update name",
+			verifyContainer: latest.VerifyContainer{
+				Name: "my-new-container",
+			},
+			k8sContainer: corev1.Container{
+				Name: "my-container",
+			},
+			expected: corev1.Container{
+				Name: "my-new-container",
+			},
+		},
+		{
+			description: "update env",
+			verifyContainer: latest.VerifyContainer{
+				Env: []latest.VerifyEnvVar{
+					{Name: "FOO", Value: "BARR"},
+					{Name: "BAZ", Value: "QUX"},
+				},
+			},
+			k8sContainer: corev1.Container{
+				Env: []corev1.EnvVar{
+					{Name: "FOO", Value: "BAR"},
+				},
+			},
+			// Duplicate name should be ok, as the last writer should win.
+			expected: corev1.Container{
+				Env: []corev1.EnvVar{
+					{Name: "FOO", Value: "BAR"},
+					{Name: "FOO", Value: "BARR"},
+					{Name: "BAZ", Value: "QUX"},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			patchToK8sContainer(test.verifyContainer, &test.k8sContainer)
+			t.CheckDeepEqual(test.expected, test.k8sContainer)
+		})
+	}
+}


### PR DESCRIPTION

Fixes: #8974 

 - To use container information provided from user's k8s job manifest, we cannot just replace the container with the when set up in skaffold.yaml
 - We can use the container in the job manifest as the base, then as a patch with verify container. 
 - Note that to make the patch work, the container names must match in skaffold.yaml verify stanza and from k8s  job manifest. 

