### PR TITLE
feat: support metadata to start debugger in wait mode for g…

### DIFF
--- a/pkg/skaffold/debug/transform.go
+++ b/pkg/skaffold/debug/transform.go
@@ -67,6 +67,14 @@ type PortAllocator func(int32) int32
 // configurationRetriever retrieves an container image configuration
 type ConfigurationRetriever func(string) (ImageConfiguration, error)
 
+// DebuggerMetaData captures info for debug tranformers to construct the cli command appropriately
+type DebuggerMetaData struct {
+	// ShouldWait hints that the process should start and wait for the debugger to be attached.
+	// For kubernetes this derives from an annotation at Pod-Level skaffold.dev/debug-suspend and
+	// for docker from an image label skaffold.dev/debug-suspend.
+	ShouldWait bool
+}
+
 // ImageConfiguration captures information from a docker/oci image configuration.
 // It also includes a "artifact", usually containing the corresponding artifact's' image name from `skaffold.yaml`.
 type ImageConfiguration struct {
@@ -91,6 +99,20 @@ const (
 var entrypointLaunchers []string
 
 var Protocols = []string{}
+
+// ExtractDebuggerMetaData extracts and returns the appropriate DebuggerMetaData based on the passed map[string]string
+// which contains the context-appropriate metadata, e.g. for Kubernetes deployment the annotations and for Docker the image
+// Labels.
+func ExtractDebuggerMetaData(md map[string]string) *DebuggerMetaData {
+	dmd := &DebuggerMetaData{}
+
+	if md == nil {
+		return dmd
+	}
+
+	_, dmd.ShouldWait = md["skaffold.dev/debug-suspend"]
+	return dmd
+}
 
 // isEntrypointLauncher checks if the given entrypoint is a known entrypoint launcher,
 // meaning an entrypoint that treats the image's CMD as a command-line.

--- a/pkg/skaffold/debug/transform_go_test.go
+++ b/pkg/skaffold/debug/transform_go_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestNewDlvSpecDefaults(t *testing.T) {
 	spec := newDlvSpec(20)
-	expected := dlvSpec{mode: "exec", port: 20, apiVersion: 2, headless: true, log: false}
+	expected := dlvSpec{mode: "exec", port: 20, apiVersion: 2, headless: true, log: false, wait: true}
 	testutil.CheckDeepEqual(t, expected, spec, cmp.AllowUnexported(spec))
 }
 
@@ -40,14 +40,15 @@ func TestExtractDlvArg(t *testing.T) {
 		{nil, nil},
 		{[]string{"foo"}, nil},
 		{[]string{"foo", "--foo"}, nil},
-		{[]string{"dlv", "debug", "--headless"}, &dlvSpec{mode: "debug", headless: true, apiVersion: 2, log: false}},
-		{[]string{"dlv", "--headless", "exec"}, &dlvSpec{mode: "exec", headless: true, apiVersion: 2, log: false}},
-		{[]string{"dlv", "--headless", "exec", "--", "--listen=host:4345"}, &dlvSpec{mode: "exec", headless: true, apiVersion: 2, log: false}},
-		{[]string{"dlv", "test", "--headless", "--listen=host:4345"}, &dlvSpec{mode: "test", host: "host", port: 4345, headless: true, apiVersion: 2, log: false}},
-		{[]string{"dlv", "debug", "--headless", "--api-version=1"}, &dlvSpec{mode: "debug", headless: true, apiVersion: 1, log: false}},
-		{[]string{"dlv", "debug", "--listen=host:4345", "--headless", "--api-version=2", "--log"}, &dlvSpec{mode: "debug", host: "host", port: 4345, headless: true, apiVersion: 2, log: true}},
-		{[]string{"dlv", "debug", "--listen=:4345"}, &dlvSpec{mode: "debug", port: 4345, apiVersion: 2}},
-		{[]string{"dlv", "debug", "--listen=host:"}, &dlvSpec{mode: "debug", host: "host", apiVersion: 2}},
+		{[]string{"dlv", "debug", "--headless"}, &dlvSpec{mode: "debug", headless: true, apiVersion: 2, log: false, wait: true}},
+		{[]string{"dlv", "--headless", "exec"}, &dlvSpec{mode: "exec", headless: true, apiVersion: 2, log: false, wait: true}},
+		{[]string{"dlv", "--headless", "exec", "--", "--listen=host:4345"}, &dlvSpec{mode: "exec", headless: true, apiVersion: 2, log: false, wait: true}},
+		{[]string{"dlv", "test", "--headless", "--listen=host:4345"}, &dlvSpec{mode: "test", host: "host", port: 4345, headless: true, apiVersion: 2, log: false, wait: true}},
+		{[]string{"dlv", "debug", "--headless", "--api-version=1"}, &dlvSpec{mode: "debug", headless: true, apiVersion: 1, log: false, wait: true}},
+		{[]string{"dlv", "debug", "--listen=host:4345", "--headless", "--api-version=2", "--log"}, &dlvSpec{mode: "debug", host: "host", port: 4345, headless: true, apiVersion: 2, log: true, wait: true}},
+		{[]string{"dlv", "debug", "--listen=:4345"}, &dlvSpec{mode: "debug", port: 4345, apiVersion: 2, wait: true}},
+		{[]string{"dlv", "debug", "--listen=host:"}, &dlvSpec{mode: "debug", host: "host", apiVersion: 2, wait: true}},
+		{[]string{"dlv", "debug", "--listen=host:", "--continue"}, &dlvSpec{mode: "debug", host: "host", apiVersion: 2, wait: false}},
 	}
 	for _, test := range tests {
 		testutil.Run(t, strings.Join(test.in, " "), func(t *testutil.T) {

--- a/pkg/skaffold/debug/transform_netcore.go
+++ b/pkg/skaffold/debug/transform_netcore.go
@@ -80,7 +80,7 @@ func (t netcoreTransformer) IsApplicable(config ImageConfiguration) bool {
 
 // Apply configures a container definition for vsdbg.
 // Returns a simple map describing the debug configuration details.
-func (t netcoreTransformer) Apply(adapter types.ContainerAdapter, config ImageConfiguration, portAlloc PortAllocator, overrideProtocols []string) (types.ContainerDebugConfiguration, string, error) {
+func (t netcoreTransformer) Apply(adapter types.ContainerAdapter, config ImageConfiguration, portAlloc PortAllocator, overrideProtocols []string, dmd *DebuggerMetaData) (types.ContainerDebugConfiguration, string, error) {
 	container := adapter.GetContainer()
 	log.Entry(context.TODO()).Infof("Configuring %q for netcore debugging", container.Name)
 

--- a/pkg/skaffold/debug/transform_nodejs.go
+++ b/pkg/skaffold/debug/transform_nodejs.go
@@ -87,7 +87,7 @@ func (t nodeTransformer) IsApplicable(config ImageConfiguration) bool {
 
 // Apply configures a container definition for NodeJS Chrome V8 Inspector.
 // Returns a simple map describing the debug configuration details.
-func (t nodeTransformer) Apply(adapter types.ContainerAdapter, config ImageConfiguration, portAlloc PortAllocator, overrideProtocols []string) (types.ContainerDebugConfiguration, string, error) {
+func (t nodeTransformer) Apply(adapter types.ContainerAdapter, config ImageConfiguration, portAlloc PortAllocator, overrideProtocols []string, dmd *DebuggerMetaData) (types.ContainerDebugConfiguration, string, error) {
 	container := adapter.GetContainer()
 	log.Entry(context.TODO()).Infof("Configuring %q for node.js debugging", container.Name)
 
@@ -95,6 +95,12 @@ func (t nodeTransformer) Apply(adapter types.ContainerAdapter, config ImageConfi
 	spec := retrieveNodeInspectSpec(config)
 	if spec == nil {
 		spec = &inspectSpec{host: "0.0.0.0", port: portAlloc(defaultDevtoolsPort)}
+		if dmd != nil {
+			spec.brk = dmd.ShouldWait
+		} else {
+			spec.brk = false
+		}
+
 		switch {
 		case isLaunchingNode(config.Entrypoint):
 			container.Command = rewriteNodeCommandLine(config.Entrypoint, *spec)

--- a/pkg/skaffold/docker/debugger/transform.go
+++ b/pkg/skaffold/docker/debugger/transform.go
@@ -58,7 +58,9 @@ func transformImage(ctx context.Context, artifact graph.Artifact, cfg *container
 	// the set of image IDs required to provide debugging support files
 	requiredSupportImages := make(map[string]bool)
 
-	if configuration, requiredImage, err := debug.TransformContainer(adapter, imageConfig, portAlloc); err == nil {
+	dmd := debug.ExtractDebuggerMetaData(imageConfig.Labels)
+
+	if configuration, requiredImage, err := debug.TransformContainer(adapter, imageConfig, portAlloc, dmd); err == nil {
 		configurations[adapter.GetContainer().Name] = configuration
 		if len(requiredImage) > 0 {
 			log.Entry(ctx).Infof("%q requires debugging support image %q", cfg.Image, requiredImage)

--- a/pkg/skaffold/kubernetes/debugging/debug_test.go
+++ b/pkg/skaffold/kubernetes/debugging/debug_test.go
@@ -41,7 +41,7 @@ func (t testTransformer) MatchRuntime(config debug.ImageConfiguration) bool {
 	return true
 }
 
-func (t testTransformer) Apply(adapter types.ContainerAdapter, config debug.ImageConfiguration, portAlloc debug.PortAllocator, overrideProtocols []string) (types.ContainerDebugConfiguration, string, error) {
+func (t testTransformer) Apply(adapter types.ContainerAdapter, config debug.ImageConfiguration, portAlloc debug.PortAllocator, overrideProtocols []string, dmd *debug.DebuggerMetaData) (types.ContainerDebugConfiguration, string, error) {
 	port := portAlloc(9999)
 	container := adapter.GetContainer()
 	container.Ports = append(container.Ports, types.ContainerPort{Name: "test", ContainerPort: port})

--- a/pkg/skaffold/kubernetes/debugging/transform.go
+++ b/pkg/skaffold/kubernetes/debugging/transform.go
@@ -267,7 +267,10 @@ func rewriteContainers(metadata *metav1.ObjectMeta, podSpec *v1.PodSpec, retriev
 		a := adapter.NewAdapter(&container)
 		// requiredImage, if not empty, is the image ID providing the debugging support files
 		// `err != nil` means that the container did not or could not be transformed
-		if configuration, requiredImage, err := debug.TransformContainer(a, imageConfig, portAlloc); err == nil {
+
+		dmd := debug.ExtractDebuggerMetaData(metadata.Annotations)
+
+		if configuration, requiredImage, err := debug.TransformContainer(a, imageConfig, portAlloc, dmd); err == nil {
 			configurations[container.Name] = configuration
 			podSpec.Containers[i] = container // apply any configuration changes
 			if len(requiredImage) > 0 {

--- a/pkg/skaffold/kubernetes/debugging/transform_netcore_test.go
+++ b/pkg/skaffold/kubernetes/debugging/transform_netcore_test.go
@@ -63,7 +63,7 @@ func TestNetcoreTransformerApply(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			adapter := adapter.NewAdapter(&test.containerSpec)
-			config, image, err := debug.NewNetcoreTransformer().Apply(adapter, test.configuration, identity, nil)
+			config, image, err := debug.NewNetcoreTransformer().Apply(adapter, test.configuration, identity, nil, nil)
 			adapter.Apply()
 
 			t.CheckError(test.shouldErr, err)


### PR DESCRIPTION
Implements https://github.com/GoogleContainerTools/skaffold/issues/4870: 

* support for starting the respective runtime debugger in "wait" mode for go, python, nodejs, jvm if the container image has the label `skaffold.dev/debug-suspend` [docker deploy]
* support for starting the respective runtime debugger in "wait" mode for go, python, nodejs, jvm if the pod template has the annotation the `skaffold.dev/debug-suspend` [k8s deploy]