### PR TITLE
fix: Scope Issue with the 'entry' variable when looking up remote images and tests additions

### DIFF
--- a/integration/build_dependencies_test.go
+++ b/integration/build_dependencies_test.go
@@ -96,6 +96,7 @@ func TestBuildDependenciesCache(t *testing.T) {
 	// The test then triggers another build and verifies that the images in `rebuilt` were built
 	// (e.g., the changed images and their dependents), and that the other images were found in the artifact cache.
 	// It runs the profile `concurrency-0` which builds with maximum concurrency.
+	MarkIntegrationTest(t, CanRunWithoutGcp)
 	tests := []struct {
 		description string
 		change      []int
@@ -136,7 +137,6 @@ func TestBuildDependenciesCache(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			MarkIntegrationTest(t, CanRunWithoutGcp)
 			// modify file `foo` to invalidate cache for target artifacts
 			for _, i := range test.change {
 				Run(t, fmt.Sprintf("testdata/build-dependencies/app%d", i), "sh", "-c", fmt.Sprintf("echo %s > foo", uuid.New().String()))

--- a/pkg/skaffold/build/cache/lookup.go
+++ b/pkg/skaffold/build/cache/lookup.go
@@ -68,14 +68,14 @@ func (c *cache) lookup(ctx context.Context, a *latest.Artifact, tag string, plat
 		return failed{err: fmt.Errorf("getting hash for artifact %q: %s", a.ImageName, err)}
 	}
 
-	c.cacheMutex.RLock()
-	entry, cacheHit := c.artifactCache[hash]
-	c.cacheMutex.RUnlock()
-
 	pls := platforms.GetPlatforms(a.ImageName)
 	if isLocal, err := c.isLocalImage(a.ImageName); err != nil {
 		return failed{err}
 	} else if isLocal {
+		c.cacheMutex.RLock()
+		entry, cacheHit := c.artifactCache[hash]
+		c.cacheMutex.RUnlock()
+
 		// TODO (gaghosh): allow `tryImport` when the Docker daemon starts supporting multiarch images
 		// See https://github.com/docker/buildx/issues/1220#issuecomment-1189996403
 		if !cacheHit && !pls.IsMultiPlatform() {
@@ -90,23 +90,7 @@ func (c *cache) lookup(ctx context.Context, a *latest.Artifact, tag string, plat
 		}
 		return c.lookupLocal(ctx, hash, tag, entry)
 	}
-	if !cacheHit {
-		if digest, err := docker.RemoteDigest(tag, c.cfg, nil); err == nil {
-			log.Entry(ctx).Debugf("Added digest for %s to cache entry", tag)
-			entry.Digest = digest
-		} else {
-			log.Entry(ctx).Debugf("Could not get remote digest from docker, building instead (%s)", err)
-			return needsBuilding{hash: hash}
-		}
-
-		c.cacheMutex.Lock()
-		c.artifactCache[hash] = entry
-		c.cacheMutex.Unlock()
-
-		// No need to lookup remote if we have already found the image remotely
-		return found{hash: hash}
-	}
-	return c.lookupRemote(ctx, hash, tag, pls.Platforms, entry)
+	return c.lookupRemote(ctx, hash, tag, pls.Platforms)
 }
 
 func (c *cache) lookupLocal(ctx context.Context, hash, tag string, entry ImageDetails) cacheDetails {
@@ -134,29 +118,39 @@ func (c *cache) lookupLocal(ctx context.Context, hash, tag string, entry ImageDe
 	return needsBuilding{hash: hash}
 }
 
-func (c *cache) lookupRemote(ctx context.Context, hash, tag string, platforms []specs.Platform, entry ImageDetails) cacheDetails {
-	log.Entry(ctx).Debugf("Looking up %s tag when in entry it's %s", tag, entry.Digest)
-	if remoteDigest, err := docker.RemoteDigest(tag, c.cfg, nil); err == nil {
-		// Image exists remotely with the same tag and digest
+func (c *cache) lookupRemote(ctx context.Context, hash, tag string, platforms []specs.Platform) cacheDetails {
+	var cacheHit bool
+	entry := ImageDetails{}
+
+	if digest, err := docker.RemoteDigest(tag, c.cfg, nil); err == nil {
 		log.Entry(ctx).Debugf("Found %s remote", tag)
-		if remoteDigest == entry.Digest {
-			return found{hash: hash}
-		}
+		entry.Digest = digest
+
+		c.cacheMutex.Lock()
+		c.artifactCache[hash] = entry
+		c.cacheMutex.Unlock()
+		return found{hash: hash}
 	}
 
-	// Image exists remotely with a different tag
-	fqn := tag + "@" + entry.Digest // Actual tag will be ignored but we need the registry and the digest part of it.
-	log.Entry(ctx).Debugf("Looking up %s tag with the full fqn %s", tag, entry.Digest)
-	if remoteDigest, err := docker.RemoteDigest(fqn, c.cfg, nil); err == nil {
-		log.Entry(ctx).Debugf("Found %s with the full fqn", tag)
-		if remoteDigest == entry.Digest {
-			return needsRemoteTagging{hash: hash, tag: tag, digest: entry.Digest, platforms: platforms}
-		}
-	}
+	c.cacheMutex.RLock()
+	entry, cacheHit = c.artifactCache[hash]
+	c.cacheMutex.RUnlock()
 
-	// Image exists locally
-	if entry.ID != "" && c.client != nil && c.client.ImageExists(ctx, entry.ID) {
-		return needsPushing{hash: hash, tag: tag, imageID: entry.ID}
+	if cacheHit {
+		// Image exists remotely with a different tag
+		fqn := tag + "@" + entry.Digest // Actual tag will be ignored but we need the registry and the digest part of it.
+		log.Entry(ctx).Debugf("Looking up %s tag with the full fqn %s", tag, entry.Digest)
+		if remoteDigest, err := docker.RemoteDigest(fqn, c.cfg, nil); err == nil {
+			log.Entry(ctx).Debugf("Found %s with the full fqn", tag)
+			if remoteDigest == entry.Digest {
+				return needsRemoteTagging{hash: hash, tag: tag, digest: entry.Digest, platforms: platforms}
+			}
+		}
+
+		// Image exists locally
+		if entry.ID != "" && c.client != nil && c.client.ImageExists(ctx, entry.ID) {
+			return needsPushing{hash: hash, tag: tag, imageID: entry.ID}
+		}
 	}
 
 	return needsBuilding{hash: hash}

--- a/pkg/skaffold/build/cache/lookup_test.go
+++ b/pkg/skaffold/build/cache/lookup_test.go
@@ -149,13 +149,6 @@ func TestLookupRemote(t *testing.T) {
 		expected    cacheDetails
 	}{
 		{
-			description: "miss",
-			hasher:      mockHasher{"hash"},
-			api:         &testutil.FakeAPIClient{ErrImagePull: true},
-			cache:       map[string]ImageDetails{},
-			expected:    needsBuilding{hash: "hash"},
-		},
-		{
 			description: "hash failure",
 			hasher:      failingHasher{errors.New("BUG")},
 			expected:    failed{err: errors.New("getting hash for artifact \"artifact\": BUG")},
@@ -222,7 +215,7 @@ func TestLookupRemote(t *testing.T) {
 
 			// cmp.Diff cannot access unexported fields in *exec.Cmd, so use reflect.DeepEqual here directly
 			if !reflect.DeepEqual(test.expected, details[0]) {
-				t.Errorf("Expected result different from actual result. Expected: \n%v, \nActual: \n%v", test.expected, details)
+				t.Errorf("Expected result different from actual result. Expected: \n\"%v\", \nActual: \n\"%v\"", test.expected, details[0])
 			}
 		})
 	}

--- a/pkg/skaffold/build/cache/lookup_test.go
+++ b/pkg/skaffold/build/cache/lookup_test.go
@@ -146,11 +146,13 @@ func TestLookupRemote(t *testing.T) {
 		hasher      artifactHasher
 		cache       map[string]ImageDetails
 		api         *testutil.FakeAPIClient
+		tag         string
 		expected    cacheDetails
 	}{
 		{
 			description: "hash failure",
 			hasher:      failingHasher{errors.New("BUG")},
+			tag:         "tag",
 			expected:    failed{err: errors.New("getting hash for artifact \"artifact\": BUG")},
 		},
 		{
@@ -159,6 +161,7 @@ func TestLookupRemote(t *testing.T) {
 			cache: map[string]ImageDetails{
 				"hash": {Digest: "digest"},
 			},
+			tag:      "tag",
 			expected: found{hash: "hash"},
 		},
 		{
@@ -167,7 +170,8 @@ func TestLookupRemote(t *testing.T) {
 			cache: map[string]ImageDetails{
 				"hash": {Digest: "otherdigest"},
 			},
-			expected: needsRemoteTagging{hash: "hash", tag: "tag", digest: "otherdigest"},
+			tag:      "fqn_tag",
+			expected: needsRemoteTagging{hash: "hash", tag: "fqn_tag", digest: "otherdigest"},
 		},
 		{
 			description: "found locally",
@@ -175,8 +179,9 @@ func TestLookupRemote(t *testing.T) {
 			cache: map[string]ImageDetails{
 				"hash": {ID: "imageID"},
 			},
-			api:      (&testutil.FakeAPIClient{}).Add("tag", "imageID"),
-			expected: needsPushing{hash: "hash", tag: "tag", imageID: "imageID"},
+			api:      (&testutil.FakeAPIClient{}).Add("no_remote_tag", "imageID"),
+			tag:      "no_remote_tag",
+			expected: needsPushing{hash: "hash", tag: "no_remote_tag", imageID: "imageID"},
 		},
 		{
 			description: "not found",
@@ -185,6 +190,7 @@ func TestLookupRemote(t *testing.T) {
 				"hash": {ID: "imageID"},
 			},
 			api:      &testutil.FakeAPIClient{},
+			tag:      "no_remote_tag",
 			expected: needsBuilding{hash: "hash"},
 		},
 	}
@@ -194,7 +200,7 @@ func TestLookupRemote(t *testing.T) {
 				switch {
 				case identifier == "tag":
 					return "digest", nil
-				case identifier == "tag@otherdigest":
+				case identifier == "fqn_tag@otherdigest":
 					return "otherdigest", nil
 				default:
 					return "", errors.New("unknown remote tag")
@@ -209,7 +215,7 @@ func TestLookupRemote(t *testing.T) {
 				cfg:                &mockConfig{mode: config.RunModes.Build},
 			}
 			t.Override(&newArtifactHasherFunc, func(_ graph.ArtifactGraph, _ DependencyLister, _ config.RunMode) artifactHasher { return test.hasher })
-			details := cache.lookupArtifacts(context.Background(), map[string]string{"artifact": "tag"}, platform.Resolver{}, []*latest.Artifact{{
+			details := cache.lookupArtifacts(context.Background(), map[string]string{"artifact": test.tag}, platform.Resolver{}, []*latest.Artifact{{
 				ImageName: "artifact",
 			}})
 


### PR DESCRIPTION

**Related**: #9177


**Description**
The variable "entry" was not overridden before triggering the lookupRemote method.
The reason is because the entry variable was redeclared within an if block, resulting in a new, locally scoped variable. This redeclaration prevented the updates made to entry within this block from being reflected outside of it.

The bug was introduced in my last PR (9181)... I had no idea that in go, the "if" statement can define a whole new scope

I've also added some tests, so it would test the scenario where we have tags in the remote which shouldn't be built and also fixed another test where it uses missingPull functionality on the remote