### PR TITLE
fix(lookupRemote): fixed lookup.go lookupRemote to compare remote and cached digests

### DIFF
--- a/pkg/skaffold/build/cache/cache.go
+++ b/pkg/skaffold/build/cache/cache.go
@@ -42,6 +42,14 @@ type ImageDetails struct {
 	ID     string `yaml:"id,omitempty"`
 }
 
+func (d ImageDetails) HasID() bool {
+	return d.ID != ""
+}
+
+func (d ImageDetails) HasDigest() bool {
+	return d.Digest != ""
+}
+
 // ArtifactCache is a map of [artifact dependencies hash : ImageDetails]
 type ArtifactCache map[string]ImageDetails
 

--- a/pkg/skaffold/build/cache/lookup.go
+++ b/pkg/skaffold/build/cache/lookup.go
@@ -131,12 +131,12 @@ func (c *cache) lookupRemote(ctx context.Context, hash, tag string, platforms []
 
 		log.Entry(ctx).Debugf("Found %s remote with a different digest", tag)
 
+		cachedEntry.Digest = remoteDigest
 		c.cacheMutex.Lock()
-		c.artifactCache[hash] = ImageDetails{Digest: remoteDigest}
+		c.artifactCache[hash] = cachedEntry
 		c.cacheMutex.Unlock()
-		return needsRemoteTagging{hash: hash, tag: tag, digest: remoteDigest, platforms: platforms}
+		cacheHit = true
 	}
-
 
 	if cacheHit {
 		// Image exists remotely with a different tag

--- a/pkg/skaffold/build/cache/lookup.go
+++ b/pkg/skaffold/build/cache/lookup.go
@@ -135,7 +135,7 @@ func (c *cache) lookupRemote(ctx context.Context, hash, tag string, platforms []
 		c.cacheMutex.Lock()
 		c.artifactCache[hash] = cachedEntry
 		c.cacheMutex.Unlock()
-		cacheHit = true
+		return needsRemoteTagging{hash: hash, tag: tag, digest: cachedEntry.Digest, platforms: platforms}
 	}
 
 	if cacheHit {

--- a/pkg/skaffold/build/cache/retrieve_test.go
+++ b/pkg/skaffold/build/cache/retrieve_test.go
@@ -206,31 +206,23 @@ func TestCacheBuildRemote(t *testing.T) {
 			Write("dep1", "content1").
 			Write("dep2", "content2").
 			Write("dep3", "content3").
-			Write("dep4", "content4").
-			Write("dep5", "content5").
 			Chdir()
 
 		tags := map[string]string{
-			"artifact1":       "artifact1:tag1",
-			"artifact2":       "artifact2:tag2",
-			"exist_artifact1": "exist_artifact1:tag1",
-			"exist_artifact2": "exist_artifact2:tag2",
+			"artifact1": "artifact1:tag1",
+			"artifact2": "artifact2:tag2",
 		}
 		artifacts := []*latest.Artifact{
 			{ImageName: "artifact1", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{}}},
 			{ImageName: "artifact2", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{}}},
-			{ImageName: "exist_artifact1", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{}}},
-			{ImageName: "exist_artifact2", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{}}},
 		}
 		deps := depLister(map[string][]string{
-			"artifact1":       {"dep1", "dep2"},
-			"artifact2":       {"dep3"},
-			"exist_artifact1": {"dep4"},
-			"exist_artifact2": {"dep5"},
+			"artifact1": {"dep1", "dep2"},
+			"artifact2": {"dep3"},
 		})
 		tagToDigest := map[string]string{
-			"exist_artifact1:tag1": "sha256:51ae7fa00c92525c319404a3a6d400e52ff9372c5a39cb415e0486fe425f3165",
-			"exist_artifact2:tag2": "sha256:35bdf2619f59e6f2372a92cb5486f4a0bf9b86e0e89ee0672864db6ed9c51539",
+			"artifact1:tag1": "sha256:51ae7fa00c92525c319404a3a6d400e52ff9372c5a39cb415e0486fe425f3165",
+			"artifact2:tag2": "sha256:35bdf2619f59e6f2372a92cb5486f4a0bf9b86e0e89ee0672864db6ed9c51539",
 		}
 
 		// Mock Docker
@@ -273,16 +265,10 @@ func TestCacheBuildRemote(t *testing.T) {
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual(2, len(builder.built))
-		t.CheckDeepEqual(4, len(bRes))
+		t.CheckDeepEqual(2, len(bRes))
 		// Artifacts should always be returned in their original order
 		t.CheckDeepEqual("artifact1", bRes[0].ImageName)
 		t.CheckDeepEqual("artifact2", bRes[1].ImageName)
-
-		// Add the other tags to the remote cache
-		tagToDigest["artifact1:tag1"] = tagToDigest["exist_artifact1:tag1"]
-		tagToDigest["artifact2:tag2"] = tagToDigest["exist_artifact2:tag2"]
-		api.Add("artifact1:tag1", tagToDigest["artifact1:tag1"])
-		api.Add("artifact2:tag2", tagToDigest["artifact2:tag2"])
 
 		// Second build: both artifacts are read from cache
 		builder = &mockBuilder{dockerDaemon: dockerDaemon, push: true, cache: artifactCache}
@@ -290,20 +276,18 @@ func TestCacheBuildRemote(t *testing.T) {
 
 		t.CheckNoError(err)
 		t.CheckEmpty(builder.built)
-		t.CheckDeepEqual(4, len(bRes))
+		t.CheckDeepEqual(2, len(bRes))
 		t.CheckDeepEqual("artifact1", bRes[0].ImageName)
 		t.CheckDeepEqual("artifact2", bRes[1].ImageName)
 
 		// Third build: change one artifact's dependencies
 		tmpDir.Write("dep1", "new content")
-		tags["artifact1"] = "artifact1:new_tag1"
-
 		builder = &mockBuilder{dockerDaemon: dockerDaemon, push: true, cache: artifactCache}
 		bRes, err = artifactCache.Build(context.Background(), io.Discard, tags, artifacts, platform.Resolver{}, builder.Build)
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual(1, len(builder.built))
-		t.CheckDeepEqual(4, len(bRes))
+		t.CheckDeepEqual(2, len(bRes))
 		t.CheckDeepEqual("artifact1", bRes[0].ImageName)
 		t.CheckDeepEqual("artifact2", bRes[1].ImageName)
 	})

--- a/pkg/skaffold/runner/new.go
+++ b/pkg/skaffold/runner/new.go
@@ -232,8 +232,12 @@ func isImageLocal(runCtx *runcontext.RunContext, imageName string) (bool, error)
 		log.Entry(context.TODO()).Debugf("Didn't find pipeline for image %s. Using default pipeline!", imageName)
 		pipeline = runCtx.DefaultPipeline()
 	}
-	if pipeline.Build.GoogleCloudBuild != nil || pipeline.Build.Cluster != nil {
-		log.Entry(context.TODO()).Debugf("Image %s is remote because it has GoogleCloudBuild or pipeline.Build.Cluster", imageName)
+	if pipeline.Build.GoogleCloudBuild != nil {
+		log.Entry(context.TODO()).Debugf("Image %s is remote because it has pipeline.Build.GoogleCloudBuild", imageName)
+		return false, nil
+	}
+	if pipeline.Build.Cluster != nil {
+		log.Entry(context.TODO()).Debugf("Image %s is remote because it has pipeline.Build.Cluster", imageName)
 		return false, nil
 	}
 


### PR DESCRIPTION
Fixes: #9248 <!-- tracking issues that this PR will close -->

**Description**
It is used to lookup remote images by tag and overwrite a cached item even if the digests are different, now it compares the digests
