### PR TITLE
feat: support templating in diagnose command

### DIFF
--- a/cmd/skaffold/app/cmd/diagnose.go
+++ b/cmd/skaffold/app/cmd/diagnose.go
@@ -30,6 +30,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/latest"
 	schemaUtil "github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/util"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/tags"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/version"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/yaml"
@@ -38,6 +39,8 @@ import (
 var (
 	yamlOnly   bool
 	outputFile string
+
+	enableTemplating bool
 	// for testing
 	getRunContext = runcontext.GetRunContext
 	getCfgs       = parser.GetAllConfigs
@@ -52,6 +55,7 @@ func NewCmdDiagnose() *cobra.Command {
 		WithCommonFlags().
 		WithFlags([]*Flag{
 			{Value: &yamlOnly, Name: "yaml-only", DefValue: false, Usage: "Only prints the effective skaffold.yaml configuration"},
+			{Value: &enableTemplating, Name: "enable-templating", DefValue: false, Usage: "Render supported templated fields with golang template engine"},
 			{Value: &outputFile, Name: "output", Shorthand: "o", DefValue: "", Usage: "File to write diagnose result"},
 		}).
 		NoArgs(doDiagnose)
@@ -82,10 +86,16 @@ func doDiagnose(ctx context.Context, out io.Writer) error {
 	for i := range configs {
 		configs[i].(*latest.SkaffoldConfig).Dependencies = nil
 	}
+	if enableTemplating {
+		if err := tags.ApplyTemplates(configs); err != nil {
+			return err
+		}
+	}
 	buf, err := yaml.MarshalWithSeparator(configs)
 	if err != nil {
 		return fmt.Errorf("marshalling configuration: %w", err)
 	}
+
 	out.Write(buf)
 
 	return nil

--- a/docs-v2/content/en/docs/references/cli/_index.md
+++ b/docs-v2/content/en/docs/references/cli/_index.md
@@ -903,6 +903,7 @@ Examples:
 Options:
       --assume-yes=false: If true, skaffold will skip yes/no confirmation from the user and default to yes
   -c, --config='': File for global configurations (defaults to $HOME/.skaffold/config)
+      --enable-templating=false: Render supported templated fields with golang template engine
   -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
   -m, --module=[]: Filter Skaffold configs to only the provided named modules
   -o, --output='': File to write diagnose result
@@ -924,6 +925,7 @@ Env vars:
 
 * `SKAFFOLD_ASSUME_YES` (same as `--assume-yes`)
 * `SKAFFOLD_CONFIG` (same as `--config`)
+* `SKAFFOLD_ENABLE_TEMPLATING` (same as `--enable-templating`)
 * `SKAFFOLD_FILENAME` (same as `--filename`)
 * `SKAFFOLD_MODULE` (same as `--module`)
 * `SKAFFOLD_OUTPUT` (same as `--output`)

--- a/integration/testdata/diagnose/direct-templates/diagnose.tmpl
+++ b/integration/testdata/diagnose/direct-templates/diagnose.tmpl
@@ -1,0 +1,52 @@
+apiVersion: skaffold/v4beta11
+kind: Config
+build:
+  artifacts:
+    - image: skaffold-helm
+      context: {{.Root}}
+      docker:
+        dockerfile: Dockerfile
+        buildArgs:
+          key1: aaa
+    - image: skaffold-ko
+      context: {{.Root}}
+      ko:
+        fromImage: gcr.io/distroless/static-debian11:nonroot
+        dependencies:
+          paths:
+            - '**/*.go'
+            - go.*
+        env:
+          - first=aaa
+        labels:
+          xxx: aaa
+  tagPolicy:
+    gitCommit: {}
+  local:
+    concurrency: 1
+manifests:
+  kustomize:
+    paths:
+      - {{.Root}}/aaa
+      - {{.Root}}/aaa
+  helm:
+    releases:
+      - name: aaa
+        chartPath: {{.Root}}/aaa
+        valuesFiles:
+          - {{.Root}}/aaa
+        namespace: aaa
+        setValues:
+          aaa: aaa
+          bbb: aaa
+        setValueTemplates:
+          image.tag: aaa
+deploy:
+  kubectl:
+    defaultNamespace: aaa
+  logs:
+    prefix: container
+portForward:
+  - resourceName: aaa
+    namespace: aaa
+    address: 127.0.0.1

--- a/integration/testdata/diagnose/direct-templates/skaffold.yaml
+++ b/integration/testdata/diagnose/direct-templates/skaffold.yaml
@@ -1,0 +1,44 @@
+apiVersion: skaffold/v4beta11
+kind: Config
+build:
+  artifacts:
+    - image: skaffold-helm
+      docker:
+        buildArgs:
+          "key1": "{{.AAA}}"
+    - image: skaffold-ko
+      ko:
+        dependencies:
+          paths:
+            - "**/*.go"
+            - go.*
+        fromImage: gcr.io/distroless/static-debian11:nonroot
+        env:
+          - "first={{.AAA}}"
+        labels:
+          xxx: "{{.AAA}}"
+
+manifests:
+  kustomize:
+    paths:
+      - "{{.AAA}}"
+      - "{{.AAA}}"
+  helm:
+    releases:
+      - name: "{{.AAA}}"
+        chartPath: "{{.AAA}}"
+        valuesFiles:
+          - "{{.AAA}}"
+        namespace: "{{.AAA}}"
+        setValues:
+          aaa: "{{.AAA}}"
+          bbb: "{{.AAA}}"
+        setValueTemplates:
+          image:
+            tag: "{{.AAA}}"
+deploy:
+  kubectl:
+    defaultNamespace: "{{.AAA}}"
+portForward:
+  - namespace: "{{.AAA}}"
+    resourceName: "{{.AAA}}"

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -191,10 +191,10 @@ type PortForwardResource struct {
 	Type ResourceType `yaml:"resourceType,omitempty"`
 
 	// Name is the name of the Kubernetes resource or local container to port forward.
-	Name string `yaml:"resourceName,omitempty"`
+	Name string `yaml:"resourceName,omitempty" skaffold:"template"`
 
 	// Namespace is the namespace of the resource to port forward. Does not apply to local containers.
-	Namespace string `yaml:"namespace,omitempty"`
+	Namespace string `yaml:"namespace,omitempty" skaffold:"template"`
 
 	// Port is the resource port that will be forwarded.
 	Port util.IntOrString `yaml:"port,omitempty"`
@@ -294,7 +294,7 @@ type EnvTemplateTagger struct {
 	// The template is executed against the current environment,
 	// with those variables injected.
 	// For example: `{{.RELEASE}}`.
-	Template string `yaml:"template,omitempty" yamltags:"required"`
+	Template string `yaml:"template,omitempty" yamltags:"required" skaffold:"template"`
 }
 
 // DateTimeTagger *beta* tags images with the build timestamp.
@@ -790,7 +790,7 @@ type RemoteManifest struct {
 type Kustomize struct {
 	// Paths is the path to Kustomization files.
 	// Defaults to `["."]`.
-	Paths []string `yaml:"paths,omitempty" skaffold:"filepath"`
+	Paths []string `yaml:"paths,omitempty" skaffold:"filepath,template"`
 
 	// BuildArgs are additional args passed to `kustomize build`.
 	BuildArgs []string `yaml:"buildArgs,omitempty"`
@@ -935,7 +935,7 @@ type KubectlDeploy struct {
 	RemoteManifests []string `yaml:"remoteManifests,omitempty"`
 
 	// DefaultNamespace is the default namespace passed to kubectl on deployment if no other override is given.
-	DefaultNamespace *string `yaml:"defaultNamespace,omitempty"`
+	DefaultNamespace *string `yaml:"defaultNamespace,omitempty" skaffold:"template"`
 
 	// LifecycleHooks describes a set of lifecycle hooks that are executed before and after every deploy.
 	LifecycleHooks DeployHooks `yaml:"hooks,omitempty"`
@@ -989,32 +989,32 @@ type HelmDeployFlags struct {
 type HelmRelease struct {
 	// Name is the name of the Helm release.
 	// It accepts environment variables via the go template syntax.
-	Name string `yaml:"name,omitempty" yamltags:"required"`
+	Name string `yaml:"name,omitempty" yamltags:"required" skaffold:"template"`
 
 	// ChartPath is the local path to a packaged Helm chart or an unpacked Helm chart directory.
-	ChartPath string `yaml:"chartPath,omitempty" yamltags:"oneOf=chartSource" skaffold:"filepath"`
+	ChartPath string `yaml:"chartPath,omitempty" yamltags:"oneOf=chartSource" skaffold:"filepath,template"`
 
 	// RemoteChart refers to a remote Helm chart reference or URL.
 	RemoteChart string `yaml:"remoteChart,omitempty" yamltags:"oneOf=chartSource"`
 
 	// ValuesFiles are the paths to the Helm `values` files.
-	ValuesFiles []string `yaml:"valuesFiles,omitempty" skaffold:"filepath"`
+	ValuesFiles []string `yaml:"valuesFiles,omitempty" skaffold:"filepath,template"`
 
 	// Namespace is the Kubernetes namespace.
-	Namespace string `yaml:"namespace,omitempty"`
+	Namespace string `yaml:"namespace,omitempty" skaffold:"template"`
 
 	// Version is the version of the chart.
-	Version string `yaml:"version,omitempty"`
+	Version string `yaml:"version,omitempty" skaffold:"template"`
 
 	// SetValues are key-value pairs.
 	// If present, Skaffold will send `--set` flag to Helm CLI and append all pairs after the flag.
-	SetValues util.FlatMap `yaml:"setValues,omitempty"`
+	SetValues util.FlatMap `yaml:"setValues,omitempty" skaffold:"template"`
 
 	// SetValueTemplates are key-value pairs.
 	// If present, Skaffold will try to parse the value part of each key-value pair using
 	// environment variables in the system, then send `--set` flag to Helm CLI and append
 	// all parsed pairs after the flag.
-	SetValueTemplates util.FlatMap `yaml:"setValueTemplates,omitempty"`
+	SetValueTemplates util.FlatMap `yaml:"setValueTemplates,omitempty" skaffold:"template"`
 
 	// SetFiles are key-value pairs.
 	// If present, Skaffold will send `--set-file` flag to Helm CLI and append all pairs after the flag.
@@ -1547,7 +1547,7 @@ type DockerArtifact struct {
 
 	// BuildArgs are arguments passed to the docker build.
 	// For example: `{"key1": "value1", "key2": "{{ .ENV_VAR }}"}`.
-	BuildArgs map[string]*string `yaml:"buildArgs,omitempty"`
+	BuildArgs map[string]*string `yaml:"buildArgs,omitempty" skaffold:"template"`
 
 	// NetworkMode is passed through to docker and overrides the
 	// network configuration of docker builder. If unset, use whatever
@@ -1634,19 +1634,19 @@ type KoArtifact struct {
 	// These environment variables are only used at build time.
 	// They are _not_ set in the resulting container image.
 	// For example: `["GOPRIVATE=git.example.com", "GOCACHE=/workspace/.gocache"]`.
-	Env []string `yaml:"env,omitempty"`
+	Env []string `yaml:"env,omitempty" skaffold:"template"`
 
 	// Flags are additional build flags passed to `go build`.
 	// For example: `["-trimpath", "-v"]`.
-	Flags []string `yaml:"flags,omitempty"`
+	Flags []string `yaml:"flags,omitempty" skaffold:"template"`
 
 	// Labels are key-value string pairs to add to the image config.
 	// For example: `{"foo":"bar"}`.
-	Labels map[string]string `yaml:"labels,omitempty"`
+	Labels map[string]string `yaml:"labels,omitempty" skaffold:"template"`
 
 	// Ldflags are linker flags passed to the builder.
 	// For example: `["-buildid=", "-s", "-w"]`.
-	Ldflags []string `yaml:"ldflags,omitempty"`
+	Ldflags []string `yaml:"ldflags,omitempty" skaffold:"template"`
 
 	// Main is the location of the main package. It is the pattern passed to `go build`.
 	// If main is specified as a relative path, it is relative to the `context` directory.

--- a/pkg/skaffold/tags/paths.go
+++ b/pkg/skaffold/tags/paths.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/output/log"
@@ -122,5 +123,7 @@ func filepathTagExists(f reflect.StructField) bool {
 	if !ok {
 		return false
 	}
-	return t == "filepath"
+	split := strings.Split(t, ",")
+
+	return slices.Contains(split, "filepath")
 }

--- a/pkg/skaffold/tags/templates.go
+++ b/pkg/skaffold/tags/templates.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2024 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tags
+
+import (
+	"fmt"
+	"reflect"
+	"slices"
+	"strings"
+
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/util"
+)
+
+// ApplyTemplates recursively traverses the provided interface{} value,
+// expanding any string fields or elements that contain Go templates.
+//
+// Supported types for template expansion include:
+//   - string
+//   - *string
+//   - []string
+//   - []*string
+//   - map[string]string
+//   - map[string]*string
+//
+// The function uses the "skaffold" struct tag to identify fields that should be
+// treated as templates. A field is considered a template if its "skaffold" tag
+// contains the value "template".
+//
+// If an error occurs during template expansion, the function returns the error.
+// Otherwise, it returns nil.
+func ApplyTemplates(in interface{}) error {
+	return applyTemplatesRecursive(reflect.ValueOf(in))
+}
+
+func applyTemplatesRecursive(v reflect.Value) error {
+	switch v.Kind() {
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			field := v.Field(i)
+			if isSupportedType(field) && containTemplateTag(v.Type().Field(i)) {
+				if err := expandTemplate(field); err != nil {
+					return err
+				}
+			} else if err := applyTemplatesRecursive(field); err != nil {
+				return err
+			}
+		}
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			if err := applyTemplatesRecursive(v.Index(i)); err != nil {
+				return err
+			}
+		}
+	case reflect.Map:
+		for _, key := range v.MapKeys() {
+			value := v.MapIndex(key)
+			if value.Kind() == reflect.Ptr {
+				if err := applyTemplatesRecursive(value); err != nil {
+					return err
+				}
+			} else {
+				p := reflect.New(value.Type())
+				p.Elem().Set(value)
+				if err := applyTemplatesRecursive(p); err != nil {
+					return err
+				}
+				v.SetMapIndex(key, p.Elem())
+			}
+		}
+	case reflect.Interface, reflect.Ptr:
+		if err := applyTemplatesRecursive(v.Elem()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func isSupportedType(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.String:
+		return true
+	case reflect.Ptr:
+		return isSupportedType(v.Elem())
+	case reflect.Slice, reflect.Array:
+		if v.Len() == 0 {
+			return false
+		}
+		k := v.Type().Elem().Kind()
+		return k == reflect.String || (k == reflect.Ptr && v.Index(0).Elem().Kind() == reflect.String)
+	case reflect.Map:
+		if v.Len() == 0 {
+			return false
+		}
+		iter := v.MapRange()
+		iter.Next()
+		mv := iter.Value()
+		return reflect.Indirect(mv).Kind() == reflect.String
+	default:
+		return false
+	}
+}
+
+func expandTemplate(v reflect.Value) error {
+	switch v.Kind() {
+	case reflect.String:
+		updated, err := util.ExpandEnvTemplate(v.String(), nil)
+		if strings.Contains(updated, "<no value>") {
+			return fmt.Errorf("environment variables missing for template keys")
+		}
+		if err != nil {
+			return err
+		}
+		v.SetString(updated)
+	case reflect.Ptr:
+		return expandTemplate(v.Elem())
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			if err := expandTemplate(v.Index(i)); err != nil {
+				return err
+			}
+		}
+	case reflect.Map:
+		for _, key := range v.MapKeys() {
+			vv := v.MapIndex(key)
+			if vv.Kind() == reflect.Ptr {
+				if err := expandTemplate(vv); err != nil {
+					return err
+				}
+			} else if vv.Kind() == reflect.String {
+				updated, err := util.ExpandEnvTemplate(vv.String(), nil)
+				if strings.Contains(updated, "<no value>") {
+					return fmt.Errorf("environment variables missing for template keys")
+				}
+				if err != nil {
+					return err
+				}
+				v.SetMapIndex(key, reflect.ValueOf(updated))
+			}
+		}
+	}
+	return nil
+}
+func containTemplateTag(sf reflect.StructField) bool {
+	v, ok := sf.Tag.Lookup("skaffold")
+	if !ok {
+		return ok
+	}
+	split := strings.Split(v, ",")
+	return slices.Contains(split, "template")
+}

--- a/pkg/skaffold/tags/templates_test.go
+++ b/pkg/skaffold/tags/templates_test.go
@@ -1,0 +1,347 @@
+/*
+Copyright 2024 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tags
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/util"
+	"github.com/GoogleContainerTools/skaffold/v2/testutil"
+)
+
+func TestApplyTemplates(t *testing.T) {
+	type Inner struct {
+		Name string `skaffold:"template"`
+	}
+	type testStruct struct {
+		SimpleString  string             `skaffold:"template"`
+		PtrString     *string            `skaffold:"template"`
+		PtrPtrString  **string           `skaffold:"template"`
+		SliceString   []string           `skaffold:"template"`
+		ArrayString   [2]string          `skaffold:"template"`
+		MapString     map[string]string  `skaffold:"template"`
+		MapPtrString  map[string]*string `skaffold:"template"`
+		IgnoredString string
+		MapStruct     map[string]Inner
+	}
+	tests := []struct {
+		name    string
+		input   testStruct
+		want    testStruct
+		wantErr bool
+		envs    map[string]string
+	}{
+		{
+			name:    "Simple string",
+			input:   testStruct{SimpleString: `Hello-{{.NAME}}`},
+			want:    testStruct{SimpleString: `Hello-World`},
+			wantErr: false,
+			envs:    map[string]string{"NAME": "World"},
+		},
+		{
+			name:    "Pointer to string",
+			input:   testStruct{PtrString: util.Ptr(`Hello-{{.NAME}}`)},
+			want:    testStruct{PtrString: util.Ptr(`Hello-World`)},
+			wantErr: false,
+			envs:    map[string]string{"NAME": "World"},
+		},
+		{
+			name:    "Pointer to pointer to string",
+			input:   testStruct{PtrPtrString: util.Ptr(util.Ptr(`Hello-{{.NAME}}`))},
+			want:    testStruct{PtrPtrString: util.Ptr(util.Ptr(`Hello-World`))},
+			wantErr: false,
+			envs:    map[string]string{"NAME": "World"},
+		},
+		{
+			name:    "Map of strings",
+			input:   testStruct{MapString: map[string]string{"first": "first", "second": "{{.SECOND}}", "third": "{{.THIRD}}"}},
+			want:    testStruct{MapString: map[string]string{"first": "first", "second": "second", "third": "third"}},
+			wantErr: false,
+			envs:    map[string]string{"SECOND": "second", "THIRD": "third"},
+		},
+		{
+			name:    "Map of strings, no value",
+			input:   testStruct{MapString: map[string]string{"first": "first", "second": "{{.SECOND}}", "third": "{{.THIRD}}"}},
+			want:    testStruct{MapString: map[string]string{"first": "first", "second": "{{.SECOND}}", "third": "{{.THIRD}}"}},
+			wantErr: true,
+			envs:    map[string]string{},
+		},
+		{
+			name:    "Map of pointers to strings",
+			input:   testStruct{MapPtrString: map[string]*string{"first": util.Ptr("first"), "second": util.Ptr("{{.SECOND}}"), "third": util.Ptr("{{.THIRD}}")}},
+			want:    testStruct{MapPtrString: map[string]*string{"first": util.Ptr("first"), "second": util.Ptr("second"), "third": util.Ptr("third")}},
+			wantErr: false,
+			envs:    map[string]string{"SECOND": "second", "THIRD": "third"},
+		},
+		{
+			name: "Array of strings",
+			input: testStruct{
+				ArrayString: [2]string{"{{ .ENV_VAR }}", "{{ .ENV_VAR }}"},
+			},
+			want: testStruct{
+				ArrayString: [2]string{"replaced", "replaced"},
+			},
+			envs: map[string]string{"ENV_VAR": "replaced"},
+		}, {
+			name: "Ignored string",
+			input: testStruct{
+				IgnoredString: "{{ .ENV_VAR }}",
+			},
+			want: testStruct{
+				IgnoredString: "{{ .ENV_VAR }}",
+			},
+			wantErr: false,
+		},
+		{
+			name: "string not found - <no value>",
+			input: testStruct{
+				SimpleString: "{{ .ENV_VAR }}",
+			},
+			want: testStruct{
+				SimpleString: "{{ .ENV_VAR }}",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid template",
+			input: testStruct{
+				SimpleString: "{{ .ENV_VAR ",
+			},
+			want: testStruct{
+				SimpleString: "{{ .ENV_VAR ",
+			},
+			wantErr: true,
+		},
+		{
+			name: "mapInner",
+			input: testStruct{
+				MapStruct: map[string]Inner{"aaa": {
+					Name: "{{.NAME}}",
+				}},
+			},
+			want: testStruct{
+				MapStruct: map[string]Inner{"aaa": {
+					Name: "World",
+				}},
+			},
+			envs:    map[string]string{"NAME": "World"},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		testutil.Run(t, tt.name, func(t *testutil.T) {
+			if tt.envs != nil {
+				for k, v := range tt.envs {
+					t.Setenv(k, v)
+				}
+			}
+
+			if err := ApplyTemplates(&tt.input); (err != nil) != tt.wantErr {
+				t.Errorf("applyTemplates() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			t.CheckDeepEqual(tt.input, tt.want)
+		})
+	}
+}
+
+func Test_isSupportedType(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+		v    reflect.Value
+	}{
+		{
+			name: "Simple string",
+			v:    reflect.ValueOf("test"),
+			want: true,
+		},
+		{
+			name: "Pointer to string",
+			v:    reflect.ValueOf(util.Ptr("test")),
+			want: true,
+		},
+		{
+			name: "Slice of strings",
+			v:    reflect.ValueOf([]string{"a", "b"}),
+			want: true,
+		},
+		{
+			name: "Array of strings",
+			v:    reflect.ValueOf([2]string{"a", "b"}),
+			want: true,
+		},
+		{
+			name: "Map of strings",
+			v:    reflect.ValueOf(map[string]string{"a": "b"}),
+			want: true,
+		},
+		{
+			name: "Slice of pointer to strings",
+			v:    reflect.ValueOf([]*string{util.Ptr("test"), util.Ptr("test")}),
+			want: true,
+		},
+		{
+			name: "Unsupported type - int",
+			v:    reflect.ValueOf(123),
+			want: false,
+		},
+		{
+			name: "Unsupported type - struct",
+			v:    reflect.ValueOf(struct{}{}),
+			want: false,
+		},
+		{
+			name: "Empty slice",
+			v:    reflect.ValueOf([]string{}),
+			want: false,
+		},
+		{
+			name: "Empty map",
+			v:    reflect.ValueOf(map[string]string{}),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		testutil.Run(t, tt.name, func(t *testutil.T) {
+			t.CheckDeepEqual(tt.want, isSupportedType(tt.v))
+		})
+	}
+}
+
+func TestExpandTemplate(t *testing.T) {
+	tests := []struct {
+		name    string
+		v       reflect.Value
+		want    interface{}
+		wantErr bool
+	}{
+		{
+			name:    "Simple string",
+			v:       reflect.ValueOf(util.Ptr("Hello, {{ .NAME }}!")),
+			want:    "Hello, World!",
+			wantErr: false,
+		},
+		{
+			name:    "Pointer to string",
+			v:       reflect.ValueOf(util.Ptr(util.Ptr("Hello, {{ .NAME }}!"))),
+			want:    util.Ptr("Hello, World!"),
+			wantErr: false,
+		},
+		{
+			name:    "Slice of strings",
+			v:       reflect.ValueOf([]string{"Hello, {{ .NAME }}!", "{{ .NAME }}, welcome!"}),
+			want:    []string{"Hello, World!", "World, welcome!"},
+			wantErr: false,
+		},
+		{
+			name:    "Array of strings",
+			v:       reflect.ValueOf(util.Ptr([2]string{"Hello, {{ .NAME }}!", "{{ .NAME }}, welcome!"})),
+			want:    [2]string{"Hello, World!", "World, welcome!"},
+			wantErr: false,
+		},
+		{
+			name:    "Map of strings",
+			v:       reflect.ValueOf(map[string]string{"greeting": "Hello, {{ .NAME }}!", "welcome": "{{ .NAME }}, welcome!"}),
+			want:    map[string]string{"greeting": "Hello, World!", "welcome": "World, welcome!"},
+			wantErr: false,
+		},
+		{
+			name:    "Invalid template",
+			v:       reflect.ValueOf(util.Ptr("{{ .INVALID ")),
+			want:    "{{ .INVALID ",
+			wantErr: true,
+		},
+		{
+			name: "Map of pointers to strings",
+			v: reflect.ValueOf(map[string]*string{
+				"greeting": util.Ptr("Hello, {{ .NAME }}!"),
+				"welcome":  util.Ptr("{{ .NAME }}, welcome!"),
+			}),
+			want: map[string]*string{
+				"greeting": util.Ptr("Hello, World!"),
+				"welcome":  util.Ptr("World, welcome!"),
+			},
+			wantErr: false,
+		},
+		{
+			name:    "Slice of pointers to strings",
+			v:       reflect.ValueOf([]*string{util.Ptr("Hello, {{ .NAME }}!"), util.Ptr("{{ .NAME }}, welcome!")}),
+			want:    []*string{util.Ptr("Hello, World!"), util.Ptr("World, welcome!")},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		testutil.Run(t, tt.name, func(t *testutil.T) {
+			// Set environment variable for templating
+			t.Setenv("NAME", "World")
+			err := expandTemplate(tt.v)
+			t.CheckErrorAndDeepEqual(tt.wantErr, err, tt.want, reflect.Indirect(tt.v).Interface())
+		})
+	}
+}
+
+func TestContainTemplateTag(t *testing.T) {
+	tests := []struct {
+		name string
+		sf   reflect.StructField
+		want bool
+	}{
+		{
+			name: "Tag with template",
+			sf: reflect.StructField{
+				Tag: reflect.StructTag(`skaffold:"template"`),
+			},
+			want: true,
+		},
+		{
+			name: "Tag with template and other options",
+			sf: reflect.StructField{
+				Tag: reflect.StructTag(`skaffold:"template,option1,option2"`),
+			},
+			want: true,
+		},
+		{
+			name: "Tag without template",
+			sf: reflect.StructField{
+				Tag: reflect.StructTag(`skaffold:"option1,option2"`),
+			},
+			want: false,
+		},
+		{
+			name: "No skaffold tag",
+			sf: reflect.StructField{
+				Tag: reflect.StructTag(`json:"field"`),
+			},
+			want: false,
+		},
+		{
+			name: "Empty tag",
+			sf: reflect.StructField{
+				Tag: reflect.StructTag(""),
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		testutil.Run(t, tt.name, func(t *testutil.T) {
+			got := containTemplateTag(tt.sf)
+			t.CheckDeepEqual(tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #8758  


**Description**
 - add support templating in diagnose command when using --yaml-only
    -  add skaffold:template tag to label templated fields, so we can use `go template` engine to render the specified fields, supported fields are the same as other commands see [templated fields](https://skaffold.dev/docs/environment/templating/) , 
    - the feature is guarded by a flag `enable-templating` in diagnose command, as this feature is a breaking change for users are keeping template place holder when using diagnose command. 
    - The implementation doesn't have special handling for templated fields for `ko builder` as other command which replace `{{.ENV` with `{{`, that was for ko-skaffold templates compatibilities , but we've documented that for more than one year https://skaffold.dev/docs/builders/builder-types/ko/#build-flags `.ENV` is not needed, so treating it as normal templated fields should be fine. 
    - The implementation will  error out if  key is missing when rendering templates. 

**Schema change**
 - #9401


**Follow-up Work**
 - the skaffold:template may be used for generating docs to show which fields are templated fields, we may add an issue if the approach in this pr is the way we want to implement the feature . 

**Alternative Solution**
 - unmarshal  the whole config and then render with go template. 
   - Pros:
      - easy to implement 
   - Cons:
     - The behavior is not consistent with other commands and the whole skaffold.yaml might be taken as a template file, misuse can lead to unexpected result when skaffold marshal `skaffold.yaml` -> `Skaffold.Configuration` struct 



