### PR TITLE
chore: inject imageInfo when expanding templates for ko builder

### DIFF
--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -62,6 +62,11 @@ var tests = []struct {
 		targetLog:   "Hello world!",
 	},
 	{
+		description: "ko",
+		dir:         "examples/ko",
+		deployments: []string{"ko"},
+	},
+	{
 		description: "nodejs",
 		dir:         "examples/nodejs",
 		deployments: []string{"node"},

--- a/pkg/skaffold/build/ko/build.go
+++ b/pkg/skaffold/build/ko/build.go
@@ -41,7 +41,7 @@ func (b *Builder) Build(ctx context.Context, out io.Writer, a *latest.Artifact, 
 	if b.pushImages && strings.HasPrefix(ref, build.StrictScheme) {
 		return "", fmt.Errorf("default repo must be set when using the 'ko://' prefix and pushing to a registry: %s, see https://skaffold.dev/docs/environment/image-registries/", a.ImageName)
 	}
-	koBuilder, err := b.newKoBuilder(ctx, a, platforms)
+	koBuilder, err := b.newKoBuilder(ctx, a, platforms, ref)
 	if err != nil {
 		return "", fmt.Errorf("error creating ko builder: %w", err)
 	}

--- a/pkg/skaffold/build/ko/builder.go
+++ b/pkg/skaffold/build/ko/builder.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/ko/pkg/commands/options"
 
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/platform"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/latest"
@@ -40,9 +41,9 @@ func (b *Builder) newKoBuilder(ctx context.Context, a *latest.Artifact, platform
 		return nil, fmt.Errorf("parsing image %v: %w", tag, err)
 	}
 	imageInfoEnv := map[string]string{
-		"IMAGE_REPO": ref.Repo,
-		"IMAGE_NAME": ref.Name,
-		"IMAGE_TAG":  ref.Tag,
+		constants.ImageRef.Repo: ref.Repo,
+		constants.ImageRef.Name: ref.Name,
+		constants.ImageRef.Tag:  ref.Tag,
 	}
 	if err != nil {
 		return nil, fmt.Errorf("could not resolve skaffold runtime env for ko builder: %v", err)

--- a/pkg/skaffold/build/ko/builder_test.go
+++ b/pkg/skaffold/build/ko/builder_test.go
@@ -40,6 +40,7 @@ const (
 func TestBuildOptions(t *testing.T) {
 	tests := []struct {
 		description string
+		envs        map[string]string
 		artifact    latest.Artifact
 		platforms   platform.Matcher
 		envVarValue string
@@ -150,11 +151,44 @@ func TestBuildOptions(t *testing.T) {
 				UserAgent:        version.UserAgentWithClient(),
 			},
 		},
+		{
+			description: "",
+			artifact: latest.Artifact{
+				ArtifactType: latest.ArtifactType{
+					KoArtifact: &latest.KoArtifact{
+						Flags: []string{
+							"-v",
+							fmt.Sprintf("-flag-{{.%s}}", "IMAGE_NAME"),
+						},
+						Ldflags: []string{
+							"-s",
+							fmt.Sprintf("-ldflag-{{.%s}}", "IMAGE_TAG"),
+						},
+					},
+				},
+				ImageName: "ko://example.com/foo",
+			},
+			envs: map[string]string{"IMAGE_NAME": "name", "IMAGE_TAG": "tag"},
+			wantBo: options.BuildOptions{
+				BuildConfigs: map[string]build.Config{
+					"example.com/foo": {
+						ID:      "ko://example.com/foo",
+						Dir:     ".",
+						Flags:   build.FlagArray{"-v", "-flag-name"},
+						Ldflags: build.StringArray{"-s", "-ldflag-tag"},
+					},
+				},
+				ConcurrentBuilds: 1,
+				SBOM:             "none",
+				Trimpath:         true,
+				UserAgent:        version.UserAgentWithClient(),
+			},
+		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Setenv(testKoBuildOptionsEnvVar, test.envVarValue)
-			gotBo, err := buildOptions(&test.artifact, test.runMode, test.platforms, nil)
+			gotBo, err := buildOptions(&test.artifact, test.runMode, test.platforms, test.envs)
 			t.CheckErrorAndFailNow(false, err)
 			t.CheckDeepEqual(test.wantBo, *gotBo,
 				cmpopts.EquateEmpty(),

--- a/pkg/skaffold/build/ko/builder_test.go
+++ b/pkg/skaffold/build/ko/builder_test.go
@@ -154,7 +154,7 @@ func TestBuildOptions(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Setenv(testKoBuildOptionsEnvVar, test.envVarValue)
-			gotBo, err := buildOptions(&test.artifact, test.runMode, test.platforms, "")
+			gotBo, err := buildOptions(&test.artifact, test.runMode, test.platforms, nil)
 			t.CheckErrorAndFailNow(false, err)
 			t.CheckDeepEqual(test.wantBo, *gotBo,
 				cmpopts.EquateEmpty(),

--- a/pkg/skaffold/build/ko/builder_test.go
+++ b/pkg/skaffold/build/ko/builder_test.go
@@ -152,7 +152,7 @@ func TestBuildOptions(t *testing.T) {
 			},
 		},
 		{
-			description: "",
+			description: "test build option, inject envs for expanding templates",
 			artifact: latest.Artifact{
 				ArtifactType: latest.ArtifactType{
 					KoArtifact: &latest.KoArtifact{

--- a/pkg/skaffold/build/ko/builder_test.go
+++ b/pkg/skaffold/build/ko/builder_test.go
@@ -154,7 +154,7 @@ func TestBuildOptions(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Setenv(testKoBuildOptionsEnvVar, test.envVarValue)
-			gotBo, err := buildOptions(&test.artifact, test.runMode, test.platforms)
+			gotBo, err := buildOptions(&test.artifact, test.runMode, test.platforms, "")
 			t.CheckErrorAndFailNow(false, err)
 			t.CheckDeepEqual(test.wantBo, *gotBo,
 				cmpopts.EquateEmpty(),

--- a/pkg/skaffold/constants/constants.go
+++ b/pkg/skaffold/constants/constants.go
@@ -140,10 +140,12 @@ var ImageRef = struct {
 	Repo   string
 	Tag    string
 	Digest string
+	Name   string
 }{
 	Repo:   "IMAGE_REPO",
 	Tag:    "IMAGE_TAG",
 	Digest: "IMAGE_DIGEST",
+	Name:   "IMAGE_NAME",
 }
 var DefaultKubectlManifests = []string{"k8s/*.yaml"}
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #9045 <!-- tracking issues that this PR will close -->
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
 - The original ticket ask was to inject all available runtime envs in custom builder also available to other builders
 - After investigation, it looks like that the reason we have some envs such as platform, pushImage to custom builder due to the custom builder may have some logic to build based on these values. 
 - Other builders don't need those info, hence only inject imageInfo to ko builder, we're already doing this for docker and kaniko. 


