### PR TITLE
fix(helm): use secrets helm plugin to render when useHelmSecrets is true

### DIFF
--- a/pkg/skaffold/deploy/helm/helm_test.go
+++ b/pkg/skaffold/deploy/helm/helm_test.go
@@ -280,6 +280,18 @@ var testDeployNoOverridesConfig = latest.LegacyHelmDeploy{
 	}},
 }
 
+var testDeployChartWithUseHelmSecrets = latest.LegacyHelmDeploy{
+	Releases: []latest.HelmRelease{{
+		Name:      "skaffold-helm",
+		ChartPath: "examples/test",
+		SetValues: map[string]string{
+			"some.key": "somevalue",
+		},
+		UseHelmSecrets:        true,
+		SkipBuildDependencies: true,
+	}},
+}
+
 var validDeployYaml = `
 # Source: skaffold-helm/templates/deployment.yaml
 apiVersion: apps/v1
@@ -1339,6 +1351,13 @@ func TestHelmRender(t *testing.T) {
 					ImageName: "skaffold-helm",
 					Tag:       "skaffold-helm:tag1",
 				}},
+		},
+		{
+			description: "render with useHelmSecrets",
+			shouldErr:   false,
+			commands: testutil.
+				CmdRun("helm secrets --kube-context kubecontext template skaffold-helm examples/test --set some.key=somevalue --kubeconfig kubeconfig"),
+			helm: testDeployChartWithUseHelmSecrets,
 		},
 	}
 	labeller := label.DefaultLabeller{}

--- a/pkg/skaffold/render/renderer/helm/helm.go
+++ b/pkg/skaffold/render/renderer/helm/helm.go
@@ -213,7 +213,7 @@ func (h Helm) generateHelmManifest(ctx context.Context, builds []graph.Artifact,
 		}
 	}
 
-	err = helm.ExecWithStdoutAndStderr(ctx, h, outBuffer, errBuffer, false, env, args...)
+	err = helm.ExecWithStdoutAndStderr(ctx, h, outBuffer, errBuffer, release.UseHelmSecrets, env, args...)
 	errorMsg := errBuffer.String()
 
 	if len(errorMsg) > 0 {


### PR DESCRIPTION
Fixes: #7651 and possibly #9119

**Description**
`skaffold render` used to ignore `useHelmSecrets` flag

**User facing changes**
*Before*: `skaffold render` didn't use helm secrets plugin
*After*: `skaffold render` uses helm secrets plugin
