### PR TITLE
Debug: Output marshalled config used for patching

### DIFF
--- a/pkg/skaffold/schema/profiles.go
+++ b/pkg/skaffold/schema/profiles.go
@@ -275,6 +275,8 @@ func applyProfile(config *latest.SkaffoldConfig, fieldsOverrodeByProfile map[str
 		return err
 	}
 
+	log.Entry(context.TODO()).Debugf("Use intermediate config for patching:\n%s", string(buf))
+
 	for i, patch := range profile.Patches {
 		// Default patch operation to `replace`
 		op := patch.Op


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**Description**
Patching sometimes fails when due to unmarshal and remarshaling, values get omitted.
At least output the remarshalled form when debugging.

**User facing changes (remove if N/A)**
When debugging with profile patching configured, there now will be more verbose debug output.
