### PR TITLE
feat: implement kaniko.imagePullSecret for pulling images from private registry w/ auth

### DIFF
--- a/pkg/skaffold/build/cluster/pod.go
+++ b/pkg/skaffold/build/cluster/pod.go
@@ -95,6 +95,13 @@ func (b *Builder) kanikoPodSpec(artifact *latest.KanikoArtifact, tag string, pla
 		addSecretVolume(pod, kaniko.DefaultSecretName, b.ClusterDetails.PullSecretMountPath, b.ClusterDetails.PullSecretName)
 	}
 
+	// Add secret for pulling kaniko images from a private registry
+	if artifact.ImagePullSecret != "" {
+		pod.Spec.ImagePullSecrets = []v1.LocalObjectReference{{
+			Name: artifact.ImagePullSecret,
+		}}
+	}
+
 	// Add host path volume for cache
 	if artifact.Cache != nil && artifact.Cache.HostPath != "" {
 		addHostPathVolume(pod, kaniko.DefaultCacheDirName, kaniko.DefaultCacheDirMountPath, artifact.Cache.HostPath)

--- a/pkg/skaffold/build/cluster/pod_test.go
+++ b/pkg/skaffold/build/cluster/pod_test.go
@@ -181,9 +181,10 @@ func TestKanikoArgs(t *testing.T) {
 
 func TestKanikoPodSpec(t *testing.T) {
 	artifact := &latest.KanikoArtifact{
-		Image:          "image",
-		DockerfilePath: "Dockerfile",
-		InitImage:      "init/image",
+		Image:          	"image",
+		DockerfilePath: 	"Dockerfile",
+		InitImage:      	"init/image",
+		ImagePullSecret:	"image-pull-secret",
 		Destination: []string{
 			"gcr.io/foo/bar:test-1",
 			"gcr.io/foo/bar:test-2",
@@ -352,6 +353,9 @@ func TestKanikoPodSpec(t *testing.T) {
 						v1.ResourceCPU: resource.MustParse("0.5"),
 					},
 				},
+			}},
+			ImagePullSecrets: []v1.LocalObjectReference{{
+				Name: "image-pull-secret",
 			}},
 			ServiceAccountName: "aVerySpecialSA",
 			SecurityContext: &v1.PodSecurityContext{

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -1465,6 +1465,9 @@ type KanikoArtifact struct {
 	// Defaults to the latest released version of `gcr.io/kaniko-project/executor`.
 	Image string `yaml:"image,omitempty"`
 
+	// ImagePullSecret is the name of the Kubernetes secret for pulling kaniko image and kaniko init image from a private registry
+	ImagePullSecret string `yaml:"imagePullSecret,omitempty"`
+
 	// Destination is additional tags to push.
 	Destination []string `yaml:"destination,omitempty"`
 


### PR DESCRIPTION
Fixes: #9170
**Related**: #9183 (closed), #9190 
**Merge before/after**: after #9190 

**Description**

Implements the config option, see #9183 and #9170

**User facing changes (remove if N/A)**
n/a
**Follow-up Work (remove if N/A)**
n/a
