### PR TITLE
docs: add templatable field

### DIFF
--- a/docs-v2/content/en/docs/environment/templating.md
+++ b/docs-v2/content/en/docs/environment/templating.md
@@ -31,6 +31,7 @@ will be `gcr.io/k8s-skaffold/example:v1`.
 * `deploy.helm.releases[].repo` (see [Deploying with helm]({{< relref "/docs/deployers#deploying-with-helm)" >}}))
 * `deploy.helm.releases[].setValueTemplates` (see [Deploying with helm]({{< relref "/docs/deployers#deploying-with-helm)" >}}))
 * `deploy.helm.releases[].version` (see [Deploying with helm]({{< relref "/docs/deployers#deploying-with-helm)" >}}))
+* `deploy.helm.releases.valuesFiles` (see [Deploying with helm]({{< relref "/docs/deployers#deploying-with-helm)" >}}))
 * `deploy.kubectl.defaultNamespace`
 * `deploy.kustomize.defaultNamespace`
 * `manifests.kustomize.paths.[]`


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
**Related**:  https://github.com/GoogleContainerTools/skaffold/pull/7612

**Description**
Field deploy.helm.releases.valuesFiles of skaffold.yaml can be used with templates (see #2849).
