### PR TITLE
fix(docs): document link

### DIFF
--- a/docs-v2/content/en/docs/install/_index.md
+++ b/docs-v2/content/en/docs/install/_index.md
@@ -25,7 +25,7 @@ Your use of this software is subject to the [Google Privacy Policy](https://poli
 
 {{% tab "CLOUD CODE" %}}
 
-[Cloud Code](https://cloud.google.com/code) provides a managed experience of using Skaffold in supported IDEs. You can install the `Cloud Code` extension for [Visual Studio Code]([https://cloud.google.com/code/docs/vscode/quickstart-k8s#installing](https://cloud.google.com/code/docs/vscode/install#installing)) or the plugin for [JetBrains IDEs](https://cloud.google.com/code/docs/intellij/quickstart-k8s#installing_the_plugin). It manages and keeps Skaffold  up-to-date, along with other common dependencies, and works with any kubernetes cluster.
+[Cloud Code](https://cloud.google.com/code) provides a managed experience of using Skaffold in supported IDEs. You can install the `Cloud Code` extension for [Visual Studio Code](https://cloud.google.com/code/docs/vscode/install#installing) or the plugin for [JetBrains IDEs](https://cloud.google.com/code/docs/intellij/quickstart-k8s#installing_the_plugin). It manages and keeps Skaffold  up-to-date, along with other common dependencies, and works with any kubernetes cluster.
 
 {{% /tab %}}
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
This is a trivial patch to some doc.
<!-- Include if applicable: -->
Fixes: (A wrong URL)

**Description**
The link is malformed as `[text]([url_a](url_b))` which produces an `<a>` with `href="%5Bhttps://cloud.google.com/code/docs/vscode/quickstart-k8s#installing%5D(https://cloud.google.com/code/docs/vscode/install#installing)"`.

**Notes**:
I forget to follow conventional commit message when editing from GitHub webpage. 
Maybe a squashing merge would help to regularize the commit history.