### PR TITLE
fix(kaniko): delete kaniko pod on graceful shutdown

### DIFF
--- a/pkg/skaffold/build/cluster/kaniko.go
+++ b/pkg/skaffold/build/cluster/kaniko.go
@@ -83,6 +83,8 @@ func (b *Builder) buildWithKaniko(ctx context.Context, out io.Writer, workspace 
 	}
 
 	defer func() {
+		// if build interrupted the original context is cancelled
+		// and pod deletion will not be called, so we need a new ctx
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 		defer cancel()
 

--- a/pkg/skaffold/build/cluster/kaniko.go
+++ b/pkg/skaffold/build/cluster/kaniko.go
@@ -77,10 +77,15 @@ func (b *Builder) buildWithKaniko(ctx context.Context, out io.Writer, workspace 
 	}
 
 	pod, err := pods.Create(ctx, podSpec, metav1.CreateOptions{})
+
 	if err != nil {
 		return "", fmt.Errorf("creating kaniko pod: %w", err)
 	}
+
 	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+
 		if err := pods.Delete(ctx, pod.Name, metav1.DeleteOptions{
 			GracePeriodSeconds: new(int64),
 		}); err != nil {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #8800 <!-- tracking issues that this PR will close -->

**Description**
Fixed kaniko pod delete in case of graceful shutdown

**User facing changes**
**Before**: skaffold doesn't delete kaniko pod if build is interrupted with ctrl-c after creating the pod

**After**: skaffold triggers deletion of kaniko pod if build is interrupted with ctrl-c after creating the pod