### PR TITLE
fix: print output from post render hook in console when `withChange: false`

### DIFF
--- a/integration/testdata/post-render-hooks/module1/skaffold.yaml
+++ b/integration/testdata/post-render-hooks/module1/skaffold.yaml
@@ -48,3 +48,17 @@ profiles:
               command:
                 - "sed"
                 - "s/before-change-1/after-change-1/g"
+
+  - name: one-change-two-without-change-but-with-output
+    manifests:
+      hooks:
+        after:
+          - host:
+              command: ["sh", "-c", "echo running post-render hook 1"]
+          - host:
+              command:
+                - "sed"
+                - "s/before-change-2/after-change-2/g"
+              withChange: true
+          - host:
+              command: ["sh", "-c", "echo running post-render hook 2"]

--- a/pkg/skaffold/hooks/render.go
+++ b/pkg/skaffold/hooks/render.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/kubernetes/manifest"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/output"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/output/log"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/latest"
 )
@@ -69,8 +70,10 @@ func (r renderRunner) RunPreHooks(ctx context.Context, out io.Writer) error {
 }
 
 func (r renderRunner) RunPostHooks(ctx context.Context, list manifest.ManifestList, out io.Writer) (manifest.ManifestList, error) {
+	logWriter := log.GetWriter()
+
 	if len(r.PostHooks) > 0 {
-		log.Entry(context.TODO()).Errorf("Starting %s hooks...", phases.PostRender)
+		output.Default.Fprintln(logWriter, fmt.Sprintf("Starting %s hooks...", phases.PostRender))
 	}
 	updated, err := manifest.Load(list.Reader())
 	if err != nil {
@@ -100,14 +103,14 @@ func (r renderRunner) RunPostHooks(ctx context.Context, list manifest.ManifestLi
 					return manifest.ManifestList{}, fmt.Errorf("failed to load manifest")
 				}
 			} else {
-				if err := hook.run(ctx, updated.Reader(), &b); err != nil && !errors.Is(err, &Skip{}) {
+				if err := hook.run(ctx, updated.Reader(), logWriter); err != nil && !errors.Is(err, &Skip{}) {
 					return manifest.ManifestList{}, err
 				}
 			}
 		}
 	}
 	if len(r.PostHooks) > 0 {
-		log.Entry(context.TODO()).Errorf("Completed %s hooks", phases.PostRender)
+		output.Default.Fprintln(logWriter, fmt.Sprintf("Completed %s hooks", phases.PostRender))
 	}
 	return updated, nil
 }
@@ -119,8 +122,10 @@ func (r renderRunner) getEnv() []string {
 }
 
 func (r renderRunner) run(ctx context.Context, out io.Writer, hooks []latest.RenderHookItem, phase phase) error {
+	logWriter := log.GetWriter()
+
 	if len(hooks) > 0 {
-		log.Entry(context.TODO()).Errorf("Starting %s hooks...", phase)
+		output.Default.Fprintln(logWriter, fmt.Sprintf("Starting %s hooks...", phase))
 	}
 	env := r.getEnv()
 	for _, h := range hooks {
@@ -132,7 +137,7 @@ func (r renderRunner) run(ctx context.Context, out io.Writer, hooks []latest.Ren
 		}
 	}
 	if len(hooks) > 0 {
-		log.Entry(context.TODO()).Errorf("Completed %s hooks...", phase)
+		output.Default.Fprintln(logWriter, fmt.Sprintf("Completed %s hooks...", phase))
 	}
 	return nil
 }

--- a/pkg/skaffold/output/log/log.go
+++ b/pkg/skaffold/output/log/log.go
@@ -122,6 +122,11 @@ func Entry(ctx context.Context) *logrus.Entry {
 	})
 }
 
+// Returns the output used by the logger to write its content.
+func GetWriter() io.Writer {
+	return logger.Out
+}
+
 // IsDebugLevelEnabled returns true if debug level log is enabled.
 func IsDebugLevelEnabled() bool {
 	return logger.IsLevelEnabled(logrus.DebugLevel)


### PR DESCRIPTION
Fixes: #9262

**Description**

- This PR sends stdout to the post-render hooks, when `withChange: false`, so user can print content from their associated script and see it in console

- From https://github.com/GoogleContainerTools/skaffold/blob/5904a97f994261008e644591ecf4a9c66de33dc9/cmd/skaffold/app/cmd/cmd.go#L94 the logger is configured to use stderr, so we can get the writer from it to print the content

- Decided to get the writer from the logger instead of calling `os.Stderr` directly so we share the same behaviour in case the logger changes, e.g., printing to a document (that's something that can not do today)
- Changed back the `Starting post-render hooks...`, etc, messages to use `output.Default.Fprintln` so we print the `ERRO` label

**Follow-up Work**

- A good idea might be to send both, `stdout` and `stderr` to the post-render hooks when `withChange: true` so users can print info content + the rendered manifests

