### PR TITLE
docs: fix releaseNoteLink for v2.8.0

### DIFF
--- a/docs-v2/content/en/schemas/version-mappings/v4beta7-version.json
+++ b/docs-v2/content/en/schemas/version-mappings/v4beta7-version.json
@@ -1,1 +1,1 @@
-{"binVersion":"2.8.0","releaseNoteLink":"https://github.com/GoogleContainerTools/skaffold/releases/tag/2.8.0"}
+{"binVersion":"2.8.0","releaseNoteLink":"https://github.com/GoogleContainerTools/skaffold/releases/tag/v2.8.0"}


### PR DESCRIPTION
**Description**

Fixes the link to the v2.8.0 changelog on https://skaffold.dev/docs/references/yaml/.

The current link leads to a 404. The actual tag has a `v` prefix.

<!-- Describe your changes here. The more detail, the easier the review! -->

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->

**Follow-up Work (remove if N/A)**
<!-- Mention any related follow up work to this PR. -->

