### PR TITLE
fix: Allow partial match for manual sync

### DIFF
--- a/pkg/skaffold/sync/sync.go
+++ b/pkg/skaffold/sync/sync.go
@@ -217,9 +217,9 @@ func autoSyncItem(ctx context.Context, a *latest.Artifact, tag string, e filemon
 }
 
 func latestTag(image string, builds []graph.Artifact) string {
-	for _, build := range builds {
-		if build.ImageName == image {
-			return build.Tag
+	for _, _build := range builds {
+		if _build.ImageName == image {
+			return _build.Tag
 		}
 	}
 	return ""
@@ -227,6 +227,7 @@ func latestTag(image string, builds []graph.Artifact) string {
 
 func intersect(ctx context.Context, contextWd, containerWd string, syncRules []*latest.SyncRule, files []string) (syncMap, error) {
 	ret := make(syncMap)
+	hadMismatch := false
 	for _, f := range files {
 		relPath, err := filepath.Rel(contextWd, f)
 		if err != nil {
@@ -240,10 +241,14 @@ func intersect(ctx context.Context, contextWd, containerWd string, syncRules []*
 
 		if len(dsts) == 0 {
 			log.Entry(ctx).Infof("Changed file %s does not match any sync pattern. Skipping sync", relPath)
-			return nil, nil
+			hadMismatch = true
+			continue
 		}
 
 		ret[f] = dsts
+	}
+	if len(ret) == 0 && hadMismatch {
+		return nil, nil
 	}
 	return ret, nil
 }

--- a/pkg/skaffold/sync/sync_test.go
+++ b/pkg/skaffold/sync/sync_test.go
@@ -82,6 +82,58 @@ func TestNewSyncItem(t *testing.T) {
 			},
 		},
 		{
+			description: "manual: match copy partial match first",
+			artifact: &latest.Artifact{
+				ImageName: "test",
+				Sync: &latest.Sync{
+					Manual: []*latest.SyncRule{{Src: "*.html", Dest: "."}},
+				},
+				Workspace: ".",
+			},
+			builds: []graph.Artifact{
+				{
+					ImageName: "test",
+					Tag:       "test:123",
+				},
+			},
+			evt: filemon.Events{
+				Added: []string{"someOtherFile.txt", "index.html"},
+			},
+			expected: &Item{
+				Image: "test:123",
+				Copy: map[string][]string{
+					"index.html": {"index.html"},
+				},
+				Delete: map[string][]string{},
+			},
+		},
+		{
+			description: "manual: match copy partial match last",
+			artifact: &latest.Artifact{
+				ImageName: "test",
+				Sync: &latest.Sync{
+					Manual: []*latest.SyncRule{{Src: "*.html", Dest: "."}},
+				},
+				Workspace: ".",
+			},
+			builds: []graph.Artifact{
+				{
+					ImageName: "test",
+					Tag:       "test:123",
+				},
+			},
+			evt: filemon.Events{
+				Added: []string{"index.html", "someOtherFile.txt"},
+			},
+			expected: &Item{
+				Image: "test:123",
+				Copy: map[string][]string{
+					"index.html": {"index.html"},
+				},
+				Delete: map[string][]string{},
+			},
+		},
+		{
 			description: "manual: no tag for image",
 			artifact: &latest.Artifact{
 				ImageName: "notbuildyet",


### PR DESCRIPTION
<!-- Include if applicable: -->
Fixes: #9326 <!-- tracking issues that this PR will close -->


**Description**
Current behavior: If files `someFile.txt` and `someFile.html` are changed and a manual sync pattern ` *.html` exists then no sync is made because the first file does not match. 

With this MR partial matches should be correctly recognized.


**Follow-up Work (remove if N/A)**
Not sure if this approach is correct or if the returned values should be interpreted differently instead of saving the mismatch inside the function.


