### PR TITLE
docs: add bazel cross-platform documentation

### DIFF
--- a/docs-v2/content/en/docs/builders/builder-types/bazel.md
+++ b/docs-v2/content/en/docs/builders/builder-types/bazel.md
@@ -22,7 +22,7 @@ To use Bazel, `bazel` field to each artifact you specify in the
 {{< schema root="BazelArtifact" >}}
 
 {{% alert title="Not any Bazel target can be used" %}}
-The target specified must produce a bundle compatible
+The target specified must produce a .tar bundle compatible
 with docker load. See
 <a href="https://github.com/bazelbuild/rules_docker#using-with-docker-locally">https://github.com/bazelbuild/rules_docker#using-with-docker-locally</a>
 {{% /alert %}}
@@ -34,3 +34,17 @@ The following `build` section instructs Skaffold to build a
 Docker image `gcr.io/k8s-skaffold/example` with Bazel:
 
 {{% readfile file="samples/builders/bazel.yaml" %}}
+
+The following `build` section shows how to use Skaffold's
+cross-platform support to pass `--platforms` to Bazel. In this
+example, the Bazel project defines the `//platforms:linux-x86_64`
+`//platforms:linux-arm64` targets. Skaffold will pass `--platforms=//platforms:linux-x86_64` to `bazel build`
+if its target build platform matches `linux/amd64`, `--platforms=//platforms:linux-arm64`
+if its target build platform matches `linux/arm64`, and will not pass `--platforms` otherwise.
+
+{{% readfile file="samples/builders/bazel-xplat.yaml" %}}
+
+Note that Skaffold does not support intelligently selecting the most specific
+variant for platforms with variants. For example, specifying `linux/arm64`
+and `linux/arm64/v8` will not work. In this example it would be better to
+specify `linux/arm64/v7` and `linux/arm64/v8` instead.

--- a/docs-v2/content/en/docs/builders/cross-platform.md
+++ b/docs-v2/content/en/docs/builders/cross-platform.md
@@ -27,7 +27,7 @@ The final list of target platforms need to ultimately be supported by the target
 | **Dockerfile** | Cross-platform and multi-platform supported | Cross-platform supported but platform should match cluster node running the pod. | Cross-platform and multi-platform supported |
 | **Jib Maven and Gradle** | Cross-platform and multi-platform supported | - | Cross-platform and multi-platform supported |
 | **Cloud Native Buildpacks** | Only supports `linux/amd64` | - | Only supports `linux/amd64` |
-| **Bazel** | Cross-platform supported but requires explicit platform specific rules. Not yet implemented | - | - |
+| **Bazel** | Cross-platform supported | - | - |
 | **ko** | Cross-platform and multi-platform supported | - | Cross-platform and multi-platform supported |
 | **Custom Script** | Cross-platform and multi-platform supported but requires user to implement it in the build script | Cross-platform and multi-platform supported but requires user to implement it in the build script | - |
 

--- a/docs-v2/content/en/samples/builders/bazel-xplat.yaml
+++ b/docs-v2/content/en/samples/builders/bazel-xplat.yaml
@@ -1,0 +1,10 @@
+build:
+  artifacts:
+    - image: gcr.io/k8s-skaffold/example
+      bazel:
+        target: //:example.tar
+        platforms:
+          - platform: linux/amd64
+            target: //platforms:linux-x86_64
+          - platform: linux/arm64
+            target: //platforms:linux-arm64


### PR DESCRIPTION
 * Update Bazel builder documentation to include an example
 * Update Skaffold cross-platform page to document that Bazel cross-platform builds are now supported.

Merge after: #9300

Tested with `make preview-docs-v2`.
Note unrelated POSTCSS error present in main in `./hack/check-docs.sh`/`make build-docs-preview`

