### PR TITLE
chore: new googleCloudBuildRepoV2 field to configure a remote dependency

### DIFF
--- a/docs-v2/content/en/schemas/v4beta10.json
+++ b/docs-v2/content/en/schemas/v4beta10.json
@@ -1319,6 +1319,11 @@
           "description": "describes a remote git repository containing the required configs.",
           "x-intellij-html-description": "describes a remote git repository containing the required configs."
         },
+        "googleCloudBuildRepoV2": {
+          "$ref": "#/definitions/GoogleCloudBuildRepoV2Info",
+          "description": "describes a [Google Cloud Build repository (2nd gen)](https://cloud.google.com/build/docs/repositories#repositories_2nd_gen) that points to a repo with the required configs.",
+          "x-intellij-html-description": "describes a <a href=\"https://cloud.google.com/build/docs/repositories#repositories_2nd_gen\">Google Cloud Build repository (2nd gen)</a> that points to a repo with the required configs."
+        },
         "googleCloudStorage": {
           "$ref": "#/definitions/GoogleCloudStorageInfo",
           "description": "describes remote Google Cloud Storage objects containing the required configs.",
@@ -1335,6 +1340,7 @@
         "path",
         "git",
         "googleCloudStorage",
+        "googleCloudBuildRepoV2",
         "activeProfiles"
       ],
       "additionalProperties": false,
@@ -2132,6 +2138,64 @@
       "type": "object",
       "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
+    },
+    "GoogleCloudBuildRepoV2Info": {
+      "required": [
+        "projectID",
+        "region",
+        "connection",
+        "repo"
+      ],
+      "properties": {
+        "connection": {
+          "type": "string",
+          "description": "name of the GCB repository connection associated with the repo.",
+          "x-intellij-html-description": "name of the GCB repository connection associated with the repo."
+        },
+        "path": {
+          "type": "string",
+          "description": "relative path from the repo root to the skaffold configuration file. eg. `getting-started/skaffold.yaml`.",
+          "x-intellij-html-description": "relative path from the repo root to the skaffold configuration file. eg. <code>getting-started/skaffold.yaml</code>."
+        },
+        "projectID": {
+          "type": "string",
+          "description": "ID of the GCP project where the repository is configured.",
+          "x-intellij-html-description": "ID of the GCP project where the repository is configured."
+        },
+        "ref": {
+          "type": "string",
+          "description": "git ref the repo should be cloned from. e.g. `master` or `main`.",
+          "x-intellij-html-description": "git ref the repo should be cloned from. e.g. <code>master</code> or <code>main</code>."
+        },
+        "region": {
+          "type": "string",
+          "description": "GCP region where the repository is configured.",
+          "x-intellij-html-description": "GCP region where the repository is configured."
+        },
+        "repo": {
+          "type": "string",
+          "description": "name of repository under the given connection.",
+          "x-intellij-html-description": "name of repository under the given connection."
+        },
+        "sync": {
+          "type": "boolean",
+          "description": "when set to `true` will reset the cached repository to the latest commit from remote on every run. To use the cached repository with uncommitted changes or unpushed commits, it needs to be set to `false`.",
+          "x-intellij-html-description": "when set to <code>true</code> will reset the cached repository to the latest commit from remote on every run. To use the cached repository with uncommitted changes or unpushed commits, it needs to be set to <code>false</code>."
+        }
+      },
+      "preferredOrder": [
+        "projectID",
+        "region",
+        "connection",
+        "repo",
+        "path",
+        "ref",
+        "sync"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "contains information on the origin of skaffold configurations cloned from Google Cloud Build repository (2nd gen).",
+      "x-intellij-html-description": "contains information on the origin of skaffold configurations cloned from Google Cloud Build repository (2nd gen)."
     },
     "GoogleCloudStorageInfo": {
       "properties": {

--- a/integration/deploy_test.go
+++ b/integration/deploy_test.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
+
 	"github.com/GoogleContainerTools/skaffold/v2/cmd/skaffold/app/flags"
 	"github.com/GoogleContainerTools/skaffold/v2/integration/skaffold"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/util"
@@ -38,7 +40,7 @@ func TestBuildDeploy(t *testing.T) {
 
 	ns, client := SetupNamespace(t)
 
-	outputBytes := skaffold.Build("--quiet", "--platform=linux/arm64,linux/amd64").InDir("examples/nodejs").InNs(ns.Name).RunOrFailOutput(t)
+	outputBytes := skaffold.Build("--quiet", "--platform=linux/arm64,linux/amd64", "--cache-artifacts=false", "--tag", uuid.New().String()).InDir("examples/nodejs").InNs(ns.Name).RunOrFailOutput(t)
 	// Parse the Build Output
 	buildArtifacts, err := flags.ParseBuildOutput(outputBytes)
 	failNowIfError(t, err)

--- a/integration/remote_config_dependency_test.go
+++ b/integration/remote_config_dependency_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2024 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/v2/integration/skaffold"
+	"github.com/GoogleContainerTools/skaffold/v2/testutil"
+)
+
+func TestRenderWithGCBRepositoryRemoteDependency(t *testing.T) {
+	tests := []struct {
+		description    string
+		configFile     string
+		shouldErr      bool
+		expectedOutput string
+		expectedErrMsg string
+	}{
+		{
+			description: "GCB repository remote dependency with private git repo",
+			configFile: `apiVersion: skaffold/v4beta10
+kind: Config
+requires:
+  - googleCloudBuildRepoV2:
+      projectID: k8s-skaffold
+      region: us-central1
+      connection: github-connection-e2e-tests
+      repo: skaffold-getting-started
+`,
+			expectedOutput: `apiVersion: v1
+kind: Pod
+metadata:
+  name: getting-started
+spec:
+  containers:
+  - image: skaffold-example:fixed
+    name: getting-started
+`,
+		},
+		{
+			description: "GCB repository remote dependency with private git repo, pointing to an specific branch",
+			configFile: `apiVersion: skaffold/v4beta10
+kind: Config
+requires:
+  - googleCloudBuildRepoV2:
+      projectID: k8s-skaffold
+      region: us-central1
+      connection: github-connection-e2e-tests
+      repo: skaffold-getting-started
+      ref: feature-branch
+`,
+			expectedOutput: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deployment
+  labels:
+    app: my-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-deployment
+  template:
+    metadata:
+      labels:
+        app: my-deployment
+    spec:
+      containers:
+      - name: getting-started
+        image: skaffold-example-deployment:fixed
+`,
+		},
+		{
+			description: "GCB repository remote dependency with private git repo fails, bad configuration",
+			configFile: `apiVersion: skaffold/v4beta10
+kind: Config
+requires:
+  - googleCloudBuildRepoV2:
+      projectID: bad-repo
+      region: us-central1
+      connection: github-connection-e2e-tests
+      repo: skaffold-getting-started
+      ref: feature-branch
+`,
+			shouldErr:      true,
+			expectedErrMsg: "getting GCB repo info for skaffold-getting-started: failed to get remote URI for repository skaffold-getting-started",
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			MarkIntegrationTest(t.T, NeedsGcp)
+			tmpDir := t.NewTempDir()
+			tmpDir.Write("skaffold.yaml", test.configFile)
+			args := []string{"--remote-cache-dir", tmpDir.Root(), "--tag", "fixed", "--default-repo=", "--digest-source", "tag"}
+			output, err := skaffold.Render(args...).InDir(tmpDir.Root()).RunWithCombinedOutput(t.T)
+
+			t.CheckError(test.shouldErr, err)
+
+			if !test.shouldErr {
+				t.CheckDeepEqual(test.expectedOutput, string(output), testutil.YamlObj(t.T))
+			} else {
+				t.CheckContains(test.expectedErrMsg, string(output))
+			}
+		})
+	}
+}

--- a/pkg/skaffold/git/errors.go
+++ b/pkg/skaffold/git/errors.go
@@ -20,12 +20,11 @@ import (
 	"fmt"
 
 	sErrors "github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/errors"
-	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/v2/proto/v1"
 )
 
 // SyncDisabledErr returns error when git repository sync is turned off by the user but the repository clone doesn't exist inside the cache directory.
-func SyncDisabledErr(g latest.GitInfo, repoCacheDir string) error {
+func SyncDisabledErr(g Config, repoCacheDir string) error {
 	msg := fmt.Sprintf("cache directory %q for repository %q at ref %q does not exist, and repository sync is explicitly disabled via flag `--sync-remote-cache`", repoCacheDir, g.Repo, g.Ref)
 	return sErrors.NewError(fmt.Errorf(msg),
 		&proto.ActionableErr{

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -121,6 +121,30 @@ type GoogleCloudStorageInfo struct {
 	Sync *bool `yaml:"sync,omitempty"`
 }
 
+// GoogleCloudBuildRepoV2Info contains information on the origin of skaffold configurations cloned from Google Cloud Build repository (2nd gen).
+type GoogleCloudBuildRepoV2Info struct {
+	// ProjectID is the ID of the GCP project where the repository is configured.
+	ProjectID string `yaml:"projectID" yamltags:"required"`
+
+	// Region is the GCP region where the repository is configured.
+	Region string `yaml:"region" yamltags:"required"`
+
+	// Connection is the name of the GCB repository connection associated with the repo.
+	Connection string `yaml:"connection" yamltags:"required"`
+
+	// Repo is the name of repository under the given connection.
+	Repo string `yaml:"repo" yamltags:"required"`
+
+	// Path is the relative path from the repo root to the skaffold configuration file. eg. `getting-started/skaffold.yaml`.
+	Path string `yaml:"path,omitempty"`
+
+	// Ref is the git ref the repo should be cloned from. e.g. `master` or `main`.
+	Ref string `yaml:"ref,omitempty"`
+
+	// Sync when set to `true` will reset the cached repository to the latest commit from remote on every run. To use the cached repository with uncommitted changes or unpushed commits, it needs to be set to `false`.
+	Sync *bool `yaml:"sync,omitempty"`
+}
+
 // ConfigDependency describes a dependency on another skaffold configuration.
 type ConfigDependency struct {
 	// Names includes specific named configs within the file path. If empty, then all configs in the file are included.
@@ -134,6 +158,9 @@ type ConfigDependency struct {
 
 	// GoogleCloudStorage describes remote Google Cloud Storage objects containing the required configs.
 	GoogleCloudStorage *GoogleCloudStorageInfo `yaml:"googleCloudStorage,omitempty" yamltags:"oneOf=paths"`
+
+	// GoogleCloudBuildRepoV2 describes a [Google Cloud Build repository (2nd gen)](https://cloud.google.com/build/docs/repositories#repositories_2nd_gen) that points to a repo with the required configs.
+	GoogleCloudBuildRepoV2 *GoogleCloudBuildRepoV2Info `yaml:"googleCloudBuildRepoV2,omitempty" yamltags:"oneOf=paths"`
 
 	// ActiveProfiles describes the list of profiles to activate when resolving the required configs. These profiles must exist in the imported config.
 	ActiveProfiles []ProfileDependency `yaml:"activeProfiles,omitempty"`


### PR DESCRIPTION
**Related**: #9236

**Description**

- Add a new `requires[].googleCloudBuildRepoV2` config key to allow a remote dependency configuration using Google Cloud Build Repositories V2
- Changes in the gitutil package to be able to handle the case when we have a URI with the `oauth2` format. Now the package defines the struct it accepts to download/sync a repo instead of using the `latest.GitInfo` from the yaml schema, leaving only the necessary fields it needs
- Now when the gitutil package detects that the repo needs to be sync (instead of cloned), it will try to change the `remote origin` URL before triggering `git fetch` and `git reset`. This to handle the case when we use `oauth2`, the read token can expire, so we need to use the new one fetched from CB
- If the same repo, e.g, https://github.com/org/repo.git, is configured with `requires[].googleCloudBuildRepoV2` and `requires[].git`, the generated folder name will be the same for both due to they use the same inputs to generate the hash (repo + ref). This shouldn't be a problem due to is the same source, and what will change is the `remote origin` URL to use, or not, the `oauth2` format
- The integration test is using `skaffold render` to check that the remote dependency was fetched correctly