### PR TITLE
fix: custom crd not printing streams logs

### DIFF
--- a/pkg/skaffold/deploy/helm/helm.go
+++ b/pkg/skaffold/deploy/helm/helm.go
@@ -303,7 +303,7 @@ func (h *Deployer) Deploy(ctx context.Context, out io.Writer, builds []graph.Art
 	for ns := range nsMap {
 		namespaces = append(namespaces, ns)
 	}
-	deployedImages, _ := manifests.GetImages(manifest.NewResourceSelectorImages(manifest.TransformAllowlist, manifest.TransformDenylist))
+	deployedImages, _ := manifests.GetImages(manifest.NewResourceSelectorImages(h.transformableAllowlist, h.transformableDenylist))
 
 	h.TrackBuildArtifacts(builds, deployedImages)
 	h.trackNamespaces(namespaces)

--- a/pkg/skaffold/deploy/helm/helm.go
+++ b/pkg/skaffold/deploy/helm/helm.go
@@ -295,7 +295,7 @@ func (h *Deployer) Deploy(ctx context.Context, out io.Writer, builds []graph.Art
 	// Otherwise, templates have no way to use the images that were built.
 	// Skip warning for multi-config projects as there can be artifacts without any usage in the current deployer.
 	if !h.isMultiConfig {
-		warnAboutUnusedImages(builds, manifests)
+		h.warnAboutUnusedImages(builds, manifests)
 	}
 
 	// Collect namespaces in a string
@@ -622,9 +622,9 @@ func (h *Deployer) packageChart(ctx context.Context, r latest.HelmRelease) (stri
 	return output[idx:], nil
 }
 
-func warnAboutUnusedImages(builds []graph.Artifact, manifests manifest.ManifestList) {
+func (h *Deployer) warnAboutUnusedImages(builds []graph.Artifact, manifests manifest.ManifestList) {
 	seen := map[string]bool{}
-	images, _ := manifests.GetImages(manifest.NewResourceSelectorImages(manifest.TransformAllowlist, manifest.TransformDenylist))
+	images, _ := manifests.GetImages(manifest.NewResourceSelectorImages(h.transformableAllowlist, h.transformableDenylist))
 	for _, a := range images {
 		seen[a.Tag] = true
 	}

--- a/pkg/skaffold/deploy/kubectl/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl.go
@@ -268,7 +268,7 @@ func (k *Deployer) Deploy(ctx context.Context, out io.Writer, builds []graph.Art
 		endTrace(instrumentation.TraceEndError(err))
 		return err
 	}
-	deployedImages, _ := manifests.GetImages(manifest.NewResourceSelectorImages(manifest.TransformAllowlist, manifest.TransformDenylist))
+	deployedImages, _ := manifests.GetImages(manifest.NewResourceSelectorImages(k.transformableAllowlist, k.transformableDenylist))
 
 	k.TrackBuildArtifacts(builds, deployedImages)
 	k.statusMonitor.RegisterDeployManifests(manifests)


### PR DESCRIPTION
**Description**
my company uses a custom CRD (openkruise https://openkruise.io/) to manage workloads. 
During local development, we discovered that aggregated logs were not being printed.  Aggregated logs are crucial for microservices architecture.

![dce3f3fb-d041-4a1d-8235-35be90b628a6](https://github.com/GoogleContainerTools/skaffold/assets/14088506/283f7ae9-eba0-41ae-b319-fc19b4624c85)


**skaffold.yaml**
```
apiVersion: skaffold/v4beta7
kind: Config
build:
  artifacts:
  - image: skaffold-example
  local:
    push: false
manifests:
  rawYaml:
  - sts.yaml

resourceSelector:
  allow:
    - groupKind: CloneSet.apps.kruise.io
      image:
        - .*
      labels:
        - .*
    - groupKind: StatefulSet.apps.kruise.io
      image:
        - .*
      labels:
        - .*
```

**sts.yaml**
```
apiVersion: apps.kruise.io/v1beta1
kind: StatefulSet
metadata:
  name: getting-started
spec:
  replicas: 1
  serviceName: getting-started
  selector:
    matchLabels:
      app: getting-started
  template:
    metadata:
      labels:
        app: getting-started
    spec:
      containers:
      - name: getting-started
        image: skaffold-example
        imagePullPolicy: IfNotPresent
```

**User facing changes (remove if N/A)**
I found that the reason was the absence of corresponding GVK (GroupVersionKind) in `manifest.TransformAllowlist` and `manifest.TransformDenylist`. 

My solution is to pass ConsolidateTransformConfiguration into the NewResourceSelectorImages method because we can configure resourceSelector in the skaffold.yaml file.


