### PR TITLE
Support `FORCE_COLOR` env variable

### DIFF
--- a/docs-v2/content/en/docs/references/cli/_index.md
+++ b/docs-v2/content/en/docs/references/cli/_index.md
@@ -1108,6 +1108,7 @@ Env vars:
 The following options can be passed to any command:
 
       --color=34: Specify the default output color in ANSI escape codes
+      --force-color=false: Always print color codes
       --interactive=true: Allow user prompts for more information
       --timestamps=false: Print timestamps in logs
       --update-check=true: Check for a more recent version of Skaffold
@@ -1115,6 +1116,15 @@ The following options can be passed to any command:
 
 
 ```
+
+Env vars:
+
+* `SKAFFOLD_COLOR` (same as `--color`)
+* `SKAFFOLD_INTERACTIVE` (same as `--interactive`)
+* `SKAFFOLD_TIMESTAMPS` (same as `--timestamps`)
+* `SKAFFOLD_UPDATE_CHECK` (same as `--update-check`)
+* `SKAFFOLD_VERBOSITY` (same as `--verbosity`)
+* `SKAFFOLD_FORCE_COLOR` or `FORCE_COLOR` (same as `--force-color`)
 
 ### skaffold render
 

--- a/pkg/skaffold/output/color.go
+++ b/pkg/skaffold/output/color.go
@@ -52,14 +52,14 @@ var DefaultColorCodes = []Color{
 }
 
 // SetupColors conditionally wraps the input `Writer` with a color enabled `Writer`.
-func SetupColors(ctx context.Context, out io.Writer, defaultColor int, forceColors bool) io.Writer {
+func SetupColors(ctx context.Context, out io.Writer, defaultColor int, forceColor bool) io.Writer {
 	_, isTerm := term.IsTerminal(out)
 	supportsColor, err := term.SupportsColor(ctx)
 	if err != nil {
 		log.Entry(context.TODO()).Debugf("error checking for color support: %v", err)
 	}
 
-	useColors := (isTerm && supportsColor) || forceColors
+	useColors := (isTerm && supportsColor) || forceColor
 	if useColors {
 		// Use EnableColorsStdout to enable use of color on Windows
 		useColors = false // value is updated if color-enablement is successful

--- a/pkg/skaffold/output/output.go
+++ b/pkg/skaffold/output/output.go
@@ -63,13 +63,13 @@ func (s skaffoldWriter) Write(p []byte) (int, error) {
 	return written, nil
 }
 
-func GetWriter(ctx context.Context, out io.Writer, defaultColor int, forceColors bool, timestamps bool) io.Writer {
+func GetWriter(ctx context.Context, out io.Writer, defaultColor int, forceColor bool, timestamps bool) io.Writer {
 	if _, isSW := out.(skaffoldWriter); isSW {
 		return out
 	}
 
 	return skaffoldWriter{
-		MainWriter:  SetupColors(ctx, out, defaultColor, forceColors),
+		MainWriter:  SetupColors(ctx, out, defaultColor, forceColor),
 		EventWriter: eventV2.NewLogger(constants.DevLoop, "-1"),
 		timestamps:  timestamps,
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
**Related**: #2033

**Description**
Adds support for the common [`FORCE_COLOR`](https://force-color.org/) environmental variable to force the use of color output. I also decided to rename `--force-colors` to `--force-color` for consistency with the environmental variable and have made the option no longer hidden as it makes it hard to discover.

**User facing changes**
<!-- Describe any user facing changes this PR introduces. -->
Makes discovery of the global option and the associated environmental variable easier to discover.

<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
