### PR TITLE
fix: apply-setter and transformer should ignore non-k8s-resource for kustomize paramterization

### DIFF
--- a/.github/workflows/integration-linux.yml
+++ b/.github/workflows/integration-linux.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        kustomize_version: [3.5.4]
+        kustomize_version: [5.0.3]
         ko_version: [0.4.0]
         kompose_version: [1.21.0]
         kpt_version: [1.0.0-beta.24]

--- a/.github/workflows/performance-comparison.yml
+++ b/.github/workflows/performance-comparison.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        kustomize_version: [3.5.4]
+        kustomize_version: [5.0.3]
         ko_version: [0.4.0]
         kompose_version: [1.21.0]
         gcloud_sdk_version: [410.0.0]

--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -1466,6 +1466,74 @@ spec:
         name: skaffold-kustomize
 `,
 		},
+		{
+			description: "kustomize parameterization success with patches",
+			args:        []string{"--offline", "--set", "app1=111a"},
+			config: `apiVersion: skaffold/v4beta2
+kind: Config
+metadata:
+  name: getting-started-kustomize
+manifests:
+  kustomize:
+    paths:
+    - base
+`, input: map[string]string{"base/kustomization.yaml": `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patches:
+  - path: patch.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: skaffold-kustomize
+resources:
+  - deployment.yaml
+`, "base/deployment.yaml": `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: skaffold-kustomize
+  labels:
+    app: skaffold-kustomize # from-param: ${app1}
+spec:
+  selector:
+    matchLabels:
+      app: skaffold-kustomize
+  template:
+    metadata:
+      labels:
+        app: skaffold-kustomize
+    spec:
+      containers:
+      - name: skaffold-kustomize
+        image: skaffold-kustomize
+`, "base/patch.yaml": `
+- op: add
+  path: /metadata/annotations/example.com
+  value: dummy
+`}, expectedOut: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: 111a
+  name: skaffold-kustomize
+  annotations:
+    example.com: dummy
+spec:
+  selector:
+    matchLabels:
+      app: skaffold-kustomize
+  template:
+    metadata:
+      labels:
+        app: skaffold-kustomize
+    spec:
+      containers:
+      - image: skaffold-kustomize
+        name: skaffold-kustomize
+`,
+		},
 		{description: "test set transformer values with value file",
 			args: []string{"--offline=true", "--set-value-file", "values.env"},
 			config: `

--- a/pkg/skaffold/render/renderer/kustomize/kustomize.go
+++ b/pkg/skaffold/render/renderer/kustomize/kustomize.go
@@ -33,6 +33,7 @@ import (
 	sErrors "github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/errors"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/kubectl"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/kubernetes/manifest"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/render"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/render/applysetters"
@@ -312,14 +313,16 @@ func (k Kustomize) mirrorFile(kusDir string, fs TmpFS, path string) error {
 		return err
 	}
 
-	err = k.transformer.TransformPath(fsPath)
-	if err != nil {
-		return err
-	}
+	if kubernetes.IsKubernetesManifest(fsPath) {
+		err = k.transformer.TransformPath(fsPath)
+		if err != nil {
+			return err
+		}
 
-	err = k.applySetters.ApplyPath(fsPath)
-	if err != nil {
-		return fmt.Errorf("failed to apply setter to file %s, err: %v", pFile, err)
+		err = k.applySetters.ApplyPath(fsPath)
+		if err != nil {
+			return fmt.Errorf("failed to apply setter to file %s, err: %v", pFile, err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION

Fixes: #9239 
 - kustomize parameterization doesn't work when having dependent files that are not k8s resources as apply-setters and other krm functions should only be applied to k8s resources, hence skipping applying those functions when mirroring kustomization files

