### PR TITLE
chore: clean up example project deps

### DIFF
--- a/examples/grpc-e2e-tests/tests/go.mod
+++ b/examples/grpc-e2e-tests/tests/go.mod
@@ -3,7 +3,6 @@ module github.com/GoogleContainerTools/skaffold/v2/integration/examples/grpc-e2e
 go 1.19
 
 require (
-	github.com/GoogleContainerTools/skaffold/examples/grpc-e2e-tests/service v0.0.0-00010101000000-000000000000
 	github.com/google/uuid v1.3.0
 	github.com/onsi/ginkgo/v2 v2.2.0
 	github.com/onsi/gomega v1.21.1

--- a/integration/examples/grpc-e2e-tests/tests/go.mod
+++ b/integration/examples/grpc-e2e-tests/tests/go.mod
@@ -3,7 +3,6 @@ module github.com/GoogleContainerTools/skaffold/v2/integration/examples/grpc-e2e
 go 1.19
 
 require (
-	github.com/GoogleContainerTools/skaffold/examples/grpc-e2e-tests/service v0.0.0-00010101000000-000000000000
 	github.com/google/uuid v1.3.0
 	github.com/onsi/ginkgo/v2 v2.2.0
 	github.com/onsi/gomega v1.21.1


### PR DESCRIPTION
I've been seeing 
```bash
go: github.com/GoogleContainerTools/skaffold/examples/grpc-e2e-tests/service@v0.0.0-00010101000000-000000000000: invalid version: unknown revision 000000000000
go: github.com/GoogleContainerTools/skaffold/examples/grpc-e2e-tests/service@v0.0.0-00010101000000-000000000000: invalid version: unknown revision 000000000000
```
every time I open skaffold project with IntelliJ, this doesn't seem doing anything, but it's very annoying.
