### PR TITLE
chore: add new skip-unreachable-dirs to not error on init command when a dir can not be read

### DIFF
--- a/cmd/skaffold/app/cmd/init.go
+++ b/cmd/skaffold/app/cmd/init.go
@@ -36,6 +36,7 @@ var (
 	cliKubernetesManifests   []string
 	skipBuild                bool
 	skipDeploy               bool
+	skipUnreachableDirs      bool
 	force                    bool
 	analyze                  bool
 	enableJibInit            bool
@@ -70,6 +71,7 @@ func NewCmdInit() *cobra.Command {
 			{Value: &enableBuildpacksInit, Name: "XXenableBuildpacksInit", DefValue: true, Usage: "", Hidden: true, IsEnum: true},
 			{Value: &buildpacksBuilder, Name: "XXdefaultBuildpacksBuilder", DefValue: "gcr.io/buildpacks/builder:v1", Usage: "", Hidden: true},
 			{Value: &enableManifestGeneration, Name: "generate-manifests", DefValue: false, Usage: "Allows skaffold to try and generate basic kubernetes resources to get your project started", IsEnum: true},
+			{Value: &skipUnreachableDirs, Name: "skip-unreachable-dirs", DefValue: false, Usage: "Instead of erroring, it will skip the directories that cannot be accessed due to permissions", IsEnum: true},
 		}).
 		NoArgs(doInit)
 }
@@ -83,6 +85,7 @@ func doInit(ctx context.Context, out io.Writer) error {
 		CliKubernetesManifests:   cliKubernetesManifests,
 		SkipBuild:                skipBuild,
 		SkipDeploy:               skipDeploy,
+		SkipUnreachableDirs:      skipUnreachableDirs,
 		Force:                    force,
 		Analyze:                  analyze,
 		EnableJibInit:            enableJibInit,

--- a/docs-v2/content/en/docs/references/cli/_index.md
+++ b/docs-v2/content/en/docs/references/cli/_index.md
@@ -1073,6 +1073,7 @@ Options:
   -m, --module=[]: Filter Skaffold configs to only the provided named modules
       --remote-cache-dir='': Specify the location of the remote cache (default $HOME/.skaffold/remote-cache)
       --skip-build=false: Skip generating build artifacts in Skaffold config
+      --skip-unreachable-dirs=false: Instead of erroring, it will skip the directories that cannot be accessed due to permissions
       --sync-remote-cache='always': Controls how Skaffold manages the remote config cache (see `remote-cache-dir`). One of `always` (default), `missing`, or `never`. `always` syncs remote repositories to latest on access. `missing` only clones remote repositories if they do not exist locally. `never` means the user takes responsibility for updating remote repositories.
 
 Usage:
@@ -1096,6 +1097,7 @@ Env vars:
 * `SKAFFOLD_MODULE` (same as `--module`)
 * `SKAFFOLD_REMOTE_CACHE_DIR` (same as `--remote-cache-dir`)
 * `SKAFFOLD_SKIP_BUILD` (same as `--skip-build`)
+* `SKAFFOLD_SKIP_UNREACHABLE_DIRS` (same as `--skip-unreachable-dirs`)
 * `SKAFFOLD_SYNC_REMOTE_CACHE` (same as `--sync-remote-cache`)
 
 ### skaffold options

--- a/pkg/skaffold/initializer/config/config.go
+++ b/pkg/skaffold/initializer/config/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	CliKubernetesManifests   []string
 	SkipBuild                bool
 	SkipDeploy               bool
+	SkipUnreachableDirs      bool
 	Force                    bool
 	Analyze                  bool
 	EnableJibInit            bool // TODO: Remove this parameter


### PR DESCRIPTION
Fixes: #9164

**Description**
This PR adds a new flag, `--skip-unreachable-dirs` to change the behaviour of `skaffold init` command so it doesn't throw an error when it tries to read a folder for which it doesn't have read permissions, instead it will skip the folder and continue with the initialization.

**Test**
To test it, using the same repro steps from #9164, now running `skaffold init --analyze --skip-unreachable-dirs` shouldn't return an error.