### PR TITLE
fix: Scope Issue with the 'entry' variable when looking up remote images and tests additions

### DIFF
--- a/pkg/skaffold/build/cache/lookup_test.go
+++ b/pkg/skaffold/build/cache/lookup_test.go
@@ -149,13 +149,6 @@ func TestLookupRemote(t *testing.T) {
 		expected    cacheDetails
 	}{
 		{
-			description: "miss",
-			hasher:      mockHasher{"hash"},
-			api:         &testutil.FakeAPIClient{ErrImagePull: true},
-			cache:       map[string]ImageDetails{},
-			expected:    needsBuilding{hash: "hash"},
-		},
-		{
 			description: "hash failure",
 			hasher:      failingHasher{errors.New("BUG")},
 			expected:    failed{err: errors.New("getting hash for artifact \"artifact\": BUG")},
@@ -222,7 +215,7 @@ func TestLookupRemote(t *testing.T) {
 
 			// cmp.Diff cannot access unexported fields in *exec.Cmd, so use reflect.DeepEqual here directly
 			if !reflect.DeepEqual(test.expected, details[0]) {
-				t.Errorf("Expected result different from actual result. Expected: \n%v, \nActual: \n%v", test.expected, details)
+				t.Errorf("Expected result different from actual result. Expected: \n\"%v\", \nActual: \n\"%v\"", test.expected, details[0])
 			}
 		})
 	}

--- a/pkg/skaffold/build/cache/retrieve_test.go
+++ b/pkg/skaffold/build/cache/retrieve_test.go
@@ -228,14 +228,14 @@ func TestCacheBuildRemote(t *testing.T) {
 			"exist_artifact1": {"dep4"},
 			"exist_artifact2": {"dep5"},
 		})
-		tag_to_digest := map[string]string{
+		tagToDigest := map[string]string{
 			"exist_artifact1:tag1": "sha256:51ae7fa00c92525c319404a3a6d400e52ff9372c5a39cb415e0486fe425f3165",
 			"exist_artifact2:tag2": "sha256:35bdf2619f59e6f2372a92cb5486f4a0bf9b86e0e89ee0672864db6ed9c51539",
 		}
 
 		// Mock Docker
 		api := &testutil.FakeAPIClient{}
-		for tag, digest := range tag_to_digest {
+		for tag, digest := range tagToDigest {
 			api = api.Add(tag, digest)
 		}
 
@@ -245,8 +245,7 @@ func TestCacheBuildRemote(t *testing.T) {
 		})
 		t.Override(&docker.DefaultAuthHelper, stubAuth{})
 		t.Override(&docker.RemoteDigest, func(ref string, _ docker.Config, _ []specs.Platform) (string, error) {
-			// If tag exists in tag_to_digest, return the digest else return the error
-			if digest, ok := tag_to_digest[ref]; ok {
+			if digest, ok := tagToDigest[ref]; ok {
 				return digest, nil
 			}
 			return "", errors.New("unknown remote tag")
@@ -280,10 +279,10 @@ func TestCacheBuildRemote(t *testing.T) {
 		t.CheckDeepEqual("artifact2", bRes[1].ImageName)
 
 		// Add the other tags to the remote cache
-		tag_to_digest["artifact1:tag1"] = tag_to_digest["exist_artifact1:tag1"]
-		tag_to_digest["artifact2:tag2"] = tag_to_digest["exist_artifact2:tag2"]
-		api.Add("artifact1:tag1", tag_to_digest["artifact1:tag1"])
-		api.Add("artifact2:tag2", tag_to_digest["artifact2:tag2"])
+		tagToDigest["artifact1:tag1"] = tagToDigest["exist_artifact1:tag1"]
+		tagToDigest["artifact2:tag2"] = tagToDigest["exist_artifact2:tag2"]
+		api.Add("artifact1:tag1", tagToDigest["artifact1:tag1"])
+		api.Add("artifact2:tag2", tagToDigest["artifact2:tag2"])
 
 		// Second build: both artifacts are read from cache
 		builder = &mockBuilder{dockerDaemon: dockerDaemon, push: true, cache: artifactCache}

--- a/pkg/skaffold/build/cache/retrieve_test.go
+++ b/pkg/skaffold/build/cache/retrieve_test.go
@@ -206,25 +206,38 @@ func TestCacheBuildRemote(t *testing.T) {
 			Write("dep1", "content1").
 			Write("dep2", "content2").
 			Write("dep3", "content3").
+			Write("dep4", "content4").
+			Write("dep5", "content5").
 			Chdir()
 
 		tags := map[string]string{
 			"artifact1": "artifact1:tag1",
 			"artifact2": "artifact2:tag2",
+			"exist_artifact1": "exist_artifact1:tag1",
+			"exist_artifact2": "exist_artifact2:tag2",
 		}
 		artifacts := []*latest.Artifact{
 			{ImageName: "artifact1", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{}}},
 			{ImageName: "artifact2", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{}}},
+			{ImageName: "exist_artifact1", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{}}},
+			{ImageName: "exist_artifact2", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{}}},
 		}
 		deps := depLister(map[string][]string{
 			"artifact1": {"dep1", "dep2"},
 			"artifact2": {"dep3"},
+			"exist_artifact1": {"dep4"},
+			"exist_artifact2": {"dep5"},
 		})
+		tag_to_digest := map[string]string{
+			"exist_artifact1:tag1": "sha256:51ae7fa00c92525c319404a3a6d400e52ff9372c5a39cb415e0486fe425f3165",
+			"exist_artifact2:tag2": "sha256:35bdf2619f59e6f2372a92cb5486f4a0bf9b86e0e89ee0672864db6ed9c51539",
+		}
 
 		// Mock Docker
 		api := &testutil.FakeAPIClient{}
-		api = api.Add("artifact1:tag1", "sha256:51ae7fa00c92525c319404a3a6d400e52ff9372c5a39cb415e0486fe425f3165")
-		api = api.Add("artifact2:tag2", "sha256:35bdf2619f59e6f2372a92cb5486f4a0bf9b86e0e89ee0672864db6ed9c51539")
+		for tag, digest := range tag_to_digest {
+			api = api.Add(tag, digest)
+		}
 
 		dockerDaemon := fakeLocalDaemon(api)
 		t.Override(&docker.NewAPIClient, func(context.Context, docker.Config) (docker.LocalDaemon, error) {
@@ -232,14 +245,11 @@ func TestCacheBuildRemote(t *testing.T) {
 		})
 		t.Override(&docker.DefaultAuthHelper, stubAuth{})
 		t.Override(&docker.RemoteDigest, func(ref string, _ docker.Config, _ []specs.Platform) (string, error) {
-			switch ref {
-			case "artifact1:tag1":
-				return "sha256:51ae7fa00c92525c319404a3a6d400e52ff9372c5a39cb415e0486fe425f3165", nil
-			case "artifact2:tag2":
-				return "sha256:35bdf2619f59e6f2372a92cb5486f4a0bf9b86e0e89ee0672864db6ed9c51539", nil
-			default:
-				return "", errors.New("unknown remote tag")
+			// If tag exists in tag_to_digest, return the digest else return the error
+			if digest, ok := tag_to_digest[ref]; ok {
+				return digest, nil
 			}
+			return "", errors.New("unknown remote tag")
 		})
 
 		// Mock args builder
@@ -264,10 +274,16 @@ func TestCacheBuildRemote(t *testing.T) {
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual(2, len(builder.built))
-		t.CheckDeepEqual(2, len(bRes))
+		t.CheckDeepEqual(4, len(bRes))
 		// Artifacts should always be returned in their original order
 		t.CheckDeepEqual("artifact1", bRes[0].ImageName)
 		t.CheckDeepEqual("artifact2", bRes[1].ImageName)
+
+		// Add the other tags to the remote cache
+		tag_to_digest["artifact1:tag1"] = tag_to_digest["exist_artifact1:tag1"]
+		tag_to_digest["artifact2:tag2"] = tag_to_digest["exist_artifact2:tag2"]
+		api.Add("artifact1:tag1", tag_to_digest["artifact1:tag1"])
+		api.Add("artifact2:tag2", tag_to_digest["artifact2:tag2"])
 
 		// Second build: both artifacts are read from cache
 		builder = &mockBuilder{dockerDaemon: dockerDaemon, push: true, cache: artifactCache}
@@ -275,18 +291,20 @@ func TestCacheBuildRemote(t *testing.T) {
 
 		t.CheckNoError(err)
 		t.CheckEmpty(builder.built)
-		t.CheckDeepEqual(2, len(bRes))
+		t.CheckDeepEqual(4, len(bRes))
 		t.CheckDeepEqual("artifact1", bRes[0].ImageName)
 		t.CheckDeepEqual("artifact2", bRes[1].ImageName)
 
 		// Third build: change one artifact's dependencies
 		tmpDir.Write("dep1", "new content")
+		tags["artifact1"] = "artifact1:new_tag1"
+
 		builder = &mockBuilder{dockerDaemon: dockerDaemon, push: true, cache: artifactCache}
 		bRes, err = artifactCache.Build(context.Background(), io.Discard, tags, artifacts, platform.Resolver{}, builder.Build)
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual(1, len(builder.built))
-		t.CheckDeepEqual(2, len(bRes))
+		t.CheckDeepEqual(4, len(bRes))
 		t.CheckDeepEqual("artifact1", bRes[0].ImageName)
 		t.CheckDeepEqual("artifact2", bRes[1].ImageName)
 	})


### PR DESCRIPTION

**Related**: #9177

**Description**
The variable "entry" was not overridden before triggering the lookupRemote method.
The reason is because the entry variable was redeclared within an if block, resulting in a new, locally scoped variable. This redeclaration prevented the updates made to entry within this block from being reflected outside of it.

The bug was introduced in my last PR (9181)... I had no idea that in go, the "if" statement can define a whole new scope

I've also added some tests, so it would test the scenario where we have tags in the remote which shouldn't be built and also fixed another test where it uses missingPull functionality on the remote
