### PR TITLE
fix(kaniko): resolve blocking on Ctrl+C during Docker context creation

### DIFF
--- a/pkg/skaffold/build/cluster/kaniko.go
+++ b/pkg/skaffold/build/cluster/kaniko.go
@@ -134,11 +134,15 @@ func (b *Builder) copyKanikoBuildContext(ctx context.Context, workspace string, 
 	var out bytes.Buffer
 	if err := b.kubectlcli.Run(ctx, buildCtx, &out, "exec", "-i", podName, "-c", initContainer, "-n", b.Namespace, "--", "tar", "-xf", "-", "-C", kaniko.DefaultEmptyDirMountPath); err != nil {
 		errRun := fmt.Errorf("uploading build context: %s", out.String())
-		errTar := <-errs
-		if errTar != nil {
-			errRun = fmt.Errorf("%v\ntar errors: %w", errRun, errTar)
+		select {
+		case errTar := <-errs:
+			if errTar != nil {
+				errRun = fmt.Errorf("%v\ntar errors: %w", errRun, errTar)
+			}
+			return errRun
+		case <-ctx.Done():
+			return nil
 		}
-		return errRun
 	}
 	return nil
 }


### PR DESCRIPTION
**Description**

This commit resolves a deadlock issue in Skaffold where sending a `Ctrl+C` interrupt during the Docker context creation process, specifically while executing `tw.WriteHeader(header)` in `pkg/skaffold/util/tar.go`, would cause an indefinite block. The solution implemented adds a `select` statement to handle the context cancellation, allowing the process to exit gracefully.

---

**User facing changes**

**Before**: Previously, when a user pressed `Ctrl+C` during the Docker context creation with Kaniko, Skaffold would block indefinitely, requiring manual termination of the process.

**After**: With the fix, Skaffold now responds to `Ctrl+C` interrupts promptly during the Docker context creation, terminating the process gracefully and avoiding a deadlock.