### PR TITLE
fix(lookupRemote): fixed lookup.go lookupRemote caching mechanism

### DIFF
--- a/pkg/skaffold/build/cache/lookup.go
+++ b/pkg/skaffold/build/cache/lookup.go
@@ -128,13 +128,6 @@ func (c *cache) lookupRemote(ctx context.Context, hash, tag string, platforms []
 			log.Entry(ctx).Debugf("Found %s remote with the same digest", tag)
 			return found{hash: hash}
 		}
-
-		if !cacheHit {
-			log.Entry(ctx).Debugf("Added digest for %s to cache entry", tag)
-			c.cacheMutex.Lock()
-			c.artifactCache[hash] = ImageDetails{Digest: remoteDigest}
-			c.cacheMutex.Unlock()
-		}
 	}
 
 	if cacheHit {

--- a/pkg/skaffold/build/cache/lookup_test.go
+++ b/pkg/skaffold/build/cache/lookup_test.go
@@ -156,20 +156,19 @@ func TestLookupRemote(t *testing.T) {
 		expected        cacheDetails
 	}{
 		{
-			description: "hash failure",
-			hasher:      failingHasher{errors.New("BUG")},
-			tag:         "tag",
+			description:     "hash failure",
+			hasher:          failingHasher{errors.New("BUG")},
+			tag:             "tag",
 			remoteDigestMap: commonRemoteDigestMap,
-			expected:    failed{err: errors.New("getting hash for artifact \"artifact\": BUG")},
+			expected:        failed{err: errors.New("getting hash for artifact \"artifact\": BUG")},
 		},
 		{
 			description: "cache miss but remote found",
 			hasher:      mockHasher{"hash"},
 			cache:       map[string]ImageDetails{},
 			remoteDigestMap: map[string]string{
-				"tag":                 "digest",
-				"tag@digest":          "digest",
-				"fqn_tag@otherdigest": "otherdigest",
+				"tag":        "digest",
+				"tag@digest": "digest",
 			},
 			tag:      "tag",
 			expected: needsBuilding{hash: "hash"},
@@ -181,8 +180,8 @@ func TestLookupRemote(t *testing.T) {
 				"hash": {Digest: "digest"},
 			},
 			remoteDigestMap: commonRemoteDigestMap,
-			tag:      "tag",
-			expected: found{hash: "hash"},
+			tag:             "tag",
+			expected:        found{hash: "hash"},
 		},
 		{
 			description: "cache hit but digests are not the same, no remote or locally",
@@ -191,8 +190,8 @@ func TestLookupRemote(t *testing.T) {
 				"hash": {Digest: "otherdigest"},
 			},
 			remoteDigestMap: commonRemoteDigestMap,
-			tag:      "tag",
-			expected: needsBuilding{hash: "hash"},
+			tag:             "tag",
+			expected:        needsBuilding{hash: "hash"},
 		},
 		{
 			description: "cache hit with different tag",
@@ -201,8 +200,8 @@ func TestLookupRemote(t *testing.T) {
 				"hash": {Digest: "otherdigest"},
 			},
 			remoteDigestMap: commonRemoteDigestMap,
-			tag:      "fqn_tag",
-			expected: needsRemoteTagging{hash: "hash", tag: "fqn_tag", digest: "otherdigest"},
+			tag:             "fqn_tag",
+			expected:        needsRemoteTagging{hash: "hash", tag: "fqn_tag", digest: "otherdigest"},
 		},
 		{
 			description: "found locally",
@@ -211,9 +210,9 @@ func TestLookupRemote(t *testing.T) {
 				"hash": {ID: "imageID"},
 			},
 			remoteDigestMap: commonRemoteDigestMap,
-			api:      (&testutil.FakeAPIClient{}).Add("no_remote_tag", "imageID"),
-			tag:      "no_remote_tag",
-			expected: needsPushing{hash: "hash", tag: "no_remote_tag", imageID: "imageID"},
+			api:             (&testutil.FakeAPIClient{}).Add("no_remote_tag", "imageID"),
+			tag:             "no_remote_tag",
+			expected:        needsPushing{hash: "hash", tag: "no_remote_tag", imageID: "imageID"},
 		},
 		{
 			description: "not found",
@@ -222,9 +221,9 @@ func TestLookupRemote(t *testing.T) {
 				"hash": {ID: "imageID"},
 			},
 			remoteDigestMap: commonRemoteDigestMap,
-			api:      &testutil.FakeAPIClient{},
-			tag:      "no_remote_tag",
-			expected: needsBuilding{hash: "hash"},
+			api:             &testutil.FakeAPIClient{},
+			tag:             "no_remote_tag",
+			expected:        needsBuilding{hash: "hash"},
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #9248  <!-- tracking issues that this PR will close -->

**Description**
Hi! Within this PR https://github.com/GoogleContainerTools/skaffold/pull/9278 I've fixed lookupRemote and it turned out that I've missed a case when the cache was missed but the image was found remotely (it'll be better to check the test case to understand it)

**User facing changes (remove if N/A)**
**Before**: when a tag wasn't found in the cache, but the image was found remotely by the tag, then we use **needsRemoteTagging**
**After**: with the same conditions it now uses **needsBuilding** instead
