### PR TITLE
chore: add set docker host by current context

### DIFF
--- a/examples/getting-started/skaffold.yaml
+++ b/examples/getting-started/skaffold.yaml
@@ -3,6 +3,8 @@ kind: Config
 build:
   artifacts:
   - image: skaffold-example
+  local:
+    push: false
 manifests:
   rawYaml:
   - k8s-pod.yaml

--- a/examples/getting-started/skaffold.yaml
+++ b/examples/getting-started/skaffold.yaml
@@ -3,8 +3,6 @@ kind: Config
 build:
   artifacts:
   - image: skaffold-example
-  local:
-    push: false
 manifests:
   rawYaml:
   - k8s-pod.yaml

--- a/pkg/skaffold/docker/client.go
+++ b/pkg/skaffold/docker/client.go
@@ -111,18 +111,15 @@ func newEnvAPIClient() ([]string, client.CommonAPIClient, error) {
 	} else {
 		log.Entry(context.TODO()).Infof("DOCKER_HOST env is not set, using the host from docker context.")
 
-		command := exec.Command("docker", "context", "inspect", "--format", "{{json .Endpoints.docker.Host}}")
+		command := exec.Command("docker", "context", "inspect", "--format", "{{.Endpoints.docker.Host}}")
 		out, err := util.RunCmdOut(context.TODO(), command)
 		if err != nil {
 			log.Entry(context.TODO()).Warnf("Could not get docker context: %s", err)
 		} else {
 			s := string(out)
 			s = strings.TrimSpace(s)
-			// remove quotes from the output
-			if len(s) > 2 {
-				s = s[1 : len(s)-1]
-				host = s
-				opts = append(opts, client.WithHost(host))
+			if len(s) > 0 {
+				opts = append(opts, client.WithHost(s))
 			}
 		}
 	}

--- a/pkg/skaffold/docker/client.go
+++ b/pkg/skaffold/docker/client.go
@@ -114,10 +114,11 @@ func newEnvAPIClient() ([]string, client.CommonAPIClient, error) {
 		command := exec.Command("docker", "context", "inspect", "--format", "{{.Endpoints.docker.Host}}")
 		out, err := util.RunCmdOut(context.TODO(), command)
 		if err != nil {
-			log.Entry(context.TODO()).Warnf("Could not get docker context: %s", err)
+			// docker cli not installed.
+			log.Entry(context.TODO()).Warnf("Could not get docker context: %s, falling back to the default docker host", err)
 		} else {
-			s := string(out)
-			s = strings.TrimSpace(s)
+			s := strings.TrimSpace(string(out))
+			// output can be empty if user uses docker as alias for podman
 			if len(s) > 0 {
 				opts = append(opts, client.WithHost(s))
 			}

--- a/pkg/skaffold/docker/client_test.go
+++ b/pkg/skaffold/docker/client_test.go
@@ -145,15 +145,18 @@ DOCKER_HOST`),
 		},
 		{
 			description: "minikube exit code 64 (minikube < 1.13.0) - fallback to host docker",
-			command:     testutil.CmdRunOutErr("minikube docker-env --shell none -p minikube", "", fmt.Errorf("fail: %w", &oldBadUsageErr{})),
+			command: testutil.CmdRunOutErr("minikube docker-env --shell none -p minikube", "", fmt.Errorf("fail: %w", &oldBadUsageErr{})).
+				AndRunOut("docker context inspect --format {{.Endpoints.docker.Host}}", ""),
 		},
 		{
 			description: "minikube exit code 51 (minikube >= 1.13.0) - fallback to host docker",
-			command:     testutil.CmdRunOutErr("minikube docker-env --shell none -p minikube", "", fmt.Errorf("fail: %w", &driverConflictErr{})),
+			command: testutil.CmdRunOutErr("minikube docker-env --shell none -p minikube", "", fmt.Errorf("fail: %w", &driverConflictErr{})).
+				AndRunOut("docker context inspect --format {{.Endpoints.docker.Host}}", ""),
 		},
 		{
 			description: "minikube exit code 89 - fallback to host docker",
-			command:     testutil.CmdRunOutErr("minikube docker-env --shell none -p minikube", "", fmt.Errorf("fail: %w", &exGuestUnavailable{})),
+			command: testutil.CmdRunOutErr("minikube docker-env --shell none -p minikube", "", fmt.Errorf("fail: %w", &exGuestUnavailable{})).
+				AndRunOut("docker context inspect --format {{.Endpoints.docker.Host}}", ""),
 		},
 	}
 	for _, test := range tests {

--- a/pkg/skaffold/docker/client_test.go
+++ b/pkg/skaffold/docker/client_test.go
@@ -62,7 +62,7 @@ func TestNewEnvClient(t *testing.T) {
 			shouldErr:   false,
 		},
 		{
-			description: "DOCKER_HOST not set, output",
+			description: "DOCKER_HOST not set, output invalid host",
 			command:     testutil.CmdRunOut("docker context inspect --format {{.Endpoints.docker.Host}}", "invalid host"),
 			shouldErr:   true,
 		},

--- a/pkg/skaffold/docker/client_test.go
+++ b/pkg/skaffold/docker/client_test.go
@@ -32,6 +32,7 @@ func TestNewEnvClient(t *testing.T) {
 	tests := []struct {
 		description string
 		envs        map[string]string
+		command     *testutil.FakeCmd
 		shouldErr   bool
 	}{
 		{
@@ -55,10 +56,28 @@ func TestNewEnvClient(t *testing.T) {
 			},
 			shouldErr: false,
 		},
+		{
+			description: "DOCKER_HOST not set",
+			command:     testutil.CmdRunOut("docker context inspect --format {{.Endpoints.docker.Host}}", ""),
+			shouldErr:   false,
+		},
+		{
+			description: "DOCKER_HOST not set, output",
+			command:     testutil.CmdRunOut("docker context inspect --format {{.Endpoints.docker.Host}}", "invalid host"),
+			shouldErr:   true,
+		},
+		{
+			description: "DOCKER_HOST not set, ignore error",
+			command:     testutil.CmdRunOutErr("docker context inspect --format {{.Endpoints.docker.Host}}", "", fmt.Errorf("cannot get context")),
+			shouldErr:   false,
+		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.SetEnvs(test.envs)
+			if test.command != nil {
+				t.Override(&util.DefaultExecCommand, test.command)
+			}
 
 			env, _, err := newEnvAPIClient()
 

--- a/pkg/skaffold/test/structure/structure_test.go
+++ b/pkg/skaffold/test/structure/structure_test.go
@@ -41,7 +41,7 @@ func TestNewRunner(t *testing.T) {
 			return "", semver.Version{}, errors.New("not found")
 		})
 
-		t.Override(&util.DefaultExecCommand, testutil.CmdRun("container-structure-test test -v warn --image image:tag --config "+tmpDir.Path("test.yaml")))
+		t.Override(&util.DefaultExecCommand, testutil.CmdRunOut("docker context inspect --format {{.Endpoints.docker.Host}}", "").AndRun("container-structure-test test -v warn --image image:tag --config "+tmpDir.Path("test.yaml")))
 
 		testCase := &latest.TestCase{
 			ImageName:      "image",


### PR DESCRIPTION
Fixes: #9028

 - The original ask from #9028 is to enforce all operations under a builder scope to use cli when useCli is set to true when using docker, but after revisiting several issues linked in #9028, the core problem we want to fix is that when DOCKER_HOST env is not set,  `golang docker rest api client` use a hard coded value as docker engine host for example, ``unix:///var/run/docker.sock`` on mac, ``but docker command line client`` use the socket from `docker current context` as host. 
 - This pr changes the hard coded value by inspecting the host of `docker current context` with docker client, if the DOCKER_HOST is not set, we should use the value from `docker current context`.  If the value is set, both docker command line and golang rest client will honor the env variable. 
 - This approach should solve the linked issues in #9028, and much easier to maintain than duplicating similar logics with command line client. 
 
