### PR TITLE
fix: Correctly call kubectl to get all known images of the node

### DIFF
--- a/pkg/skaffold/kubernetes/loader/load.go
+++ b/pkg/skaffold/kubernetes/loader/load.go
@@ -168,7 +168,7 @@ func (i *ImageLoader) loadImages(ctx context.Context, out io.Writer, artifacts [
 }
 
 func findKnownImages(ctx context.Context, cli *kubectl.CLI) ([]string, error) {
-	nodeGetOut, err := cli.RunOut(ctx, "get", "nodes", `-ojsonpath='{@.items[*].status.images[*].names[*]}'`)
+	nodeGetOut, err := cli.RunOut(ctx, "get", "nodes", `-ojsonpath={@.items[*].status.images[*].names[*]}`)
 	if err != nil {
 		return nil, fmt.Errorf("unable to inspect the nodes: %w", err)
 	}

--- a/pkg/skaffold/kubernetes/loader/load_test.go
+++ b/pkg/skaffold/kubernetes/loader/load_test.go
@@ -46,7 +46,7 @@ func TestLoadImagesInKindNodes(t *testing.T) {
 			cluster:     "kind",
 			deployed:    []graph.Artifact{{Tag: "tag1"}},
 			commands: testutil.
-				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
+				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath={@.items[*].status.images[*].names[*]}", "").
 				AndRunOut("kind load docker-image --name kind tag1", "output: image loaded"),
 		},
 		{
@@ -54,7 +54,7 @@ func TestLoadImagesInKindNodes(t *testing.T) {
 			cluster:     "other-kind",
 			deployed:    []graph.Artifact{{Tag: "tag1"}, {Tag: "tag2"}},
 			commands: testutil.
-				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "docker.io/library/tag1").
+				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath={@.items[*].status.images[*].names[*]}", "docker.io/library/tag1").
 				AndRunOut("kind load docker-image --name other-kind tag2", "output: image loaded"),
 		},
 		{
@@ -62,13 +62,13 @@ func TestLoadImagesInKindNodes(t *testing.T) {
 			cluster:     "kind",
 			deployed:    []graph.Artifact{{Tag: "tag0"}, {Tag: "docker.io/library/tag1"}, {Tag: "docker.io/tag2"}, {Tag: "gcr.io/test/tag3"}, {Tag: "someregistry.com/tag4"}},
 			commands: testutil.
-				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "docker.io/library/tag0 docker.io/library/tag1 docker.io/library/tag2 gcr.io/test/tag3 someregistry.com/tag4"),
+				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath={@.items[*].status.images[*].names[*]}", "docker.io/library/tag0 docker.io/library/tag1 docker.io/library/tag2 gcr.io/test/tag3 someregistry.com/tag4"),
 		},
 		{
 			description: "inspect error",
 			deployed:    []graph.Artifact{{Tag: "tag"}},
 			commands: testutil.
-				CmdRunOutErr("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "", errors.New("BUG")),
+				CmdRunOutErr("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath={@.items[*].status.images[*].names[*]}", "", errors.New("BUG")),
 			shouldErr:     true,
 			expectedError: "unable to inspect",
 		},
@@ -77,7 +77,7 @@ func TestLoadImagesInKindNodes(t *testing.T) {
 			cluster:     "kind",
 			deployed:    []graph.Artifact{{Tag: "tag"}},
 			commands: testutil.
-				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
+				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath={@.items[*].status.images[*].names[*]}", "").
 				AndRunOutErr("kind load docker-image --name kind tag", "output: error!", errors.New("BUG")),
 			shouldErr:     true,
 			expectedError: "output: error!",
@@ -100,7 +100,7 @@ func TestLoadImagesInK3dNodes(t *testing.T) {
 			cluster:     "k3d",
 			deployed:    []graph.Artifact{{Tag: "tag1"}},
 			commands: testutil.
-				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
+				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath={@.items[*].status.images[*].names[*]}", "").
 				AndRunOut("k3d image import --cluster k3d tag1", "output: image loaded"),
 		},
 		{
@@ -108,7 +108,7 @@ func TestLoadImagesInK3dNodes(t *testing.T) {
 			cluster:     "other-k3d",
 			deployed:    []graph.Artifact{{Tag: "tag1"}, {Tag: "tag2"}},
 			commands: testutil.
-				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "docker.io/library/tag1").
+				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath={@.items[*].status.images[*].names[*]}", "docker.io/library/tag1").
 				AndRunOut("k3d image import --cluster other-k3d tag2", "output: image loaded"),
 		},
 		{
@@ -116,13 +116,13 @@ func TestLoadImagesInK3dNodes(t *testing.T) {
 			cluster:     "k3d",
 			deployed:    []graph.Artifact{{Tag: "tag0"}, {Tag: "docker.io/library/tag1"}, {Tag: "docker.io/tag2"}, {Tag: "gcr.io/test/tag3"}, {Tag: "someregistry.com/tag4"}},
 			commands: testutil.
-				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "docker.io/library/tag0 docker.io/library/tag1 docker.io/library/tag2 gcr.io/test/tag3 someregistry.com/tag4"),
+				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath={@.items[*].status.images[*].names[*]}", "docker.io/library/tag0 docker.io/library/tag1 docker.io/library/tag2 gcr.io/test/tag3 someregistry.com/tag4"),
 		},
 		{
 			description: "inspect error",
 			deployed:    []graph.Artifact{{Tag: "tag"}},
 			commands: testutil.
-				CmdRunOutErr("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "", errors.New("BUG")),
+				CmdRunOutErr("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath={@.items[*].status.images[*].names[*]}", "", errors.New("BUG")),
 			shouldErr:     true,
 			expectedError: "unable to inspect",
 		},
@@ -131,7 +131,7 @@ func TestLoadImagesInK3dNodes(t *testing.T) {
 			cluster:     "k3d",
 			deployed:    []graph.Artifact{{Tag: "tag"}},
 			commands: testutil.
-				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
+				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath={@.items[*].status.images[*].names[*]}", "").
 				AndRunOutErr("k3d image import --cluster k3d tag", "output: error!", errors.New("BUG")),
 			shouldErr:     true,
 			expectedError: "output: error!",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #4955 <!-- tracking issues that this PR will close -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
When checking if images are already present on the k8s node, `os.exec` is used, which doesn't go through any shell expansion, so it doesn't require quoting any arguments (quotes are passed through as-is).
This means the first image returned had a `'` prepended to the name, and the last image had a `'` appended, which causes issue #4955

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->
A few less unnecessary image reloads :)

**Follow-up Work (remove if N/A)**
<!-- Mention any related follow up work to this PR. -->
There are a few more places where `jsonpath='(...)'` shows up in an `os.exec` call, someone might want to check those. I noticed at least some of them were "fixed" by trimming the quotes from the output.

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
