### PR TITLE
feat: add new `build.local.bazel` entry for local, build-level Bazel configuration

### DIFF
--- a/docs-v2/content/en/schemas/v4beta9.json
+++ b/docs-v2/content/en/schemas/v4beta9.json
@@ -712,6 +712,29 @@
       "description": "describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
     },
+    "BazelConfig": {
+      "properties": {
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "args to pass to `bazel build` for all the `bazel` targets in the build step.",
+          "x-intellij-html-description": "args to pass to <code>bazel build</code> for all the <code>bazel</code> targets in the build step.",
+          "default": "[]",
+          "examples": [
+            "[\"-flag\", \"--otherflag\"]"
+          ]
+        }
+      },
+      "preferredOrder": [
+        "args"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "contains some configuration to apply to `bazel` commands when building `BazelArtifact` targets locally.",
+      "x-intellij-html-description": "contains some configuration to apply to <code>bazel</code> commands when building <code>BazelArtifact</code> targets locally."
+    },
     "BuildConfig": {
       "type": "object",
       "anyOf": [
@@ -3198,6 +3221,11 @@
     },
     "LocalBuild": {
       "properties": {
+        "bazel": {
+          "$ref": "#/definitions/BazelConfig",
+          "description": "contains some configuration to apply to `bazel` commands when building `BazelArtifact` targets locally.",
+          "x-intellij-html-description": "contains some configuration to apply to <code>bazel</code> commands when building <code>BazelArtifact</code> targets locally."
+        },
         "concurrency": {
           "type": "integer",
           "description": "how many artifacts can be built concurrently. 0 means \"no-limit\".",
@@ -3229,6 +3257,7 @@
       },
       "preferredOrder": [
         "push",
+        "bazel",
         "tryImportMissing",
         "useDockerCLI",
         "useBuildkit",

--- a/pkg/skaffold/build/bazel/types.go
+++ b/pkg/skaffold/build/bazel/types.go
@@ -16,20 +16,25 @@ limitations under the License.
 
 package bazel
 
-import "github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/docker"
+import (
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/docker"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/latest"
+)
 
 // Builder is an artifact builder that uses Bazel
 type Builder struct {
+	cfg         *latest.BazelConfig
 	localDocker docker.LocalDaemon
-	cfg         docker.Config
+	dockerCfg   docker.Config
 	pushImages  bool
 }
 
 // NewArtifactBuilder returns a new bazel artifact builder
-func NewArtifactBuilder(localDocker docker.LocalDaemon, cfg docker.Config, pushImages bool) *Builder {
+func NewArtifactBuilder(cfg *latest.BazelConfig, localDocker docker.LocalDaemon, dockerCfg docker.Config, pushImages bool) *Builder {
 	return &Builder{
-		localDocker: localDocker,
 		cfg:         cfg,
+		localDocker: localDocker,
+		dockerCfg:   dockerCfg,
 		pushImages:  pushImages,
 	}
 }

--- a/pkg/skaffold/build/local/types.go
+++ b/pkg/skaffold/build/local/types.go
@@ -136,7 +136,7 @@ func newPerArtifactBuilder(b *Builder, a *latest.Artifact) (artifactBuilder, err
 		return dockerbuilder.NewArtifactBuilder(b.localDocker, b.cfg, b.local.UseDockerCLI, b.local.UseBuildkit, b.pushImages, b.artifactStore, b.sourceDependencies), nil
 
 	case a.BazelArtifact != nil:
-		return bazel.NewArtifactBuilder(b.localDocker, b.cfg, b.pushImages), nil
+		return bazel.NewArtifactBuilder(b.local.BazelConfig, b.localDocker, b.cfg, b.pushImages), nil
 
 	case a.JibArtifact != nil:
 		return jib.NewArtifactBuilder(b.localDocker, b.cfg, b.pushImages, b.skipTests, b.artifactStore), nil

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -327,6 +327,10 @@ type LocalBuild struct {
 	// connects to a remote cluster.
 	Push *bool `yaml:"push,omitempty"`
 
+	// BazelConfig contains some configuration to apply to `bazel` commands
+	// when building `BazelArtifact` targets locally.
+	BazelConfig *BazelConfig `yaml:"bazel,omitempty"`
+
 	// TryImportMissing whether to attempt to import artifacts from
 	// Docker (either a local or remote registry) if not in the cache.
 	TryImportMissing bool `yaml:"tryImportMissing,omitempty"`
@@ -340,6 +344,16 @@ type LocalBuild struct {
 	// Concurrency is how many artifacts can be built concurrently. 0 means "no-limit".
 	// Defaults to `1`.
 	Concurrency *int `yaml:"concurrency,omitempty"`
+}
+
+// BazelConfig contains some configuration to apply to `bazel` commands
+// when building `BazelArtifact` targets locally.
+type BazelConfig struct {
+	// BuildArgs are args to pass to `bazel build` for all the `bazel` targets
+	// in the build step.
+	//
+	// For example: `["-flag", "--otherflag"]`.
+	BuildArgs []string `yaml:"args,omitempty"`
 }
 
 // GoogleCloudBuild *beta* describes how to do a remote build on


### PR DESCRIPTION
**Description**
This PR adds a new configuration field in `build.local` specific to Bazel, to specify some build-level parameters for (or to pass to) Bazel.

Example usecase: passing `--config=ci` argument.

Before:
```yaml
apiVersion: skaffold/v4beta6
kind: Config
build:
  artifacts:
    - image: hello
      bazel:
        target: //path/to:hello.tar
profiles:
  - name: ci
    patches:
      - op: add
        path: /build/artifacts/0/bazel/args
        value: [--config=ci]
```

After:
```yaml
apiVersion: skaffold/v4beta6
kind: Config
build:
  artifacts:
    - image: hello
      bazel:
        target: //path/to:hello.tar
profiles:
  - name: ci
    build:
      local:
        bazel:
          args: [--config=ci]
```
