### PR TITLE
feat: Skaffold post renderer

### DIFF
--- a/docs-v2/content/en/schemas/v4beta9.json
+++ b/docs-v2/content/en/schemas/v4beta9.json
@@ -3445,6 +3445,68 @@
       "description": "describes a resource to port forward.",
       "x-intellij-html-description": "describes a resource to port forward."
     },
+    "PostRenderHookItem": {
+      "properties": {
+        "host": {
+          "$ref": "#/definitions/PostRenderHostHook",
+          "description": "describes a single lifecycle hook to run on the host machine.",
+          "x-intellij-html-description": "describes a single lifecycle hook to run on the host machine."
+        }
+      },
+      "preferredOrder": [
+        "host"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "describes a single lifecycle hook to execute after each render step.",
+      "x-intellij-html-description": "describes a single lifecycle hook to execute after each render step."
+    },
+    "PostRenderHostHook": {
+      "required": [
+        "command"
+      ],
+      "properties": {
+        "command": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "command to execute.",
+          "x-intellij-html-description": "command to execute.",
+          "default": "[]"
+        },
+        "dir": {
+          "type": "string",
+          "description": "specifies the working directory of the command. If empty, the command runs in the calling process's current directory.",
+          "x-intellij-html-description": "specifies the working directory of the command. If empty, the command runs in the calling process's current directory."
+        },
+        "os": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "an optional slice of operating system names. If the host machine OS is different, then it skips execution.",
+          "x-intellij-html-description": "an optional slice of operating system names. If the host machine OS is different, then it skips execution.",
+          "default": "[]"
+        },
+        "withChange": {
+          "type": "boolean",
+          "description": "preserves changes made on the manifests by the hook.",
+          "x-intellij-html-description": "preserves changes made on the manifests by the hook.",
+          "default": "false"
+        }
+      },
+      "preferredOrder": [
+        "command",
+        "os",
+        "dir",
+        "withChange"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "describes a post render hook definition to execute on the host machine.",
+      "x-intellij-html-description": "describes a post render hook definition to execute on the host machine."
+    },
     "Profile": {
       "required": [
         "name"
@@ -3699,7 +3761,7 @@
       "properties": {
         "after": {
           "items": {
-            "$ref": "#/definitions/RenderHookItem"
+            "$ref": "#/definitions/PostRenderHookItem"
           },
           "type": "array",
           "description": "describes the list of lifecycle hooks to execute *after* each render step.",

--- a/integration/examples/lifecycle-hooks/k8s-pod.yaml
+++ b/integration/examples/lifecycle-hooks/k8s-pod.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: getting-started
+  labels:
+    tier: test-1
 spec:
   containers:
   - name: getting-started

--- a/integration/examples/lifecycle-hooks/skaffold.yaml
+++ b/integration/examples/lifecycle-hooks/skaffold.yaml
@@ -9,7 +9,7 @@ manifests:
           command: ["sh", "-c", "echo pre-render host hook running on $(hostname)!"]
     after:
       - host:
-          command: ["sh", "post-render.sh", ]
+          command: ["sh", "-c", "echo post-render host hook running on $(hostname)!"]
 build:
   hooks:
     before:

--- a/integration/examples/lifecycle-hooks/skaffold.yaml
+++ b/integration/examples/lifecycle-hooks/skaffold.yaml
@@ -9,7 +9,7 @@ manifests:
           command: ["sh", "-c", "echo pre-render host hook running on $(hostname)!"]
     after:
       - host:
-          command: ["sh", "-c", "echo post-render host hook running on $(hostname)!"]
+          command: ["sh", "post-render.sh", ]
 build:
   hooks:
     before:

--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -1052,6 +1052,7 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
+  namespace: mynamespace
   labels:
     this-is-from: kustomization.yaml
   name: my-pod-1

--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -444,29 +444,6 @@ spec:
       containers:
       - image: skaffold-helm:latest
         name: skaffold-helm
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app: skaffold-helm
-    skaffold.dev/run-id: phony-run-id
-  name: skaffold-helm
-  namespace: helm-namespace-2
-spec:
-  replicas: 2
-  selector:
-    matchLabels:
-      app: skaffold-helm
-  template:
-    metadata:
-      labels:
-        app: skaffold-helm
-        skaffold.dev/run-id: phony-run-id
-    spec:
-      containers:
-      - image: skaffold-helm:latest
-        name: skaffold-helm
 `,
 		}, {
 			description:      "Template with Release.namespace set from skaffold.yaml file deploy.helm.releases.namespace - v1 skaffold schema",

--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -2057,23 +2057,6 @@ spec:
 `,
 		},
 		{
-			description: "a single module project, two hooks, one with change, one not",
-			projectDir:  "testdata/post-render-hooks",
-			args:        []string{"-m", "m1", "-p", "one-change-one-not", "-t", "customtag"},
-			expectedOutput: `apiVersion: v1
-kind: Pod
-metadata:
-  name: module1
-  labels:
-    app1: before-change-1
-    app2: after-change-2
-spec:
-  containers:
-  - image: us-central1-docker.pkg.dev/k8s-skaffold/testing/multi-config-module1:customtag
-    name: module1
-`,
-		},
-		{
 			description: "multi-module project, two hooks, two changes",
 			projectDir:  "testdata/post-render-hooks",
 			args:        []string{"-m", "m1,m2", "-p", "change1", "-t", "customtag"},
@@ -2093,7 +2076,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   labels:
-    app1: after-change-1
+    app1: before-change-1
   name: module2
 spec:
   containers:

--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -472,7 +472,8 @@ spec:
       - image: skaffold-helm:latest
         name: skaffold-helm
 `,
-		}, {
+		},
+		{
 			description:      "Template replicaCount with --set flag",
 			dir:              "testdata/helm-render-simple",
 			args:             []string{"--set", "replicaCount=3"},
@@ -500,7 +501,8 @@ spec:
       - image: skaffold-helm:latest
         name: skaffold-helm
 `,
-		}, {
+		},
+		{
 			description:      "With Helm global flags",
 			dir:              "testdata/helm-render",
 			args:             []string{"-p", "helm-render-with-global-flags"},
@@ -550,7 +552,7 @@ spec:
         skaffold.dev/run-id: phony-run-id
     spec:
       containers:
-      - image: us-central1-docker.pkg.dev/k8s-skaffold/testing/skaffold-helm:sha256-nonsenselettersandnumbers
+      - image: us-central1-docker.pkg.dev/k8s-skaffold/testing/skaffold-helm:latest
         imagePullPolicy: always
         name: skaffold-helm
         ports:

--- a/integration/testdata/post-render-hooks/module1/Dockerfile
+++ b/integration/testdata/post-render-hooks/module1/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.18 as builder
+WORKDIR /code
+COPY main.go .
+# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
+ARG SKAFFOLD_GO_GCFLAGS
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app main.go
+
+FROM alpine:3
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
+CMD ["./app"]
+COPY --from=builder /app .

--- a/integration/testdata/post-render-hooks/module1/k8s/k8s-pod.yaml
+++ b/integration/testdata/post-render-hooks/module1/k8s/k8s-pod.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: module1
+  labels:
+    app1: before-change-1
+    app2: before-change-2
+spec:
+  containers:
+  - name: module1
+    image: multi-config-module1

--- a/integration/testdata/post-render-hooks/module1/main.go
+++ b/integration/testdata/post-render-hooks/module1/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+	"time"
+)
+
+func main() {
+	for {
+		fmt.Printf("Hello module-1! Running on %s/%s\n", runtime.GOOS, runtime.GOARCH)
+
+		time.Sleep(time.Second * 1)
+	}
+}

--- a/integration/testdata/post-render-hooks/module1/skaffold.yaml
+++ b/integration/testdata/post-render-hooks/module1/skaffold.yaml
@@ -1,0 +1,50 @@
+apiVersion: skaffold/v4beta9
+kind: Config
+metadata:
+  name: m1
+build:
+  artifacts:
+  - image: multi-config-module1
+    context: .
+manifests:
+  rawYaml:
+  - k8s/k8s-pod.yaml
+deploy:
+  kubectl: {}
+profiles:
+  - name: change1
+    manifests:
+      hooks:
+        after:
+          - host:
+              command:
+                - "sed"
+                - "s/before-change-1/after-change-1/g"
+              withChange: true
+  - name: two-changes
+    manifests:
+      hooks:
+        after:
+          - host:
+              command:
+                - "sed"
+                - "s/before-change-2/after-change-2/g"
+              withChange: true
+          - host:
+              command:
+                - "sed"
+                - "s/before-change-1/after-change-1/g"
+              withChange: true
+  - name: one-change-one-not
+    manifests:
+      hooks:
+        after:
+          - host:
+              command:
+                - "sed"
+                - "s/before-change-2/after-change-2/g"
+              withChange: true
+          - host:
+              command:
+                - "sed"
+                - "s/before-change-1/after-change-1/g"

--- a/integration/testdata/post-render-hooks/module2/Dockerfile
+++ b/integration/testdata/post-render-hooks/module2/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.18 as builder
+WORKDIR /code
+COPY main.go .
+# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
+ARG SKAFFOLD_GO_GCFLAGS
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app main.go
+
+FROM alpine:3
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
+CMD ["./app"]
+COPY --from=builder /app .

--- a/integration/testdata/post-render-hooks/module2/k8s/k8s-pod.yaml
+++ b/integration/testdata/post-render-hooks/module2/k8s/k8s-pod.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: module2
+  labels:
+    app1: before-change-1
+spec:
+  containers:
+  - name: module2
+    image: multi-config-module2

--- a/integration/testdata/post-render-hooks/module2/main.go
+++ b/integration/testdata/post-render-hooks/module2/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+	"time"
+)
+
+func main() {
+	for {
+		fmt.Printf("Hello module-2! Running on %s/%s\n", runtime.GOOS, runtime.GOARCH)
+
+		time.Sleep(time.Second * 1)
+	}
+}

--- a/integration/testdata/post-render-hooks/module2/skaffold.yaml
+++ b/integration/testdata/post-render-hooks/module2/skaffold.yaml
@@ -1,0 +1,31 @@
+apiVersion: skaffold/v4beta9
+kind: Config
+metadata:
+  name: m2
+build:
+  artifacts:
+  - image: multi-config-module2
+    context: .
+manifests:
+  rawYaml:
+  - k8s/k8s-pod.yaml
+deploy:
+  kubectl: {}
+profiles:
+  - name: change2
+    manifests:
+      hooks:
+        after:
+          - host:
+              command:
+                - "sed"
+                - "s/before-change-1/after-change-1/g"
+              withChange: true
+  - name: nochange2
+    manifests:
+      hooks:
+        after:
+          - host:
+              command:
+                - "sed"
+                - "s/before-change-1/after-change-1/g"

--- a/integration/testdata/post-render-hooks/skaffold.yaml
+++ b/integration/testdata/post-render-hooks/skaffold.yaml
@@ -1,0 +1,5 @@
+apiVersion: skaffold/v4beta9
+kind: Config
+requires:
+  - path: ./module1
+  - path: ./module2

--- a/pkg/skaffold/hooks/build.go
+++ b/pkg/skaffold/hooks/build.go
@@ -18,6 +18,7 @@ package hooks
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -78,7 +79,7 @@ func (r buildRunner) run(ctx context.Context, out io.Writer, hooks []latest.Host
 	env := r.getEnv()
 	for _, h := range hooks {
 		hook := hostHook{h, env}
-		if err := hook.run(ctx, out); err != nil {
+		if err := hook.run(ctx, nil, out); err != nil && !errors.Is(err, &Skip{}) {
 			return err
 		}
 	}

--- a/pkg/skaffold/hooks/build_test.go
+++ b/pkg/skaffold/hooks/build_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/GoogleContainerTools/skaffold/v2/testutil"
 )
 
+const Windows = "windows"
+
 func TestBuildHooks(t *testing.T) {
 	workDir, _ := filepath.Abs("./foo")
 	tests := []struct {
@@ -97,13 +99,13 @@ func TestBuildHooks(t *testing.T) {
 				LifecycleHooks: latest.BuildHooks{
 					PreHooks: []latest.HostHook{
 						{
-							OS:      []string{"windows"},
+							OS:      []string{Windows},
 							Command: []string{"cmd.exe", "/C", "echo pre-hook running with SKAFFOLD_IMAGE=%SKAFFOLD_IMAGE%,SKAFFOLD_PUSH_IMAGE=%SKAFFOLD_PUSH_IMAGE%,SKAFFOLD_IMAGE_REPO=%SKAFFOLD_IMAGE_REPO%,SKAFFOLD_IMAGE_TAG=%SKAFFOLD_IMAGE_TAG%,SKAFFOLD_BUILD_CONTEXT=%SKAFFOLD_BUILD_CONTEXT%"},
 						},
 					},
 					PostHooks: []latest.HostHook{
 						{
-							OS:      []string{"windows"},
+							OS:      []string{Windows},
 							Command: []string{"cmd.exe", "/C", "echo post-hook running with SKAFFOLD_IMAGE=%SKAFFOLD_IMAGE%,SKAFFOLD_PUSH_IMAGE=%SKAFFOLD_PUSH_IMAGE%,SKAFFOLD_IMAGE_REPO=%SKAFFOLD_IMAGE_REPO%,SKAFFOLD_IMAGE_TAG=%SKAFFOLD_IMAGE_TAG%,SKAFFOLD_BUILD_CONTEXT=%SKAFFOLD_BUILD_CONTEXT%"},
 						},
 					},
@@ -122,13 +124,13 @@ func TestBuildHooks(t *testing.T) {
 				LifecycleHooks: latest.BuildHooks{
 					PreHooks: []latest.HostHook{
 						{
-							OS:      []string{"windows"},
+							OS:      []string{Windows},
 							Command: []string{"cmd.exe", "/C", "echo pre-hook running with SKAFFOLD_IMAGE=%SKAFFOLD_IMAGE%,SKAFFOLD_PUSH_IMAGE=%SKAFFOLD_PUSH_IMAGE%,SKAFFOLD_IMAGE_REPO=%SKAFFOLD_IMAGE_REPO%,SKAFFOLD_IMAGE_TAG=%SKAFFOLD_IMAGE_TAG%,SKAFFOLD_BUILD_CONTEXT=%SKAFFOLD_BUILD_CONTEXT%"},
 						},
 					},
 					PostHooks: []latest.HostHook{
 						{
-							OS:      []string{"windows"},
+							OS:      []string{Windows},
 							Command: []string{"cmd.exe", "/C", "echo post-hook running with SKAFFOLD_IMAGE=%SKAFFOLD_IMAGE%,SKAFFOLD_PUSH_IMAGE=%SKAFFOLD_PUSH_IMAGE%,SKAFFOLD_IMAGE_REPO=%SKAFFOLD_IMAGE_REPO%,SKAFFOLD_IMAGE_TAG=%SKAFFOLD_IMAGE_TAG%,SKAFFOLD_BUILD_CONTEXT=%SKAFFOLD_BUILD_CONTEXT%"},
 						},
 					},
@@ -141,7 +143,7 @@ func TestBuildHooks(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			if test.requiresWindowsOS != (runtime.GOOS == "windows") {
+			if test.requiresWindowsOS != (runtime.GOOS == Windows) {
 				t.Skip()
 			}
 			opts, err := NewBuildEnvOpts(&test.artifact, test.image, test.pushImage)

--- a/pkg/skaffold/hooks/deploy.go
+++ b/pkg/skaffold/hooks/deploy.go
@@ -18,6 +18,7 @@ package hooks
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -111,7 +112,7 @@ func (r deployRunner) run(ctx context.Context, out io.Writer, hooks []latest.Dep
 	for _, h := range hooks {
 		if h.HostHook != nil {
 			hook := hostHook{*h.HostHook, env}
-			if err := hook.run(ctx, out); err != nil {
+			if err := hook.run(ctx, nil, out); err != nil && !errors.Is(err, &Skip{}) {
 				return err
 			}
 		} else if h.ContainerHook != nil {

--- a/pkg/skaffold/hooks/host_test.go
+++ b/pkg/skaffold/hooks/host_test.go
@@ -32,6 +32,7 @@ func TestRun(t *testing.T) {
 		requiresWindowsOS bool
 		hook              hostHook
 		expected          string
+		shouldErr         bool
 	}{
 		{
 			description: "linux/darwin host hook on matching host",
@@ -46,6 +47,7 @@ func TestRun(t *testing.T) {
 		},
 		{
 			description: "windows host hook on non-matching host",
+			shouldErr:   true,
 			hook: hostHook{
 				cfg: latest.HostHook{
 					OS:      []string{"windows"},
@@ -56,6 +58,7 @@ func TestRun(t *testing.T) {
 		},
 		{
 			description:       "linux/darwin host hook on non-matching host",
+			shouldErr:         true,
 			requiresWindowsOS: true,
 			hook: hostHook{
 				cfg: latest.HostHook{
@@ -81,12 +84,12 @@ func TestRun(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			if test.requiresWindowsOS != (runtime.GOOS == "windows") {
+			if test.requiresWindowsOS != (runtime.GOOS == Windows) {
 				t.Skip()
 			}
 			var buf bytes.Buffer
-			err := test.hook.run(context.Background(), &buf)
-			t.CheckNoError(err)
+			err := test.hook.run(context.Background(), nil, &buf)
+			t.CheckError(test.shouldErr, err)
 			t.CheckDeepEqual(test.expected, buf.String())
 		})
 	}

--- a/pkg/skaffold/hooks/render.go
+++ b/pkg/skaffold/hooks/render.go
@@ -109,9 +109,6 @@ func (r renderRunner) RunPostHooks(ctx context.Context, list manifest.ManifestLi
 	if len(r.PostHooks) > 0 {
 		log.Entry(context.TODO()).Errorf("Completed %s hooks", phases.PostRender)
 	}
-	if err != nil {
-		return manifest.ManifestList{}, err
-	}
 	return updated, nil
 }
 

--- a/pkg/skaffold/hooks/render.go
+++ b/pkg/skaffold/hooks/render.go
@@ -17,13 +17,16 @@ limitations under the License.
 package hooks
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
 	"sync"
 
-	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/output"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/kubernetes/manifest"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/output/log"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/latest"
 )
 
@@ -32,8 +35,14 @@ var (
 	NewRenderRunner = newRenderRunner
 )
 
-func newRenderRunner(r latest.RenderHooks, namespaces *[]string, opts RenderEnvOpts) Runner {
-	return renderRunner{r, namespaces, opts, new(sync.Map)}
+type RenderHookRunner interface {
+	RunPreHooks(ctx context.Context, out io.Writer) error
+	RunPostHooks(ctx context.Context, list manifest.ManifestList, out io.Writer) (manifest.ManifestList, error)
+	GetConfigName() string
+}
+
+func newRenderRunner(r latest.RenderHooks, namespaces *[]string, opts RenderEnvOpts, configName string) RenderHookRunner {
+	return renderRunner{r, configName, namespaces, opts, new(sync.Map)}
 }
 
 func NewRenderEnvOpts(kubeContext string, namespaces []string) RenderEnvOpts {
@@ -45,17 +54,65 @@ func NewRenderEnvOpts(kubeContext string, namespaces []string) RenderEnvOpts {
 
 type renderRunner struct {
 	latest.RenderHooks
+	configName        string
 	namespaces        *[]string
 	opts              RenderEnvOpts
 	visitedContainers *sync.Map // maintain a list of previous iteration containers, so that they can be skipped
+}
+
+func (r renderRunner) GetConfigName() string {
+	return r.configName
 }
 
 func (r renderRunner) RunPreHooks(ctx context.Context, out io.Writer) error {
 	return r.run(ctx, out, r.PreHooks, phases.PreRender)
 }
 
-func (r renderRunner) RunPostHooks(ctx context.Context, out io.Writer) error {
-	return r.run(ctx, out, r.PostHooks, phases.PostRender)
+func (r renderRunner) RunPostHooks(ctx context.Context, list manifest.ManifestList, out io.Writer) (manifest.ManifestList, error) {
+	if len(r.PostHooks) > 0 {
+		log.Entry(context.TODO()).Errorf("Starting %s hooks...", phases.PostRender)
+	}
+	updated, err := manifest.Load(list.Reader())
+	if err != nil {
+		return manifest.ManifestList{}, fmt.Errorf("failed to load manifest")
+	}
+	env := r.getEnv()
+	for _, h := range r.PostHooks {
+		if h.HostHook != nil {
+			hook := hostHook{latest.HostHook{
+				Command: h.HostHook.Command,
+				OS:      h.HostHook.OS,
+				Dir:     h.HostHook.Dir,
+			}, env}
+			var b bytes.Buffer
+			if h.HostHook.WithChange {
+				if err := hook.run(ctx, updated.Reader(), &b); err != nil {
+					if errors.Is(err, &Skip{}) {
+						continue
+					}
+					return manifest.ManifestList{}, err
+				}
+				if b.Len() == 0 {
+					return manifest.ManifestList{}, fmt.Errorf("the length of stdout should be greater than 0 when using render post hook with change")
+				}
+				updated, err = manifest.Load(&b)
+				if err != nil {
+					return manifest.ManifestList{}, fmt.Errorf("failed to load manifest")
+				}
+			} else {
+				if err := hook.run(ctx, updated.Reader(), &b); err != nil && !errors.Is(err, &Skip{}) {
+					return manifest.ManifestList{}, err
+				}
+			}
+		}
+	}
+	if len(r.PostHooks) > 0 {
+		log.Entry(context.TODO()).Errorf("Completed %s hooks", phases.PostRender)
+	}
+	if err != nil {
+		return manifest.ManifestList{}, err
+	}
+	return updated, nil
 }
 
 func (r renderRunner) getEnv() []string {
@@ -66,19 +123,19 @@ func (r renderRunner) getEnv() []string {
 
 func (r renderRunner) run(ctx context.Context, out io.Writer, hooks []latest.RenderHookItem, phase phase) error {
 	if len(hooks) > 0 {
-		output.Default.Fprintln(out, fmt.Sprintf("Starting %s hooks...", phase))
+		log.Entry(context.TODO()).Errorf("Starting %s hooks...", phase)
 	}
 	env := r.getEnv()
 	for _, h := range hooks {
 		if h.HostHook != nil {
 			hook := hostHook{*h.HostHook, env}
-			if err := hook.run(ctx, out); err != nil {
+			if err := hook.run(ctx, nil, out); err != nil && !errors.Is(err, &Skip{}) {
 				return err
 			}
 		}
 	}
 	if len(hooks) > 0 {
-		output.Default.Fprintln(out, fmt.Sprintf("Completed %s hooks", phase))
+		log.Entry(context.TODO()).Errorf("Completed %s hooks...", phase)
 	}
 	return nil
 }

--- a/pkg/skaffold/hooks/render_test.go
+++ b/pkg/skaffold/hooks/render_test.go
@@ -19,57 +19,346 @@ package hooks
 import (
 	"bytes"
 	"context"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	kubernetesclient "github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/kubernetes/client"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/kubernetes/manifest"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/v2/testutil"
 )
 
-func TestRenderHooks(t *testing.T) {
-	testutil.Run(t, "TestRenderHooks", func(t *testutil.T) {
-		hooks := latest.RenderHooks{
-			PreHooks: []latest.RenderHookItem{
-				{
-					HostHook: &latest.HostHook{
-						OS:      []string{"linux", "darwin"},
-						Command: []string{"sh", "-c", "echo pre-hook running with SKAFFOLD_KUBE_CONTEXT=$SKAFFOLD_KUBE_CONTEXT,SKAFFOLD_NAMESPACES=$SKAFFOLD_NAMESPACES"},
+const SimpleManifest = `apiVersion: v1
+kind: Pod
+metadata:
+  name: getting-started
+  labels:
+    test-name: before
+spec:
+  containers:
+  - name: getting-started
+    image: skaffold-example`
+
+func TestRenderHooksLinux(t *testing.T) {
+	tests := []struct {
+		description     string
+		hooks           latest.RenderHooks
+		preHostHookOut  string
+		postHostHookOut string
+	}{
+		{
+			description: "test on linux machine match",
+			hooks: latest.RenderHooks{
+				PreHooks: []latest.RenderHookItem{
+					{
+						HostHook: &latest.HostHook{
+							OS:      []string{"linux", "darwin"},
+							Command: []string{"sh", "-c", "echo pre-hook running with SKAFFOLD_KUBE_CONTEXT=$SKAFFOLD_KUBE_CONTEXT,SKAFFOLD_NAMESPACES=$SKAFFOLD_NAMESPACES"},
+						},
 					},
 				},
-				{
-					HostHook: &latest.HostHook{
-						OS:      []string{"windows"},
-						Command: []string{"cmd.exe", "/C", "echo pre-hook running with SKAFFOLD_KUBE_CONTEXT=%SKAFFOLD_KUBE_CONTEXT%,SKAFFOLD_NAMESPACES=%SKAFFOLD_NAMESPACES%"},
+				PostHooks: []latest.PostRenderHookItem{
+					{
+						HostHook: &latest.PostRenderHostHook{
+							OS:      []string{"linux", "darwin"},
+							Command: []string{"sh", "-c", "echo post-hook running with SKAFFOLD_KUBE_CONTEXT=$SKAFFOLD_KUBE_CONTEXT,SKAFFOLD_NAMESPACES=$SKAFFOLD_NAMESPACES"},
+						},
 					},
 				},
 			},
-			PostHooks: []latest.RenderHookItem{
-				{
-					HostHook: &latest.HostHook{
-						OS:      []string{"linux", "darwin"},
-						Command: []string{"sh", "-c", "echo post-hook running with SKAFFOLD_KUBE_CONTEXT=$SKAFFOLD_KUBE_CONTEXT,SKAFFOLD_NAMESPACES=$SKAFFOLD_NAMESPACES"},
+			preHostHookOut:  "pre-hook running with SKAFFOLD_KUBE_CONTEXT=context1,SKAFFOLD_NAMESPACES=np1,np2",
+			postHostHookOut: "post-hook running with SKAFFOLD_KUBE_CONTEXT=context1,SKAFFOLD_NAMESPACES=np1,np2",
+		},
+		{
+			description: "test on linux non match",
+			hooks: latest.RenderHooks{
+				PreHooks: []latest.RenderHookItem{
+					{
+						HostHook: &latest.HostHook{
+							OS:      []string{"windows"},
+							Command: []string{"pwsh", "-Command", "echo pre-hook running with SKAFFOLD_KUBE_CONTEXT=%SKAFFOLD_KUBE_CONTEXT%,SKAFFOLD_NAMESPACES=%SKAFFOLD_NAMESPACES%"},
+						},
 					},
 				},
-				{
-					HostHook: &latest.HostHook{
-						OS:      []string{"windows"},
-						Command: []string{"cmd.exe", "/C", "echo post-hook running with SKAFFOLD_KUBE_CONTEXT=%SKAFFOLD_KUBE_CONTEXT%,SKAFFOLD_NAMESPACES=%SKAFFOLD_NAMESPACES%"},
+				PostHooks: []latest.PostRenderHookItem{
+					{
+						HostHook: &latest.PostRenderHostHook{
+							OS:      []string{"windows"},
+							Command: []string{"pwsh", "-Command", "echo post-hook running with SKAFFOLD_KUBE_CONTEXT=%SKAFFOLD_KUBE_CONTEXT%,SKAFFOLD_NAMESPACES=%SKAFFOLD_NAMESPACES%"},
+						},
 					},
 				},
 			},
-		}
-		preHostHookOut := "pre-hook running with SKAFFOLD_KUBE_CONTEXT=context1,SKAFFOLD_NAMESPACES=np1,np2"
-		postHostHookOut := "post-hook running with SKAFFOLD_KUBE_CONTEXT=context1,SKAFFOLD_NAMESPACES=np1,np2"
-		namespaces := []string{"np1", "np2"}
-		opts := NewRenderEnvOpts(testKubeContext, namespaces)
-		runner := newRenderRunner(hooks, &namespaces, opts)
-		t.Override(&kubernetesclient.Client, fakeKubernetesClient)
-		var preOut, postOut bytes.Buffer
-		err := runner.RunPreHooks(context.Background(), &preOut)
-		t.CheckNoError(err)
-		t.CheckContains(preHostHookOut, preOut.String())
-		err = runner.RunPostHooks(context.Background(), &postOut)
-		t.CheckNoError(err)
-		t.CheckContains(postHostHookOut, postOut.String())
-	})
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			if runtime.GOOS == Windows {
+				t.Skip("Tests require linux machine")
+			}
+
+			preOutFile, err := os.CreateTemp("", "")
+			t.CheckNoError(err)
+			t.Cleanup(func() {
+				os.Remove(preOutFile.Name())
+			})
+			test.hooks.PreHooks[0].HostHook.Command[2] = test.hooks.PreHooks[0].HostHook.Command[2] + " > " + preOutFile.Name()
+			postOutFile, err := os.CreateTemp("", "")
+			t.CheckNoError(err)
+			t.Cleanup(func() {
+				os.Remove(postOutFile.Name())
+			})
+			test.hooks.PostHooks[0].HostHook.Command[2] = test.hooks.PostHooks[0].HostHook.Command[2] + " > " + postOutFile.Name()
+
+			namespaces := []string{"np1", "np2"}
+			opts := NewRenderEnvOpts(testKubeContext, namespaces)
+			runner := newRenderRunner(test.hooks, &namespaces, opts, "")
+
+			t.Override(&kubernetesclient.Client, fakeKubernetesClient)
+
+			err = runner.RunPreHooks(context.Background(), os.Stdout)
+			t.CheckNoError(err)
+			preOut, err := io.ReadAll(preOutFile)
+			t.CheckNoError(err)
+			t.CheckContains(test.preHostHookOut, string(preOut))
+			_, err = runner.RunPostHooks(context.Background(), manifest.ManifestList{}, os.Stdout)
+			t.CheckNoError(err)
+			postOut, err := io.ReadAll(postOutFile)
+			t.CheckNoError(err)
+			t.CheckContains(test.postHostHookOut, string(postOut))
+		})
+	}
+}
+func TestRenderHooksWindows(t *testing.T) {
+	tests := []struct {
+		description     string
+		hooks           latest.RenderHooks
+		preHostHookOut  string
+		postHostHookOut string
+		shouldErr       bool
+	}{
+		{
+			description: "test on windows machine non-match",
+			shouldErr:   true,
+			hooks: latest.RenderHooks{
+				PreHooks: []latest.RenderHookItem{
+					{
+						HostHook: &latest.HostHook{
+							OS:      []string{"linux", "darwin"},
+							Command: []string{"sh", "-c", "echo pre-hook running with SKAFFOLD_KUBE_CONTEXT=$SKAFFOLD_KUBE_CONTEXT,SKAFFOLD_NAMESPACES=$SKAFFOLD_NAMESPACES"},
+						},
+					},
+				},
+				PostHooks: []latest.PostRenderHookItem{
+					{
+						HostHook: &latest.PostRenderHostHook{
+							OS:      []string{"linux", "darwin"},
+							Command: []string{"sh", "-c", "echo post-hook running with SKAFFOLD_KUBE_CONTEXT=$SKAFFOLD_KUBE_CONTEXT,SKAFFOLD_NAMESPACES=$SKAFFOLD_NAMESPACES"},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "test on window match",
+			hooks: latest.RenderHooks{
+				PreHooks: []latest.RenderHookItem{
+					{
+						HostHook: &latest.HostHook{
+							OS:      []string{"windows"},
+							Command: []string{"pwsh", "-Command", "echo pre-hook running with SKAFFOLD_KUBE_CONTEXT=%SKAFFOLD_KUBE_CONTEXT%,SKAFFOLD_NAMESPACES=%SKAFFOLD_NAMESPACES%"},
+						},
+					},
+				},
+				PostHooks: []latest.PostRenderHookItem{
+					{
+						HostHook: &latest.PostRenderHostHook{
+							OS:      []string{"windows"},
+							Command: []string{"pwsh", "-Command", "echo post-hook running with SKAFFOLD_KUBE_CONTEXT=%SKAFFOLD_KUBE_CONTEXT%,SKAFFOLD_NAMESPACES=%SKAFFOLD_NAMESPACES%"},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			if runtime.GOOS != Windows {
+				t.Skip("Tests require windows machine")
+			}
+
+			dir := os.TempDir()
+			preOutFile := filepath.Join(dir, "pre")
+			t.Cleanup(func() {
+				os.Remove(preOutFile)
+			})
+
+			test.hooks.PreHooks[0].HostHook.Command[2] = test.hooks.PreHooks[0].HostHook.Command[2] + " | Set-Content -Path " + preOutFile
+			postOutFile := filepath.Join(dir, "post")
+			t.Cleanup(func() {
+				os.Remove(postOutFile)
+			})
+
+			test.hooks.PostHooks[0].HostHook.Command[2] = test.hooks.PostHooks[0].HostHook.Command[2] + " | Set-Content -Path " + postOutFile
+
+			namespaces := []string{"np1", "np2"}
+			opts := NewRenderEnvOpts(testKubeContext, namespaces)
+			runner := newRenderRunner(test.hooks, &namespaces, opts, "")
+
+			t.Override(&kubernetesclient.Client, fakeKubernetesClient)
+
+			err := runner.RunPreHooks(context.Background(), os.Stdout)
+			t.CheckNoError(err)
+			preOut, err := ioutil.ReadFile(preOutFile)
+			t.CheckError(test.shouldErr, err)
+			t.CheckContains(test.preHostHookOut, string(preOut))
+			_, err = runner.RunPostHooks(context.Background(), manifest.ManifestList{}, os.Stdout)
+			t.CheckNoError(err)
+			postOut, err := ioutil.ReadFile(preOutFile)
+			t.CheckError(test.shouldErr, err)
+			t.CheckContains(test.postHostHookOut, string(postOut))
+		})
+	}
+}
+
+func TestPostRenderHook(t *testing.T) {
+	tests := []struct {
+		description          string
+		requireWindows       bool
+		manifestList         string
+		expectedManifestList string
+		postHooks            []latest.PostRenderHookItem
+		shouldError          bool
+	}{
+		{
+			description:  "should change manifests with change linux",
+			manifestList: SimpleManifest,
+			expectedManifestList: `apiVersion: v1
+kind: Pod
+metadata:
+  name: getting-started
+  labels:
+    test-name: after
+spec:
+  containers:
+  - name: getting-started
+    image: skaffold-example`,
+			postHooks: []latest.PostRenderHookItem{
+				{
+					HostHook: &latest.PostRenderHostHook{
+						OS:         []string{"linux", "darwin"},
+						Command:    []string{"sed", "s/before/after/g"},
+						WithChange: true,
+					},
+				},
+			},
+		},
+		{
+			description:          "should error with change does not have output linux",
+			manifestList:         SimpleManifest,
+			expectedManifestList: "",
+			shouldError:          true,
+			postHooks: []latest.PostRenderHookItem{
+				{
+					HostHook: &latest.PostRenderHostHook{
+						OS:         []string{"linux", "darwin"},
+						Command:    []string{"bash", "-c", "sleep 0.01s"},
+						WithChange: true,
+					},
+				},
+			},
+		},
+		{
+			description:          "should not change manifests with change linux",
+			manifestList:         SimpleManifest,
+			expectedManifestList: SimpleManifest,
+			postHooks: []latest.PostRenderHookItem{
+				{
+					HostHook: &latest.PostRenderHostHook{
+						OS:         []string{"linux", "darwin"},
+						Command:    []string{"sed", "s/before/after/g"},
+						WithChange: false,
+					},
+				},
+			},
+		},
+		{
+			description:    "should change manifests with change windows",
+			requireWindows: true,
+			manifestList:   SimpleManifest,
+			expectedManifestList: `apiVersion: v1
+kind: Pod
+metadata:
+  name: getting-started
+  labels:
+    test-name: after
+spec:
+  containers:
+  - name: getting-started
+    image: skaffold-example`,
+			postHooks: []latest.PostRenderHookItem{
+				{
+					HostHook: &latest.PostRenderHostHook{
+						OS:         []string{"windows"},
+						Command:    []string{"powershell", "-Command", `$input | ForEach-Object { $_ -replace "before", "after" }`},
+						WithChange: true,
+					},
+				},
+			},
+		},
+		{
+			requireWindows:       true,
+			description:          "should error with change does not have output windows",
+			manifestList:         SimpleManifest,
+			expectedManifestList: "",
+			shouldError:          true,
+			postHooks: []latest.PostRenderHookItem{
+				{
+					HostHook: &latest.PostRenderHostHook{
+						OS:         []string{"windows"},
+						Command:    []string{"cmd.exe", "/C", `timeout 1`},
+						WithChange: true,
+					},
+				},
+			},
+		},
+		{
+			requireWindows:       true,
+			description:          "should not change manifests with change windows",
+			manifestList:         SimpleManifest,
+			expectedManifestList: SimpleManifest,
+			postHooks: []latest.PostRenderHookItem{
+				{
+					HostHook: &latest.PostRenderHostHook{
+						OS:         []string{"windows"},
+						Command:    []string{"pwsh", "-Command", `$input | ForEach-Object { $_ -replace "before", "after" }`},
+						WithChange: false,
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			if test.requireWindows != (runtime.GOOS == Windows) {
+				t.Skip()
+			}
+			namespaces := []string{"np1", "np2"}
+			opts := NewRenderEnvOpts(testKubeContext, namespaces)
+			runner := newRenderRunner(latest.RenderHooks{PostHooks: test.postHooks}, &namespaces, opts, "")
+			t.Override(&kubernetesclient.Client, fakeKubernetesClient)
+			reader := strings.NewReader(SimpleManifest)
+			manifestList, err := manifest.Load(reader)
+			t.CheckNoError(err)
+			var out bytes.Buffer
+			postHookResult, err := runner.RunPostHooks(context.TODO(), manifestList, &out)
+			t.CheckErrorAndDeepEqual(test.shouldError, err, test.expectedManifestList, postHookResult.String())
+		})
+	}
 }

--- a/pkg/skaffold/hooks/render_test.go
+++ b/pkg/skaffold/hooks/render_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -184,6 +183,8 @@ func TestRenderHooksWindows(t *testing.T) {
 					},
 				},
 			},
+			preHostHookOut:  "pre-hook running with SKAFFOLD_KUBE_CONTEXT=context1,SKAFFOLD_NAMESPACES=np1,np2",
+			postHostHookOut: "post-hook running with SKAFFOLD_KUBE_CONTEXT=context1,SKAFFOLD_NAMESPACES=np1,np2",
 		},
 	}
 	for _, test := range tests {
@@ -214,12 +215,12 @@ func TestRenderHooksWindows(t *testing.T) {
 
 			err := runner.RunPreHooks(context.Background(), os.Stdout)
 			t.CheckNoError(err)
-			preOut, err := ioutil.ReadFile(preOutFile)
+			preOut, err := os.ReadFile(preOutFile)
 			t.CheckError(test.shouldErr, err)
 			t.CheckContains(test.preHostHookOut, string(preOut))
 			_, err = runner.RunPostHooks(context.Background(), manifest.ManifestList{}, os.Stdout)
 			t.CheckNoError(err)
-			postOut, err := ioutil.ReadFile(preOutFile)
+			postOut, err := os.ReadFile(preOutFile)
 			t.CheckError(test.shouldErr, err)
 			t.CheckContains(test.postHostHookOut, string(postOut))
 		})

--- a/pkg/skaffold/hooks/render_test.go
+++ b/pkg/skaffold/hooks/render_test.go
@@ -170,7 +170,7 @@ func TestRenderHooksWindows(t *testing.T) {
 					{
 						HostHook: &latest.HostHook{
 							OS:      []string{"windows"},
-							Command: []string{"pwsh", "-Command", "echo pre-hook running with SKAFFOLD_KUBE_CONTEXT=%SKAFFOLD_KUBE_CONTEXT%,SKAFFOLD_NAMESPACES=%SKAFFOLD_NAMESPACES%"},
+							Command: []string{"pwsh", "-Command", "echo pre-hook running with SKAFFOLD_KUBE_CONTEXT=@([Environment]::GetEnvironmentVariable('SKAFFOLD_KUBE_CONTEXT')),SKAFFOLD_NAMESPACES=@([Environment]::GetEnvironmentVariable('SKAFFOLD_NAMESPACES'))"},
 						},
 					},
 				},
@@ -178,7 +178,7 @@ func TestRenderHooksWindows(t *testing.T) {
 					{
 						HostHook: &latest.PostRenderHostHook{
 							OS:      []string{"windows"},
-							Command: []string{"pwsh", "-Command", "echo post-hook running with SKAFFOLD_KUBE_CONTEXT=%SKAFFOLD_KUBE_CONTEXT%,SKAFFOLD_NAMESPACES=%SKAFFOLD_NAMESPACES%"},
+							Command: []string{"pwsh", "-Command", "echo post-hook running with SKAFFOLD_KUBE_CONTEXT=@([Environment]::GetEnvironmentVariable('SKAFFOLD_KUBE_CONTEXT')),SKAFFOLD_NAMESPACES=@([Environment]::GetEnvironmentVariable('SKAFFOLD_NAMESPACES'))"},
 						},
 					},
 				},

--- a/pkg/skaffold/hooks/render_test.go
+++ b/pkg/skaffold/hooks/render_test.go
@@ -170,7 +170,7 @@ func TestRenderHooksWindows(t *testing.T) {
 					{
 						HostHook: &latest.HostHook{
 							OS:      []string{"windows"},
-							Command: []string{"pwsh", "-Command", "Write-Host -NoNewLine running with SKAFFOLD_KUBE_CONTEXT=$([Environment]::GetEnvironmentVariable('SKAFFOLD_KUBE_CONTEXT'))','SKAFFOLD_NAMESPACES=$([Environment]::GetEnvironmentVariable('SKAFFOLD_NAMESPACES'))"},
+							Command: []string{"pwsh", "-Command", "echo", "running with SKAFFOLD_KUBE_CONTEXT=$([Environment]::GetEnvironmentVariable('SKAFFOLD_KUBE_CONTEXT')),SKAFFOLD_NAMESPACES=$([Environment]::GetEnvironmentVariable('SKAFFOLD_NAMESPACES'))"},
 						},
 					},
 				},
@@ -178,7 +178,7 @@ func TestRenderHooksWindows(t *testing.T) {
 					{
 						HostHook: &latest.PostRenderHostHook{
 							OS:      []string{"windows"},
-							Command: []string{"pwsh", "-Command", "Write-Host -NoNewLine running with SKAFFOLD_KUBE_CONTEXT=$([Environment]::GetEnvironmentVariable('SKAFFOLD_KUBE_CONTEXT'))','SKAFFOLD_NAMESPACES=$([Environment]::GetEnvironmentVariable('SKAFFOLD_NAMESPACES'))"},
+							Command: []string{"pwsh", "-Command", "echo", "running with SKAFFOLD_KUBE_CONTEXT=$([Environment]::GetEnvironmentVariable('SKAFFOLD_KUBE_CONTEXT')),SKAFFOLD_NAMESPACES=$([Environment]::GetEnvironmentVariable('SKAFFOLD_NAMESPACES'))"},
 						},
 					},
 				},

--- a/pkg/skaffold/hooks/render_test.go
+++ b/pkg/skaffold/hooks/render_test.go
@@ -80,7 +80,7 @@ func TestRenderHooksLinux(t *testing.T) {
 					{
 						HostHook: &latest.HostHook{
 							OS:      []string{"windows"},
-							Command: []string{"pwsh", "-Command", "echo pre-hook running with SKAFFOLD_KUBE_CONTEXT=%SKAFFOLD_KUBE_CONTEXT%,SKAFFOLD_NAMESPACES=%SKAFFOLD_NAMESPACES%"},
+							Command: []string{"pwsh", "-Command", "echo", "pre-hook running with SKAFFOLD_KUBE_CONTEXT=$([Environment]::GetEnvironmentVariable('SKAFFOLD_KUBE_CONTEXT')),SKAFFOLD_NAMESPACES=$([Environment]::GetEnvironmentVariable('SKAFFOLD_NAMESPACES'))"},
 						},
 					},
 				},
@@ -88,7 +88,7 @@ func TestRenderHooksLinux(t *testing.T) {
 					{
 						HostHook: &latest.PostRenderHostHook{
 							OS:      []string{"windows"},
-							Command: []string{"pwsh", "-Command", "echo post-hook running with SKAFFOLD_KUBE_CONTEXT=%SKAFFOLD_KUBE_CONTEXT%,SKAFFOLD_NAMESPACES=%SKAFFOLD_NAMESPACES%"},
+							Command: []string{"pwsh", "-Command", "echo", "post-hook running with SKAFFOLD_KUBE_CONTEXT=$([Environment]::GetEnvironmentVariable('SKAFFOLD_KUBE_CONTEXT')),SKAFFOLD_NAMESPACES=$([Environment]::GetEnvironmentVariable('SKAFFOLD_NAMESPACES'))"},
 						},
 					},
 				},
@@ -170,7 +170,7 @@ func TestRenderHooksWindows(t *testing.T) {
 					{
 						HostHook: &latest.HostHook{
 							OS:      []string{"windows"},
-							Command: []string{"pwsh", "-Command", "echo", "running with SKAFFOLD_KUBE_CONTEXT=$([Environment]::GetEnvironmentVariable('SKAFFOLD_KUBE_CONTEXT')),SKAFFOLD_NAMESPACES=$([Environment]::GetEnvironmentVariable('SKAFFOLD_NAMESPACES'))"},
+							Command: []string{"pwsh", "-Command", `echo "pre-hook running with SKAFFOLD_KUBE_CONTEXT=$([Environment]::GetEnvironmentVariable('SKAFFOLD_KUBE_CONTEXT')),SKAFFOLD_NAMESPACES=$([Environment]::GetEnvironmentVariable('SKAFFOLD_NAMESPACES'))"`},
 						},
 					},
 				},
@@ -178,7 +178,7 @@ func TestRenderHooksWindows(t *testing.T) {
 					{
 						HostHook: &latest.PostRenderHostHook{
 							OS:      []string{"windows"},
-							Command: []string{"pwsh", "-Command", "echo", "running with SKAFFOLD_KUBE_CONTEXT=$([Environment]::GetEnvironmentVariable('SKAFFOLD_KUBE_CONTEXT')),SKAFFOLD_NAMESPACES=$([Environment]::GetEnvironmentVariable('SKAFFOLD_NAMESPACES'))"},
+							Command: []string{"pwsh", "-Command", `echo "post-hook running with SKAFFOLD_KUBE_CONTEXT=$([Environment]::GetEnvironmentVariable('SKAFFOLD_KUBE_CONTEXT')),SKAFFOLD_NAMESPACES=$([Environment]::GetEnvironmentVariable('SKAFFOLD_NAMESPACES'))"`},
 						},
 					},
 				},
@@ -220,7 +220,7 @@ func TestRenderHooksWindows(t *testing.T) {
 			t.CheckContains(test.preHostHookOut, string(preOut))
 			_, err = runner.RunPostHooks(context.Background(), manifest.ManifestList{}, os.Stdout)
 			t.CheckNoError(err)
-			postOut, err := os.ReadFile(preOutFile)
+			postOut, err := os.ReadFile(postOutFile)
 			t.CheckError(test.shouldErr, err)
 			t.CheckContains(test.postHostHookOut, string(postOut))
 		})

--- a/pkg/skaffold/hooks/render_test.go
+++ b/pkg/skaffold/hooks/render_test.go
@@ -170,7 +170,7 @@ func TestRenderHooksWindows(t *testing.T) {
 					{
 						HostHook: &latest.HostHook{
 							OS:      []string{"windows"},
-							Command: []string{"pwsh", "-Command", "echo pre-hook running with SKAFFOLD_KUBE_CONTEXT=@([Environment]::GetEnvironmentVariable('SKAFFOLD_KUBE_CONTEXT')),SKAFFOLD_NAMESPACES=@([Environment]::GetEnvironmentVariable('SKAFFOLD_NAMESPACES'))"},
+							Command: []string{"pwsh", "-Command", "Write-Host -NoNewLine running with SKAFFOLD_KUBE_CONTEXT=$([Environment]::GetEnvironmentVariable('SKAFFOLD_KUBE_CONTEXT'))','SKAFFOLD_NAMESPACES=$([Environment]::GetEnvironmentVariable('SKAFFOLD_NAMESPACES'))"},
 						},
 					},
 				},
@@ -178,7 +178,7 @@ func TestRenderHooksWindows(t *testing.T) {
 					{
 						HostHook: &latest.PostRenderHostHook{
 							OS:      []string{"windows"},
-							Command: []string{"pwsh", "-Command", "echo post-hook running with SKAFFOLD_KUBE_CONTEXT=@([Environment]::GetEnvironmentVariable('SKAFFOLD_KUBE_CONTEXT')),SKAFFOLD_NAMESPACES=@([Environment]::GetEnvironmentVariable('SKAFFOLD_NAMESPACES'))"},
+							Command: []string{"pwsh", "-Command", "Write-Host -NoNewLine running with SKAFFOLD_KUBE_CONTEXT=$([Environment]::GetEnvironmentVariable('SKAFFOLD_KUBE_CONTEXT'))','SKAFFOLD_NAMESPACES=$([Environment]::GetEnvironmentVariable('SKAFFOLD_NAMESPACES'))"},
 						},
 					},
 				},

--- a/pkg/skaffold/hooks/sync.go
+++ b/pkg/skaffold/hooks/sync.go
@@ -18,6 +18,7 @@ package hooks
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -81,7 +82,7 @@ func (r syncRunner) run(ctx context.Context, out io.Writer, hooks []latest.SyncH
 	for i, h := range hooks {
 		if h.HostHook != nil {
 			hook := hostHook{*h.HostHook, env}
-			if err := hook.run(ctx, out); err != nil {
+			if err := hook.run(ctx, nil, out); err != nil && !errors.Is(err, &Skip{}) {
 				return fmt.Errorf("failed to execute host %s hook %d for artifact %q: %w", phase, i+1, r.imageName, err)
 			}
 		} else if h.ContainerHook != nil {

--- a/pkg/skaffold/render/renderer/render_mux.go
+++ b/pkg/skaffold/render/renderer/render_mux.go
@@ -88,14 +88,19 @@ func (r RenderMux) Render(ctx context.Context, out io.Writer, artifacts []graph.
 	updated := manifest.NewManifestListByConfig()
 	for _, name := range allManifests.ConfigNames() {
 		list := allManifests.GetForConfig(name)
+		found := false
 		for _, hr := range r.gr.HookRunners {
 			if hr.GetConfigName() == name {
+				found = true
 				if l, err := hr.RunPostHooks(ctx, list, w); err != nil {
 					return manifest.ManifestListByConfig{}, err
 				} else {
 					updated.Add(hr.GetConfigName(), l)
 				}
 			}
+		}
+		if !found {
+			updated.Add(name, list)
 		}
 	}
 	return updated, nil

--- a/pkg/skaffold/runner/renderer.go
+++ b/pkg/skaffold/runner/renderer.go
@@ -53,7 +53,7 @@ func GetRenderer(ctx context.Context, runCtx *runcontext.RunContext, hydrationDi
 		}
 		gr.Renderers = append(gr.Renderers, rs.Renderers...)
 		gr.HookRunners = append(gr.HookRunners, hooks.NewRenderRunner(p.Render.LifecycleHooks, &[]string{runCtx.GetNamespace()},
-			hooks.NewRenderEnvOpts(runCtx.KubeContext, []string{runCtx.GetNamespace()})))
+			hooks.NewRenderEnvOpts(runCtx.KubeContext, []string{runCtx.GetNamespace()}), configName))
 	}
 	// In case of legacy helm deployer configured and render command used
 	// force a helm renderer from deploy helm config

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -1666,12 +1666,32 @@ type RenderHookItem struct {
 	HostHook *HostHook `yaml:"host,omitempty" yamltags:"oneOf=render_hook"`
 }
 
+// PostRenderHookItem describes a single lifecycle hook to execute after each render step.
+type PostRenderHookItem struct {
+	// HostHook describes a single lifecycle hook to run on the host machine.
+	HostHook *PostRenderHostHook `yaml:"host,omitempty" yamltags:"oneOf=render_hook"`
+}
+
+// PostRenderHostHook describes a post render hook definition to execute on the host machine.
+type PostRenderHostHook struct {
+	// Command is the command to execute.
+	Command []string `yaml:"command" yamltags:"required"`
+	// OS is an optional slice of operating system names. If the host machine OS is different, then it skips execution.
+	OS []string `yaml:"os,omitempty"`
+	// Dir specifies the working directory of the command.
+	// If empty, the command runs in the calling process's current directory.
+	Dir string `yaml:"dir,omitempty" skaffold:"filepath"`
+
+	// WithChange preserves changes made on the manifests by the hook.
+	WithChange bool `yaml:"withChange,omitempty"`
+}
+
 // RenderHooks describes the list of lifecycle hooks to execute before and after each render step.
 type RenderHooks struct {
 	// PreHooks describes the list of lifecycle hooks to execute *before* each render step. Container hooks will only run if the container exists from a previous deployment step (for instance the successive iterations of a dev-loop during `skaffold dev`).
 	PreHooks []RenderHookItem `yaml:"before,omitempty"`
 	// PostHooks describes the list of lifecycle hooks to execute *after* each render step.
-	PostHooks []RenderHookItem `yaml:"after,omitempty"`
+	PostHooks []PostRenderHookItem `yaml:"after,omitempty"`
 }
 
 // CloudRunDeployHooks describes the list of lifecycle hooks to execute in the host before and after the Cloud Run deployer.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #9038 <!-- tracking issues that this PR will close -->


**Description**
 - enable users to use skaffold pipeline post-render host hooks as helm post-render, so they can manipulate skaffold rendered manifests with any renderers
 - To do this, we need to introduce a flag to let users explicitly indicate that they want to leverage manifests from skaffold render phase for further processing. This may not be obvious for render command, but for dev is necessary.
 - We also need to disable stdin logging on post render hook, this is necessary regardless we introduce this feature or now, as  enable logging there could lead to unexpected output to end rendered result when using `skaffold render > somefile.txt`
 - refactor share hooks run method to return skip error, if command doesn't match host machine,  we should distinguish a command is successfully finished or just skipped. 


