### PR TITLE
feat(docker-network): docker.network now supports any value

### DIFF
--- a/docs-v2/content/en/schemas/v4beta10.json
+++ b/docs-v2/content/en/schemas/v4beta10.json
@@ -1773,14 +1773,8 @@
         },
         "network": {
           "type": "string",
-          "description": "passed through to docker and overrides the network configuration of docker builder. If unset, use whatever is configured in the underlying docker daemon. Valid modes are `host`: use the host's networking stack. `bridge`: use the bridged network configuration. `container:<name|id>`: reuse another container's network stack. `none`: no networking in the container.",
-          "x-intellij-html-description": "passed through to docker and overrides the network configuration of docker builder. If unset, use whatever is configured in the underlying docker daemon. Valid modes are <code>host</code>: use the host's networking stack. <code>bridge</code>: use the bridged network configuration. <code>container:&lt;name|id&gt;</code>: reuse another container's network stack. <code>none</code>: no networking in the container.",
-          "enum": [
-            "host",
-            "bridge",
-            "container:<name|id>",
-            "none"
-          ]
+          "description": "passed through to docker and overrides the network configuration of docker builder. If unset, use whatever is configured in the underlying docker daemon. Examples: `host`: use the host's networking stack. `bridge`: use the bridged network configuration. `container:<name|id>`: reuse another container's network stack. `none`: no networking in the container. `my-custom-network`: user-defined network.",
+          "x-intellij-html-description": "passed through to docker and overrides the network configuration of docker builder. If unset, use whatever is configured in the underlying docker daemon. Examples: <code>host</code>: use the host's networking stack. <code>bridge</code>: use the bridged network configuration. <code>container:&lt;name|id&gt;</code>: reuse another container's network stack. <code>none</code>: no networking in the container. <code>my-custom-network</code>: user-defined network."
         },
         "noCache": {
           "type": "boolean",

--- a/fs/assets/credits_generated/github.com/hashicorp/hcl/go.mod
+++ b/fs/assets/credits_generated/github.com/hashicorp/hcl/go.mod
@@ -1,3 +1,5 @@
 module github.com/hashicorp/hcl
 
+go 1.22
+
 require github.com/davecgh/go-spew v1.1.1

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -1551,11 +1551,13 @@ type DockerArtifact struct {
 
 	// NetworkMode is passed through to docker and overrides the
 	// network configuration of docker builder. If unset, use whatever
-	// is configured in the underlying docker daemon. Valid modes are
+	// is configured in the underlying docker daemon.
+	// Examples:
 	// `host`: use the host's networking stack.
 	// `bridge`: use the bridged network configuration.
 	// `container:<name|id>`: reuse another container's network stack.
 	// `none`: no networking in the container.
+	// `my-custom-network`: user-defined network.
 	NetworkMode string `yaml:"network,omitempty"`
 
 	// AddHost lists add host.

--- a/pkg/skaffold/schema/validation/validation.go
+++ b/pkg/skaffold/schema/validation/validation.go
@@ -375,8 +375,7 @@ func validateDockerNetworkMode(cfg *parser.SkaffoldConfigEntry, artifacts []*lat
 		if a.DockerArtifact == nil || a.DockerArtifact.NetworkMode == "" {
 			continue
 		}
-		mode := strings.ToLower(a.DockerArtifact.NetworkMode)
-		if mode == "none" || mode == "bridge" || mode == "host" {
+		if !strings.HasPrefix(strings.ToLower(a.DockerArtifact.NetworkMode), "container:") {
 			continue
 		}
 		networkModeErr := validateDockerNetworkModeExpression(a.ImageName, a.DockerArtifact.NetworkMode)

--- a/pkg/skaffold/schema/validation/validation_test.go
+++ b/pkg/skaffold/schema/validation/validation_test.go
@@ -529,14 +529,14 @@ func TestValidateNetworkMode(t *testing.T) {
 			},
 		},
 		{
-			description: "invalid networkmode",
-			shouldErr:   true,
+			description: "custom networkmode",
+			shouldErr:   false,
 			artifacts: []*latest.Artifact{
 				{
-					ImageName: "image/bad",
+					ImageName: "image/custom",
 					ArtifactType: latest.ArtifactType{
 						DockerArtifact: &latest.DockerArtifact{
-							NetworkMode: "Bad",
+							NetworkMode: "my-network-mode",
 						},
 					},
 				},


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #9389  <!-- tracking issues that this PR will close -->

**Description**
Removed docker network validation, now you can pass any network

**User facing changes (remove if N/A)**
*before*: docker.network used to support only predefined values. 
*before*: docker.network supports any value.
