### PR TITLE
docs: Document some undocumented config options

### DIFF
--- a/docs-v2/content/en/docs/design/global-config.md
+++ b/docs-v2/content/en/docs/design/global-config.md
@@ -20,7 +20,6 @@ The options are:
 | `kind-disable-load` | boolean | If true, do not use `kind load` to load images locally. |
 | `local-cluster` | boolean | If true, do not try to push images after building. By default, contexts with names `docker-for-desktop`, `docker-desktop`, or `minikube` are treated as local. |
 | `update-check` | boolean | Check for a more recent version of Skaffold. |
-| `survey.disable-prompt` | boolean | Disable reminder to fill in a survey. |
 | `collect-metrics` | boolean | Collect anonymized usage data. |
 
 For example, to treat any context as local by default:

--- a/docs-v2/content/en/docs/design/global-config.md
+++ b/docs-v2/content/en/docs/design/global-config.md
@@ -19,6 +19,9 @@ The options are:
 | `k3d-disable-load` | boolean | If true, do not use `k3d import image` to load images locally. |
 | `kind-disable-load` | boolean | If true, do not use `kind load` to load images locally. |
 | `local-cluster` | boolean | If true, do not try to push images after building. By default, contexts with names `docker-for-desktop`, `docker-desktop`, or `minikube` are treated as local. |
+| `update-check` | boolean | Check for a more recent version of Skaffold. |
+| `survey.disable-prompt` | boolean | Disable reminder to fill in a survey. |
+| `collect-metrics` | boolean | Collect anonymized usage data. |
 
 For example, to treat any context as local by default:
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Currently I'm getting:
1. Notice of a new version of skaffold
1. Nag to run skaffold survey
1. Notice of telemetry and opt-out command

It's starting to feel a bit spammy.  I am fine to use the config file to mute the messages, but I can't find the options to do so.  Seems like this page should be the right place? https://skaffold.dev/docs/design/global-config/

**User facing changes (remove if N/A)**
Updates the documentation for the options to disable the messages.
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
