### PR TITLE
feat(profile): Added profile list command to output available profile names

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -185,6 +185,7 @@ func NewSkaffoldCommand(out, errOut io.Writer) *cobra.Command {
 
 	// other commands
 	rootCmd.AddCommand(NewCmdVersion())
+	rootCmd.AddCommand(NewCmdProfile())
 	rootCmd.AddCommand(NewCmdFix())
 	rootCmd.AddCommand(NewCmdCompletion())
 	rootCmd.AddCommand(NewCmdConfig())

--- a/cmd/skaffold/app/cmd/profile.go
+++ b/cmd/skaffold/app/cmd/profile.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/GoogleContainerTools/skaffold/v2/cmd/skaffold/app/cmd/profile"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdProfile() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "profile",
+		Short: "Work with Skaffold profiles",
+	}
+
+	cmd.AddCommand(NewCmdProfileList())
+
+	return cmd
+}
+
+func NewCmdProfileList() *cobra.Command {
+	return NewCmd("list").
+		WithDescription("List available profile names").
+		WithFlagAdder(profile.AddListFlags).
+		NoArgs(profile.List)
+}

--- a/cmd/skaffold/app/cmd/profile.go
+++ b/cmd/skaffold/app/cmd/profile.go
@@ -17,8 +17,9 @@ limitations under the License.
 package cmd
 
 import (
-	"github.com/GoogleContainerTools/skaffold/v2/cmd/skaffold/app/cmd/profile"
 	"github.com/spf13/cobra"
+
+	"github.com/GoogleContainerTools/skaffold/v2/cmd/skaffold/app/cmd/profile"
 )
 
 func NewCmdProfile() *cobra.Command {

--- a/cmd/skaffold/app/cmd/profile/flags.go
+++ b/cmd/skaffold/app/cmd/profile/flags.go
@@ -21,9 +21,11 @@ import (
 )
 
 var (
-	filename string
+	filename   string
+	outputType string
 )
 
 func AddListFlags(f *pflag.FlagSet) {
 	f.StringVarP(&filename, "filename", "f", "skaffold.yaml", "Path to the local Skaffold config file. Defaults to `skaffold.yaml`")
+	f.StringVarP(&outputType, "output", "o", "plain", "Output format. One of: plain, json, yaml")
 }

--- a/cmd/skaffold/app/cmd/profile/flags.go
+++ b/cmd/skaffold/app/cmd/profile/flags.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package profile
+
+import (
+	"github.com/spf13/pflag"
+)
+
+var (
+	filename string
+)
+
+func AddListFlags(f *pflag.FlagSet) {
+	f.StringVarP(&filename, "filename", "f", "skaffold.yaml", "Path to the local Skaffold config file. Defaults to `skaffold.yaml`")
+}

--- a/cmd/skaffold/app/cmd/profile/list.go
+++ b/cmd/skaffold/app/cmd/profile/list.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package profile
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/parser"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/yaml"
+)
+
+func List(ctx context.Context, out io.Writer) error {
+	cfgs, err := parser.GetConfigSet(
+		ctx, config.SkaffoldOptions{
+			ConfigurationFile: filename,
+		},
+	)
+
+	if err != nil {
+		return fmt.Errorf("parsing configuration: %w", err)
+	}
+
+	profileNames := make([]string, 0)
+	for _, cfg := range cfgs {
+		for _, profile := range cfg.Profiles {
+			profileNames = append(profileNames, profile.Name)
+		}
+	}
+
+	if len(profileNames) == 0 {
+		profileNames = append(profileNames, "No profiles found")
+	}
+
+	buf, err := yaml.MarshalWithSeparator(profileNames)
+	if err != nil {
+		return fmt.Errorf("marshalling configuration: %w", err)
+	}
+	_, err = out.Write(buf)
+
+	return err
+}

--- a/cmd/skaffold/app/cmd/profile/list.go
+++ b/cmd/skaffold/app/cmd/profile/list.go
@@ -18,18 +18,25 @@ package profile
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/parser"
-	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/yaml"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/latest"
+	"gopkg.in/yaml.v3"
 )
 
 func List(ctx context.Context, out io.Writer) error {
+	return list(ctx, out, filename, outputType)
+}
+
+func list(ctx context.Context, out io.Writer, configurationFile, outputType string) error {
 	cfgs, err := parser.GetConfigSet(
 		ctx, config.SkaffoldOptions{
-			ConfigurationFile: filename,
+			ConfigurationFile: configurationFile,
 		},
 	)
 
@@ -37,22 +44,72 @@ func List(ctx context.Context, out io.Writer) error {
 		return fmt.Errorf("parsing configuration: %w", err)
 	}
 
-	profileNames := make([]string, 0)
+	profiles := make([]*latest.Profile, 0)
 	for _, cfg := range cfgs {
 		for _, profile := range cfg.Profiles {
-			profileNames = append(profileNames, profile.Name)
+			profiles = append(profiles, &profile)
 		}
 	}
 
-	if len(profileNames) == 0 {
-		profileNames = append(profileNames, "No profiles found")
+	if len(profiles) == 0 {
+		return fmt.Errorf("no profiles found in %s", configurationFile)
 	}
 
-	buf, err := yaml.MarshalWithSeparator(profileNames)
-	if err != nil {
-		return fmt.Errorf("marshalling configuration: %w", err)
+	switch outputType {
+	case "yaml":
+		return printYAML(out, profiles)
+	case "json":
+		return printJSON(out, profiles)
+	case "plain":
+		return printPlain(out, profiles)
+	default:
+		return fmt.Errorf(`invalid output type: %q. Must be "plain" or "json"`, outputType)
 	}
-	_, err = out.Write(buf)
+}
+
+func printYAML(out io.Writer, profiles []*latest.Profile) error {
+	return yaml.NewEncoder(out).Encode(profiles)
+}
+
+func printJSON(out io.Writer, profiles []*latest.Profile) error {
+	return json.NewEncoder(out).Encode(profiles)
+}
+
+func printPlain(out io.Writer, profiles []*latest.Profile) error {
+	lines := make([]string, len(profiles))
+	for i, profile := range profiles {
+		activations := activationsToString(profile.Activation)
+
+		lines[i] = fmt.Sprintf(
+			"- %s\n    Activation: %+v\n    RequiresAllActivations: %v\n",
+			profile.Name,
+			activations,
+			profile.RequiresAllActivations,
+		)
+	}
+	_, err := out.Write([]byte(strings.Join(lines, "\n")))
 
 	return err
+}
+
+func activationsToString(activations []latest.Activation) string {
+	res := make([]string, len(activations))
+	activationStringBuilder := strings.Builder{}
+
+	for i, activation := range activations {
+		activationStringBuilder.Reset()
+		if activation.KubeContext != "" {
+			activationStringBuilder.WriteString(fmt.Sprintf("kubeContext:%s ", activation.KubeContext))
+		}
+		if activation.Command != "" {
+			activationStringBuilder.WriteString(fmt.Sprintf("command:%s ", activation.Command))
+		}
+		if activation.Env != "" {
+			activationStringBuilder.WriteString(fmt.Sprintf("env:%s ", activation.Env))
+		}
+
+		res[i] = strings.TrimSpace(activationStringBuilder.String())
+	}
+
+	return fmt.Sprintf("%v", res)
 }

--- a/cmd/skaffold/app/cmd/profile/list_test.go
+++ b/cmd/skaffold/app/cmd/profile/list_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package profile
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/v2/testutil"
+)
+
+func TestList(t *testing.T) {
+	tests := []struct {
+		description    string
+		filename       string
+		filecontent	   string
+		expectedOutput string
+	}{
+		{
+			description: "has profiles",
+			filename:      "skaffold.yaml",
+			filecontent: `apiVersion: skaffold/v2beta29
+kind: Config
+profiles:
+  - name: p1
+  - name: p2
+  - name: p3
+`,
+			expectedOutput: "p1\n---\np2\n---\np3\n",
+		},
+		{
+			description: "has no profiles",
+			filename:      "skaffold.yaml",
+			filecontent: `apiVersion: skaffold/v2beta29
+kind: Config
+`,
+			expectedOutput: "No profiles found\n",
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.Override(&filename, test.filename)
+
+			t.NewTempDir().
+				Write("skaffold.yaml", test.filecontent).
+				Chdir()
+
+			buf := &bytes.Buffer{}
+			// list values
+			err := List(context.Background(), buf)
+			t.CheckNoError(err)
+
+			if buf.String() != test.expectedOutput {
+				t.Errorf("expecting output to be\n\n%s\nbut found\n\n%s\ninstead", test.expectedOutput, buf.String())
+			}
+		})
+	}
+}

--- a/cmd/skaffold/app/cmd/profile/list_test.go
+++ b/cmd/skaffold/app/cmd/profile/list_test.go
@@ -27,47 +27,169 @@ import (
 func TestList(t *testing.T) {
 	tests := []struct {
 		description    string
+		outputType     string
 		filename       string
 		filecontent    string
 		expectedOutput string
 	}{
 		{
-			description: "has profiles",
+			description: "wrong output type",
+			outputType:  "wrong",
 			filename:    "skaffold.yaml",
 			filecontent: `apiVersion: skaffold/v2beta29
 kind: Config
 profiles:
-  - name: p1
-  - name: p2
-  - name: p3
+  - name: minikube-profile
 `,
-			expectedOutput: "p1\n---\np2\n---\np3\n",
+			expectedOutput: "invalid output type: \"wrong\". Must be \"plain\" or \"json\"",
 		},
 		{
-			description: "has no profiles",
+			description:    "invalid skaffold.yaml",
+			outputType:     "plain",
+			filename:       "skaffold.yaml",
+			filecontent:    "some invalid content",
+			expectedOutput: "parsing configuration: error parsing skaffold configuration file: missing apiVersion",
+		},
+		{
+			description: "has profiles plain",
+			outputType:  "plain",
+			filename:    "skaffold.yaml",
+			filecontent: `apiVersion: skaffold/v2beta29
+kind: Config
+profiles:
+  - name: minikube-profile
+    activation:
+      - kubeContext: minikube
+      - env: ENV=local
+  - name: dev
+    activation:
+      - command: dev
+  - name: test
+    activation:
+      - env: ENV=test
+        command: dev
+`,
+			expectedOutput: `- minikube-profile
+    Activation: [kubeContext:minikube env:ENV=local]
+    RequiresAllActivations: false
+
+- dev
+    Activation: [command:dev]
+    RequiresAllActivations: false
+
+- test
+    Activation: [command:dev env:ENV=test]
+    RequiresAllActivations: false
+`,
+		},
+		{
+			description: "has profiles yaml",
+			outputType:  "yaml",
+			filename:    "skaffold.yaml",
+			filecontent: `apiVersion: skaffold/v2beta29
+kind: Config
+profiles:
+  - name: minikube-profile
+    activation:
+      - kubeContext: minikube
+      - env: ENV=local
+  - name: dev
+    activation:
+      - command: dev
+  - name: test
+    activation:
+      - env: ENV=test
+        command: dev
+`,
+			expectedOutput: `- name: minikube-profile
+  activation:
+    - kubeContext: minikube
+    - env: ENV=local
+- name: dev
+  activation:
+    - command: dev
+- name: test
+  activation:
+    - env: ENV=test
+      command: dev
+`,
+		},
+		{
+			description: "has profiles json",
+			outputType:  "json",
+			filename:    "skaffold.yaml",
+			filecontent: `apiVersion: skaffold/v2beta29
+kind: Config
+profiles:
+  - name: minikube-profile
+    activation:
+      - kubeContext: minikube
+      - env: ENV=local
+  - name: dev
+    activation:
+      - command: dev
+  - name: test
+    activation:
+      - env: ENV=test
+        command: dev
+`,
+			expectedOutput: `[{"Name":"minikube-profile","Activation":[{"Env":"","KubeContext":"minikube","Command":""},{"Env":"ENV=local","KubeContext":"","Command":""}],"RequiresAllActivations":false,"Patches":null,"Build":{"Hooks":{"PreHooks":null,"PostHooks":null},"Artifacts":null,"InsecureRegistries":null,"TagPolicy":{"GitTagger":null,"ShaTagger":null,"EnvTemplateTagger":null,"DateTimeTagger":null,"CustomTemplateTagger":null,"InputDigest":null},"Platforms":null,"LocalBuild":null,"GoogleCloudBuild":null,"Cluster":null},"Test":null,"Render":{"RawK8s":null,"RemoteManifests":null,"Kustomize":null,"Helm":null,"Kpt":null,"LifecycleHooks":{"PreHooks":null,"PostHooks":null},"Transform":null,"Validate":null,"Output":""},"Deploy":{"DockerDeploy":null,"LegacyHelmDeploy":null,"KptDeploy":null,"KubectlDeploy":null,"CloudRunDeploy":null,"StatusCheck":null,"StatusCheckDeadlineSeconds":0,"TolerateFailuresUntilDeadline":false,"KubeContext":"","Logs":{"Prefix":"","JSONParse":{"Fields":null}},"TransformableAllowList":null},"PortForward":null,"ResourceSelector":{"Allow":null,"Deny":null},"Verify":null,"CustomActions":null},{"Name":"dev","Activation":[{"Env":"","KubeContext":"","Command":"dev"}],"RequiresAllActivations":false,"Patches":null,"Build":{"Hooks":{"PreHooks":null,"PostHooks":null},"Artifacts":null,"InsecureRegistries":null,"TagPolicy":{"GitTagger":null,"ShaTagger":null,"EnvTemplateTagger":null,"DateTimeTagger":null,"CustomTemplateTagger":null,"InputDigest":null},"Platforms":null,"LocalBuild":null,"GoogleCloudBuild":null,"Cluster":null},"Test":null,"Render":{"RawK8s":null,"RemoteManifests":null,"Kustomize":null,"Helm":null,"Kpt":null,"LifecycleHooks":{"PreHooks":null,"PostHooks":null},"Transform":null,"Validate":null,"Output":""},"Deploy":{"DockerDeploy":null,"LegacyHelmDeploy":null,"KptDeploy":null,"KubectlDeploy":null,"CloudRunDeploy":null,"StatusCheck":null,"StatusCheckDeadlineSeconds":0,"TolerateFailuresUntilDeadline":false,"KubeContext":"","Logs":{"Prefix":"","JSONParse":{"Fields":null}},"TransformableAllowList":null},"PortForward":null,"ResourceSelector":{"Allow":null,"Deny":null},"Verify":null,"CustomActions":null},{"Name":"test","Activation":[{"Env":"ENV=test","KubeContext":"","Command":"dev"}],"RequiresAllActivations":false,"Patches":null,"Build":{"Hooks":{"PreHooks":null,"PostHooks":null},"Artifacts":null,"InsecureRegistries":null,"TagPolicy":{"GitTagger":null,"ShaTagger":null,"EnvTemplateTagger":null,"DateTimeTagger":null,"CustomTemplateTagger":null,"InputDigest":null},"Platforms":null,"LocalBuild":null,"GoogleCloudBuild":null,"Cluster":null},"Test":null,"Render":{"RawK8s":null,"RemoteManifests":null,"Kustomize":null,"Helm":null,"Kpt":null,"LifecycleHooks":{"PreHooks":null,"PostHooks":null},"Transform":null,"Validate":null,"Output":""},"Deploy":{"DockerDeploy":null,"LegacyHelmDeploy":null,"KptDeploy":null,"KubectlDeploy":null,"CloudRunDeploy":null,"StatusCheck":null,"StatusCheckDeadlineSeconds":0,"TolerateFailuresUntilDeadline":false,"KubeContext":"","Logs":{"Prefix":"","JSONParse":{"Fields":null}},"TransformableAllowList":null},"PortForward":null,"ResourceSelector":{"Allow":null,"Deny":null},"Verify":null,"CustomActions":null}]
+`,
+		},
+		{
+			description: "has no profiles plain",
+			outputType:  "plain",
 			filename:    "skaffold.yaml",
 			filecontent: `apiVersion: skaffold/v2beta29
 kind: Config
 `,
-			expectedOutput: "No profiles found\n",
+			expectedOutput: "no profiles found in skaffold.yaml",
+		},
+		{
+			description: "has no profiles yaml",
+			outputType:  "yaml",
+			filename:    "skaffold.yaml",
+			filecontent: `apiVersion: skaffold/v2beta29
+kind: Config
+`,
+			expectedOutput: "no profiles found in skaffold.yaml",
+		},
+		{
+			description: "has no profiles json",
+			outputType:  "json",
+			filename:    "skaffold.yaml",
+			filecontent: `apiVersion: skaffold/v2beta29
+kind: Config
+`,
+			expectedOutput: "no profiles found in skaffold.yaml",
 		},
 	}
 	for _, test := range tests {
-		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.Override(&filename, test.filename)
+		testutil.Run(
+			t, test.description, func(t *testutil.T) {
+				t.Override(&filename, test.filename)
+				t.Override(&outputType, test.outputType)
 
-			t.NewTempDir().
-				Write("skaffold.yaml", test.filecontent).
-				Chdir()
+				t.NewTempDir().
+					Write("skaffold.yaml", test.filecontent).
+					Chdir()
 
-			buf := &bytes.Buffer{}
-			// list values
-			err := List(context.Background(), buf)
-			t.CheckNoError(err)
+				buf := &bytes.Buffer{}
+				// list values
+				err := List(context.Background(), buf)
+				if err != nil {
+					t.CheckContains(test.expectedOutput, err.Error())
+					return
+				}
 
-			if buf.String() != test.expectedOutput {
-				t.Errorf("expecting output to be\n\n%s\nbut found\n\n%s\ninstead", test.expectedOutput, buf.String())
-			}
-		})
+				if buf.String() != test.expectedOutput {
+					t.Errorf(
+						"expecting output to be\n\n%q\nbut found\n\n%q\ninstead",
+						test.expectedOutput,
+						buf.String(),
+					)
+				}
+			},
+		)
 	}
 }

--- a/cmd/skaffold/app/cmd/profile/list_test.go
+++ b/cmd/skaffold/app/cmd/profile/list_test.go
@@ -28,12 +28,12 @@ func TestList(t *testing.T) {
 	tests := []struct {
 		description    string
 		filename       string
-		filecontent	   string
+		filecontent    string
 		expectedOutput string
 	}{
 		{
 			description: "has profiles",
-			filename:      "skaffold.yaml",
+			filename:    "skaffold.yaml",
 			filecontent: `apiVersion: skaffold/v2beta29
 kind: Config
 profiles:
@@ -45,7 +45,7 @@ profiles:
 		},
 		{
 			description: "has no profiles",
-			filename:      "skaffold.yaml",
+			filename:    "skaffold.yaml",
 			filecontent: `apiVersion: skaffold/v2beta29
 kind: Config
 `,

--- a/docs-v2/content/en/docs/references/cli/_index.md
+++ b/docs-v2/content/en/docs/references/cli/_index.md
@@ -90,6 +90,7 @@ Other Commands:
   diagnose          Run a diagnostic on Skaffold
   exec              Execute a custom action
   fix               Update old configuration to a newer schema version
+  profile           Work with Skaffold profiles
   schema            List JSON schemas used to validate skaffold.yaml configuration
   survey            Opens a web browser to fill out the Skaffold survey
   version           Print the version information
@@ -1115,6 +1116,42 @@ The following options can be passed to any command:
 
 
 ```
+
+### skaffold profile
+
+Work with Skaffold profiles
+
+```
+
+
+Available Commands:
+  list        List available profile names
+
+Use "skaffold <command> --help" for more information about a given command.
+
+
+```
+
+### skaffold profile list
+
+List available profile names
+
+```
+
+
+Options:
+  -f, --filename='skaffold.yaml': Path to the local Skaffold config file. Defaults to `skaffold.yaml`
+
+Usage:
+  skaffold profile list [options]
+
+Use "skaffold options" for a list of global command-line options (applies to all commands).
+
+
+```
+Env vars:
+
+* `SKAFFOLD_FILENAME` (same as `--filename`)
 
 ### skaffold render
 

--- a/docs-v2/content/en/docs/references/cli/_index.md
+++ b/docs-v2/content/en/docs/references/cli/_index.md
@@ -1141,6 +1141,7 @@ List available profile names
 
 Options:
   -f, --filename='skaffold.yaml': Path to the local Skaffold config file. Defaults to `skaffold.yaml`
+  -o, --output='plain': Output format. One of: plain, json, yaml
 
 Usage:
   skaffold profile list [options]
@@ -1152,6 +1153,7 @@ Use "skaffold options" for a list of global command-line options (applies to all
 Env vars:
 
 * `SKAFFOLD_FILENAME` (same as `--filename`)
+* `SKAFFOLD_OUTPUT` (same as `--output`)
 
 ### skaffold render
 


### PR DESCRIPTION
**Description**
Hi! What do you think about the new command `skaffold profile list` which will output a list of profile names? In big projects it's quite hard to see all the profiles you can use

**User facing changes**
*Before*: You should open a config file to see available profiles
*After*: You can execute `skaffold profile list` to see available profiles
