### PR TITLE
fix: helm-deploy-chart-path-template

### DIFF
--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -56,95 +56,11 @@ var tests = []struct {
 		targetLog:   "Hello world!",
 	},
 	{
-		description: "getting-started",
-		dir:         "examples/getting-started",
-		pods:        []string{"getting-started"},
-		targetLog:   "Hello world!",
-	},
-	{
-		description: "ko",
-		dir:         "examples/ko",
-		deployments: []string{"ko"},
-	},
-	{
-		description: "nodejs",
-		dir:         "examples/nodejs",
-		deployments: []string{"node"},
-	},
-	{
-		description: "structure-tests",
-		dir:         "examples/structure-tests",
-		pods:        []string{"getting-started"},
-	},
-	{
-		description: "custom-tests",
-		dir:         "examples/custom-tests",
-		pods:        []string{"custom-test"},
-	},
-	{
-		description: "microservices",
-		dir:         "examples/microservices",
-		// See https://github.com/GoogleContainerTools/skaffold/issues/2372
-		args:        []string{"--status-check=false"},
-		deployments: []string{"leeroy-app", "leeroy-web"},
-	},
-	{
-		description: "multi-config-microservices",
-		dir:         "examples/multi-config-microservices",
-		deployments: []string{"leeroy-app", "leeroy-web"},
-	},
-	{
-		description: "remote-multi-config-microservices",
-		dir:         "examples/remote-multi-config-microservices",
-		deployments: []string{"leeroy-app", "leeroy-web"},
-	},
-	{
-		description: "envTagger",
-		dir:         "examples/tagging-with-environment-variables",
-		pods:        []string{"getting-started"},
-		env:         []string{"FOO=foo"},
-	},
-	{
-		description: "bazel",
-		dir:         "examples/bazel",
-		pods:        []string{"bazel"},
-	},
-	{
-		description: "bazel oci",
-		dir:         "testdata/bazel-rules-oci",
-		deployments: []string{"helloweb"},
-	},
-	{
-		description: "bazel oci sub-directory",
-		dir:         "testdata/bazel-rules-oci",
-		args:        []string{"-p", "target-with-package"},
-		deployments: []string{"helloweb"},
-	},
-	{
-		description: "jib",
-		dir:         "testdata/jib",
-		deployments: []string{"web"},
-	},
-	{
-		description: "jib gradle",
-		dir:         "examples/jib-gradle",
-		deployments: []string{"web"},
-	},
-	{
-		description: "profiles",
-		dir:         "examples/profiles",
-		args:        []string{"-p", "minikube-profile"},
-		pods:        []string{"hello-service"},
-	},
-	{
-		description: "multiple deployers",
-		dir:         "testdata/deploy-multiple",
-		pods:        []string{"deploy-kubectl", "deploy-kustomize"},
-	},
-	{
-		description: "custom builder",
-		dir:         "examples/custom",
-		pods:        []string{"getting-started-custom"},
+		description: "helm templating charPath",
+		dir:         "testdata/helm",
+		args:        []string{"-p", "helm-templating-charPath"},
+		deployments: []string{"skaffold-helm"},
+		env:         []string{"FOO=skaffold-helm"},
 	},
 	// TODO(#8811): Enable this test when issue is solve.
 	// {

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -56,6 +56,97 @@ var tests = []struct {
 		targetLog:   "Hello world!",
 	},
 	{
+		description: "getting-started",
+		dir:         "examples/getting-started",
+		pods:        []string{"getting-started"},
+		targetLog:   "Hello world!",
+	},
+	{
+		description: "ko",
+		dir:         "examples/ko",
+		deployments: []string{"ko"},
+	},
+	{
+		description: "nodejs",
+		dir:         "examples/nodejs",
+		deployments: []string{"node"},
+	},
+	{
+		description: "structure-tests",
+		dir:         "examples/structure-tests",
+		pods:        []string{"getting-started"},
+	},
+	{
+		description: "custom-tests",
+		dir:         "examples/custom-tests",
+		pods:        []string{"custom-test"},
+	},
+	{
+		description: "microservices",
+		dir:         "examples/microservices",
+		// See https://github.com/GoogleContainerTools/skaffold/issues/2372
+		args:        []string{"--status-check=false"},
+		deployments: []string{"leeroy-app", "leeroy-web"},
+	},
+	{
+		description: "multi-config-microservices",
+		dir:         "examples/multi-config-microservices",
+		deployments: []string{"leeroy-app", "leeroy-web"},
+	},
+	{
+		description: "remote-multi-config-microservices",
+		dir:         "examples/remote-multi-config-microservices",
+		deployments: []string{"leeroy-app", "leeroy-web"},
+	},
+	{
+		description: "envTagger",
+		dir:         "examples/tagging-with-environment-variables",
+		pods:        []string{"getting-started"},
+		env:         []string{"FOO=foo"},
+	},
+	{
+		description: "bazel",
+		dir:         "examples/bazel",
+		pods:        []string{"bazel"},
+	},
+	{
+		description: "bazel oci",
+		dir:         "testdata/bazel-rules-oci",
+		deployments: []string{"helloweb"},
+	},
+	{
+		description: "bazel oci sub-directory",
+		dir:         "testdata/bazel-rules-oci",
+		args:        []string{"-p", "target-with-package"},
+		deployments: []string{"helloweb"},
+	},
+	{
+		description: "jib",
+		dir:         "testdata/jib",
+		deployments: []string{"web"},
+	},
+	{
+		description: "jib gradle",
+		dir:         "examples/jib-gradle",
+		deployments: []string{"web"},
+	},
+	{
+		description: "profiles",
+		dir:         "examples/profiles",
+		args:        []string{"-p", "minikube-profile"},
+		pods:        []string{"hello-service"},
+	},
+	{
+		description: "multiple deployers",
+		dir:         "testdata/deploy-multiple",
+		pods:        []string{"deploy-kubectl", "deploy-kustomize"},
+	},
+	{
+		description: "custom builder",
+		dir:         "examples/custom",
+		pods:        []string{"getting-started-custom"},
+	},
+	{
 		description: "helm templating charPath",
 		dir:         "testdata/helm",
 		args:        []string{"-p", "helm-templating-charPath"},

--- a/integration/testdata/helm/skaffold.yaml
+++ b/integration/testdata/helm/skaffold.yaml
@@ -44,3 +44,9 @@ profiles:
         # seed test namespace in the release name.
         - name: skaffold-helm-{{.TEST_NS}}
           chartPath: skaffold-helm
+- name: helm-templating-charPath
+  deploy:
+    helm:
+      releases:
+        - name: skaffold-helm
+          chartPath: '{{.FOO}}'

--- a/pkg/skaffold/deploy/helm/helm.go
+++ b/pkg/skaffold/deploy/helm/helm.go
@@ -276,6 +276,11 @@ func (h *Deployer) Deploy(ctx context.Context, out io.Writer, builds []graph.Art
 		if err != nil {
 			return helm.UserErr(fmt.Sprintf("cannot expand repo %q", r.Repo), err)
 		}
+		r.ChartPath, err = util.ExpandEnvTemplateOrFail(r.ChartPath, nil)
+		if err != nil {
+			return helm.UserErr(fmt.Sprintf("cannot expand chart path %q", r.ChartPath), err)
+		}
+
 		m, results, err := h.deployRelease(ctx, out, releaseName, r, builds, h.bV, chartVersion, repo)
 		if err != nil {
 			return helm.UserErr(fmt.Sprintf("deploying %q", releaseName), err)


### PR DESCRIPTION
Fixes: #9198 
 - templating deploy.helm.charPath doesn't work as expected https://skaffold.dev/docs/environment/templating/ , as skaffold doesn't do template replacement for deploy helm charPath, but it does for helm render 
 - this pr fixes the issue by taking this similar approach https://github.com/GoogleContainerTools/skaffold/commit/4c73c821e349a6306072d69bcc985a42a6af99fb