### PR TITLE
fix: Enable docker build without cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,7 +299,7 @@ integration-in-docker: skaffold-builder-ci
 		-e INTEGRATION_TEST_ARGS=$(INTEGRATION_TEST_ARGS) \
 		-e IT_PARTITION=$(IT_PARTITION) \
 		gcr.io/$(GCP_PROJECT)/skaffold-builder \
-		make integration
+		make integration-tests
 
 .PHONY: submit-build-trigger
 submit-build-trigger:

--- a/pkg/skaffold/build/docker/docker.go
+++ b/pkg/skaffold/build/docker/docker.go
@@ -72,7 +72,7 @@ func (b *Builder) Build(ctx context.Context, out io.Writer, a *latest.Artifact, 
 	// ignore useCLI boolean if buildkit is enabled since buildkit is only implemented for docker CLI at the moment in skaffold.
 	// we might consider a different approach in the future.
 	// use CLI for cross-platform builds
-	if b.useCLI || (b.useBuildKit != nil && *b.useBuildKit) || len(a.DockerArtifact.CliFlags) > 0 || matcher.IsNotEmpty() {
+	if b.useCLI || (b.useBuildKit != nil && *b.useBuildKit) || len(a.DockerArtifact.CliFlags) > 0 || matcher.IsCrossPlatform() {
 		imageID, err = b.dockerCLIBuild(ctx, output.GetUnderlyingWriter(out), a.ImageName, a.Workspace, dockerfile, a.ArtifactType.DockerArtifact, opts, pl)
 	} else {
 		imageID, err = b.localDocker.Build(ctx, out, a.Workspace, a.ImageName, a.ArtifactType.DockerArtifact, opts)


### PR DESCRIPTION
Fixes: #9103

## Description: 
 - when running `dev, run, debug`  command, skaffold always uses cli to build for docker builder in build phase 
 - This pr changes the part of a `if` condition that enable docker-cli by changing `|| matcher.isEmpty` to `|| matcher.isCrossPlatform`, So when user does not need to build cross-platform image, they don't have to have docker-cli installed, I think that what the comment was meant to as well.
 - I was trying to enable docker build without cli for cross-platfom builds as well, but tests are failing on kokoro, that will need some time to test and verify, I'll do it in a separate pr. 
 - Also, remove the duplicate skaffold install, as we already built it when building skaffold-builder image https://github.com/GoogleContainerTools/skaffold/blob/2fc43f6a3103b23c4e78bc57407dcffb42cf0597/deploy/skaffold/Dockerfile#L22  
