### PR TITLE
feat: Support Bazel platform mappings

### DIFF
--- a/docs-v2/content/en/schemas/v4beta10.json
+++ b/docs-v2/content/en/schemas/v4beta10.json
@@ -694,6 +694,17 @@
             "[\"-flag\", \"--otherflag\"]"
           ]
         },
+        "platforms": {
+          "items": {
+            "$ref": "#/definitions/BazelPlatformMapping"
+          },
+          "type": "array",
+          "description": "configure the --platforms flag for `bazel build` based on the configured skaffold target platform.",
+          "x-intellij-html-description": "configure the --platforms flag for <code>bazel build</code> based on the configured skaffold target platform.",
+          "examples": [
+            "``yaml platforms:   - platform: linux/amd64     target: //platforms:linux-x86_64   - platform: linux/arm64     target: //platforms:linux-arm64 ``"
+          ]
+        },
         "target": {
           "type": "string",
           "description": "`bazel build` target to run.",
@@ -705,12 +716,39 @@
       },
       "preferredOrder": [
         "target",
-        "args"
+        "args",
+        "platforms"
       ],
       "additionalProperties": false,
       "type": "object",
       "description": "describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
+    },
+    "BazelPlatformMapping": {
+      "required": [
+        "platform",
+        "target"
+      ],
+      "properties": {
+        "platform": {
+          "type": "string",
+          "description": "skaffold platform.",
+          "x-intellij-html-description": "skaffold platform."
+        },
+        "target": {
+          "type": "string",
+          "description": "bazel platform target to be passed to bazel's `--platforms` flag.",
+          "x-intellij-html-description": "bazel platform target to be passed to bazel's <code>--platforms</code> flag."
+        }
+      },
+      "preferredOrder": [
+        "platform",
+        "target"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "relates a skaffold platform (like 'linux/amd64') to a workspace-specific bazel platform target (e.g. '//platforms:linux_amd64').",
+      "x-intellij-html-description": "relates a skaffold platform (like 'linux/amd64') to a workspace-specific bazel platform target (e.g. '//platforms:linux_amd64')."
     },
     "BuildConfig": {
       "type": "object",

--- a/docs-v2/content/en/schemas/v4beta10.json
+++ b/docs-v2/content/en/schemas/v4beta10.json
@@ -700,10 +700,7 @@
           },
           "type": "array",
           "description": "configure the --platforms flag for `bazel build` based on the configured skaffold target platform.",
-          "x-intellij-html-description": "configure the --platforms flag for <code>bazel build</code> based on the configured skaffold target platform.",
-          "examples": [
-            "``yaml platforms:   - platform: linux/amd64     target: //platforms:linux-x86_64   - platform: linux/arm64     target: //platforms:linux-arm64 ``"
-          ]
+          "x-intellij-html-description": "configure the --platforms flag for <code>bazel build</code> based on the configured skaffold target platform."
         },
         "target": {
           "type": "string",

--- a/examples/bazel/BUILD.bazel
+++ b/examples/bazel/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@rules_go//go:def.bzl", "go_binary", "go_library")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_tarball")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
@@ -31,18 +30,8 @@ oci_image(
     tars = [":app_layer"],
 )
 
-# This is the target that should be released to the target platform
-platform_transition_filegroup(
-    name = "transitioned_image",
-    srcs = [":image"],
-    target_platform = select({
-        "@platforms//cpu:arm64": "@rules_go//go/toolchain:linux_arm64",
-        "@platforms//cpu:x86_64": "@rules_go//go/toolchain:linux_amd64",
-    }),
-)
-
-# $ bazel build :tarball
-# $ docker load --input $(bazel cquery --output=files :tarball)
+# $ bazel build :skaffold-example.tar
+# $ docker load --input $(bazel cquery --output=files :skaffold-example.tar)
 # $ docker run --rm gcr.io/example:latest
 
 oci_tarball(

--- a/examples/bazel/MODULE.bazel
+++ b/examples/bazel/MODULE.bazel
@@ -1,4 +1,3 @@
-bazel_dep(name = "aspect_bazel_lib", version = "1.31.1")
 bazel_dep(name = "gazelle", version = "0.31.0")
 bazel_dep(name = "platforms", version = "0.0.5")
 bazel_dep(name = "rules_oci", version = "1.2.0")

--- a/examples/bazel/README.md
+++ b/examples/bazel/README.md
@@ -12,7 +12,7 @@ build:
   - image: skaffold-bazel
     context: .
     bazel:
-      target: //:skaffold_example.tar
+      target: //:skaffold-example.tar
 ```
 
 1. make sure the `context` contains the bazel files (`WORKSPACE`, `BUILD`)

--- a/examples/bazel/skaffold.yaml
+++ b/examples/bazel/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta10
+apiVersion: skaffold/v4beta9
 kind: Config
 metadata:
   name: hello
@@ -9,11 +9,6 @@ build:
     - image: skaffold-bazel
       bazel:
         target: //:skaffold-example.tar
-        platforms:
-          - platform: linux/amd64
-            target: "@rules_go//go/toolchain:linux_amd64"
-          - platform: linux/arm64
-            target: "@rules_go//go/toolchain:linux_arm64"
 deploy:
   kubectl: {}
 manifests:

--- a/examples/bazel/skaffold.yaml
+++ b/examples/bazel/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta9
+apiVersion: skaffold/v4beta10
 kind: Config
 metadata:
   name: hello
@@ -9,6 +9,11 @@ build:
     - image: skaffold-bazel
       bazel:
         target: //:skaffold-example.tar
+        platforms:
+          - platform: linux/amd64
+            target: "@rules_go//go/toolchain:linux_amd64"
+          - platform: linux/arm64
+            target: "@rules_go//go/toolchain:linux_arm64"
 deploy:
   kubectl: {}
 manifests:

--- a/integration/examples/bazel/BUILD.bazel
+++ b/integration/examples/bazel/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
 load("@rules_go//go:def.bzl", "go_binary", "go_library")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_tarball")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
@@ -31,18 +30,8 @@ oci_image(
     tars = [":app_layer"],
 )
 
-# This is the target that should be released to the target platform
-platform_transition_filegroup(
-    name = "transitioned_image",
-    srcs = [":image"],
-    target_platform = select({
-        "@platforms//cpu:arm64": "@rules_go//go/toolchain:linux_arm64",
-        "@platforms//cpu:x86_64": "@rules_go//go/toolchain:linux_amd64",
-    }),
-)
-
-# $ bazel build :tarball
-# $ docker load --input $(bazel cquery --output=files :tarball)
+# $ bazel build :skaffold-example.tar
+# $ docker load --input $(bazel cquery --output=files :skaffold-example.tar)
 # $ docker run --rm gcr.io/example:latest
 
 oci_tarball(

--- a/integration/examples/bazel/MODULE.bazel
+++ b/integration/examples/bazel/MODULE.bazel
@@ -1,4 +1,3 @@
-bazel_dep(name = "aspect_bazel_lib", version = "1.31.1")
 bazel_dep(name = "gazelle", version = "0.31.0")
 bazel_dep(name = "platforms", version = "0.0.5")
 bazel_dep(name = "rules_oci", version = "1.2.0")

--- a/integration/examples/bazel/README.md
+++ b/integration/examples/bazel/README.md
@@ -12,7 +12,7 @@ build:
   - image: skaffold-bazel
     context: .
     bazel:
-      target: //:skaffold_example.tar
+      target: //:skaffold-example.tar
 ```
 
 1. make sure the `context` contains the bazel files (`WORKSPACE`, `BUILD`)

--- a/integration/examples/bazel/skaffold.yaml
+++ b/integration/examples/bazel/skaffold.yaml
@@ -9,6 +9,11 @@ build:
     - image: skaffold-bazel
       bazel:
         target: //:skaffold-example.tar
+        platforms:
+          - platform: linux/amd64
+            target: "@rules_go//go/toolchain:linux_amd64"
+          - platform: linux/arm64
+            target: "@rules_go//go/toolchain:linux_arm64"
 deploy:
   kubectl: {}
 manifests:

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -331,6 +331,16 @@ type TaggerComponent struct {
 	Component TagPolicy `yaml:",inline" yamltags:"skipTrim"`
 }
 
+// BazelPlatformMapping relates a skaffold platform (like 'linux/amd64')
+// to a workspace-specific bazel platform target (e.g. '//platforms:linux_amd64').
+type BazelPlatformMapping struct {
+	// Platform is the skaffold platform.
+	Platform string `yaml:"platform" yamltags:"required"`
+
+	// BazelPlatformTarget is the bazel platform target to be passed to bazel's `--platforms` flag.
+	BazelPlatformTarget string `yaml:"target" yamltags:"required"`
+}
+
 // BuildType contains the specific implementation and parameters needed
 // for the build step. Only one field should be populated.
 type BuildType struct {
@@ -1597,6 +1607,18 @@ type BazelArtifact struct {
 	// BuildArgs are additional args to pass to `bazel build`.
 	// For example: `["-flag", "--otherflag"]`.
 	BuildArgs []string `yaml:"args,omitempty"`
+
+	// PlatformMappings configure the --platforms flag for `bazel build`
+	// based on the configured skaffold target platform.
+	// For example:
+	// ```yaml
+	// platforms:
+	//   - platform: linux/amd64
+	//     target: //platforms:linux-x86_64
+	//   - platform: linux/arm64
+	//     target: //platforms:linux-arm64
+	// ```
+	PlatformMappings []BazelPlatformMapping `yaml:"platforms,omitempty"`
 }
 
 // KoArtifact builds images using [ko](https://github.com/google/ko).

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -1610,14 +1610,6 @@ type BazelArtifact struct {
 
 	// PlatformMappings configure the --platforms flag for `bazel build`
 	// based on the configured skaffold target platform.
-	// For example:
-	// ```yaml
-	// platforms:
-	//   - platform: linux/amd64
-	//     target: //platforms:linux-x86_64
-	//   - platform: linux/arm64
-	//     target: //platforms:linux-arm64
-	// ```
 	PlatformMappings []BazelPlatformMapping `yaml:"platforms,omitempty"`
 }
 


### PR DESCRIPTION
This change introduces an artifact-level setting for configuring Bazel and
defines a platform mapping from Skaffold platforms to Bazel platforms.
The Bazel artifact builder then passes the --platforms flag to Bazel if applicable.

Fixes #9360.