### PR TITLE
feat(tar): added logs to CreateTar func

### DIFF
--- a/pkg/skaffold/util/tar.go
+++ b/pkg/skaffold/util/tar.go
@@ -53,6 +53,10 @@ func CreateTar(ctx context.Context, w io.Writer, root string, paths []string) er
 	defer tw.Close()
 
 	batchSize := len(paths) / 10
+	if batchSize < 10 {
+		batchSize = 5
+	}
+
 	log.Entry(ctx).Infof("Creating tar file from %d file(s)", len(paths))
 	for i, path := range paths {
 		if err := addFileToTar(ctx, root, path, "", tw, nil); err != nil {
@@ -63,7 +67,7 @@ func CreateTar(ctx context.Context, w io.Writer, root string, paths []string) er
 			log.Entry(ctx).Infof("Added %d/%d files to tar file", i+1, len(paths))
 		}
 	}
-	log.Entry(ctx).Infof("Successfully created tar file")
+	log.Entry(ctx).Info("Successfully created tar file")
 
 	return nil
 }

--- a/pkg/skaffold/util/tar.go
+++ b/pkg/skaffold/util/tar.go
@@ -20,6 +20,7 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -52,12 +53,20 @@ func CreateTar(ctx context.Context, w io.Writer, root string, paths []string) er
 	tw := tar.NewWriter(w)
 	defer tw.Close()
 
-	for _, path := range paths {
+	batchSize := len(paths) / 10
+	log.Entry(ctx).Infof("Creating tar file from %d file(s)", len(paths))
+	for i, path := range paths {
 		if err := addFileToTar(ctx, root, path, "", tw, nil); err != nil {
 			return err
 		}
-	}
 
+		if (i+1)%batchSize == 0 {
+			log.Entry(ctx).Infof("Added %d/%d files to tar file", i+1, len(paths))
+		}
+	}
+	log.Entry(ctx).Infof("Successfully created tar file")
+
+	return errors.New("test")
 	return nil
 }
 

--- a/pkg/skaffold/util/tar.go
+++ b/pkg/skaffold/util/tar.go
@@ -20,7 +20,6 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -66,7 +65,6 @@ func CreateTar(ctx context.Context, w io.Writer, root string, paths []string) er
 	}
 	log.Entry(ctx).Infof("Successfully created tar file")
 
-	return errors.New("test")
 	return nil
 }
 


### PR DESCRIPTION
**Description**
Kaniko build can take more than 5 minutes while it creates a tar file and within the time you don't see any logs and you don't know what's going on, I think it'll be useful to show some progress so user can see that something is going on and you need to wait because sometimes I thought that it stuck while it's just trying to create a tar with a lot of files(more than 80k)

**User facing changes**
before(it took 4 minutes and I see no logs within the time): 
![image](https://github.com/GoogleContainerTools/skaffold/assets/3595194/451850ae-0774-455e-ad08-e58d9ab0fbc4)

after: 
![image](https://github.com/GoogleContainerTools/skaffold/assets/3595194/d0ea9fa5-b2f7-4c38-bc31-7fbf6429904e)
