### PR TITLE
feat: add `--destination` flag for kaniko build

### DIFF
--- a/docs-v2/content/en/schemas/v4beta11.json
+++ b/docs-v2/content/en/schemas/v4beta11.json
@@ -2671,6 +2671,15 @@
           "description": "timeout for copying build contexts to a cluster. Defaults to 5 minutes (`5m`).",
           "x-intellij-html-description": "timeout for copying build contexts to a cluster. Defaults to 5 minutes (<code>5m</code>)."
         },
+        "destination": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "additional tags to push.",
+          "x-intellij-html-description": "additional tags to push.",
+          "default": "[]"
+        },
         "digestFile": {
           "type": "string",
           "description": "to specify a file in the container. This file will receive the digest of a built image. This can be used to automatically track the exact image built by kaniko.",
@@ -2888,6 +2897,7 @@
         "target",
         "initImage",
         "image",
+        "destination",
         "digestFile",
         "imageFSExtractRetry",
         "imageNameWithDigestFile",

--- a/pkg/skaffold/build/cluster/pod_test.go
+++ b/pkg/skaffold/build/cluster/pod_test.go
@@ -48,6 +48,20 @@ func TestKanikoArgs(t *testing.T) {
 			expectedArgs: []string{},
 		},
 		{
+			description: "with Destination",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				Destination: []string{
+					"gcr.io/foo/bar:test-1",
+					"gcr.io/foo/bar:test-2",
+				},
+			},
+			expectedArgs: []string{
+				kaniko.DestinationFlag, "gcr.io/foo/bar:test-1",
+				kaniko.DestinationFlag, "gcr.io/foo/bar:test-2",
+			},
+		},
+		{
 			description: "cache layers",
 			artifact: &latest.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
@@ -170,6 +184,10 @@ func TestKanikoPodSpec(t *testing.T) {
 		Image:          "image",
 		DockerfilePath: "Dockerfile",
 		InitImage:      "init/image",
+		Destination: []string{
+			"gcr.io/foo/bar:test-1",
+			"gcr.io/foo/bar:test-2",
+		},
 		Env: []v1.EnvVar{{
 			Name:  "KEY",
 			Value: "VALUE",
@@ -284,7 +302,7 @@ func TestKanikoPodSpec(t *testing.T) {
 			Containers: []v1.Container{{
 				Name:            kaniko.DefaultContainerName,
 				Image:           "image",
-				Args:            []string{"--dockerfile", "Dockerfile", "--context", "dir:///kaniko/buildcontext", "--destination", "tag", "-v", "info"},
+				Args:            []string{"--destination", "tag", "--dockerfile", "Dockerfile", "--context", "dir:///kaniko/buildcontext", "--destination", "gcr.io/foo/bar:test-1", "--destination", "gcr.io/foo/bar:test-2"},
 				ImagePullPolicy: v1.PullIfNotPresent,
 				Env: []v1.EnvVar{{
 					Name:  "UPSTREAM_CLIENT_TYPE",
@@ -386,6 +404,7 @@ func TestKanikoPodSpec(t *testing.T) {
 	}
 
 	testutil.CheckDeepEqual(t, expectedPod.Spec.Containers[0].Env, pod.Spec.Containers[0].Env)
+	testutil.CheckDeepEqual(t, expectedPod.Spec.Containers[0].Args, pod.Spec.Containers[0].Args)
 }
 
 func TestResourceRequirements(t *testing.T) {

--- a/pkg/skaffold/build/gcb/kaniko_test.go
+++ b/pkg/skaffold/build/gcb/kaniko_test.go
@@ -48,6 +48,20 @@ func TestKanikoBuildSpec(t *testing.T) {
 			expectedArgs: []string{},
 		},
 		{
+			description: "with destination",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				Destination: []string{
+					"gcr.io/foo/bar:test-1",
+					"gcr.io/foo/bar:test-2",
+				},
+			},
+			expectedArgs: []string{
+				kaniko.DestinationFlag, "gcr.io/foo/bar:test-1",
+				kaniko.DestinationFlag, "gcr.io/foo/bar:test-2",
+			},
+		},
+		{
 			description: "with BuildArgs",
 			artifact: &latest.KanikoArtifact{
 				DockerfilePath: "Dockerfile",

--- a/pkg/skaffold/build/kaniko/args.go
+++ b/pkg/skaffold/build/kaniko/args.go
@@ -69,6 +69,12 @@ func Args(artifact *latest.KanikoArtifact, tag, context string) ([]string, error
 		args = append(args, CleanupFlag)
 	}
 
+	var tags []string
+	for _, r := range artifact.Destination {
+		tags = append(tags, DestinationFlag, r)
+	}
+	args = append(args, tags...)
+
 	if artifact.DigestFile != "" {
 		args = append(args, DigestFileFlag, artifact.DigestFile)
 	}

--- a/pkg/skaffold/build/kaniko/args_test.go
+++ b/pkg/skaffold/build/kaniko/args_test.go
@@ -41,6 +41,21 @@ func TestArgs(t *testing.T) {
 			wantErr:      false,
 		},
 		{
+			description: "with Destination",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "dir/Dockerfile",
+				Destination: []string{
+					"gcr.io/foo/bar:test-1",
+					"gcr.io/foo/bar:test-2",
+				},
+			},
+			expectedArgs: []string{
+				DestinationFlag, "gcr.io/foo/bar:test-1",
+				DestinationFlag, "gcr.io/foo/bar:test-2",
+			},
+			wantErr: false,
+		},
+		{
 			description: "with BuildArgs",
 			artifact: &latest.KanikoArtifact{
 				DockerfilePath: "dir/Dockerfile",

--- a/pkg/skaffold/build/kaniko/types.go
+++ b/pkg/skaffold/build/kaniko/types.go
@@ -35,6 +35,8 @@ const (
 	CleanupFlag = "--cleanup"
 	// DigestFileFlag additional flag
 	DigestFileFlag = "--digest-file"
+	// Destination additional flag
+	DestinationFlag = "--destination"
 	// ForceFlag additional flag
 	ForceFlag = "--force"
 	// ImageFSExtractRetry additional flag

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -1456,6 +1456,9 @@ type KanikoArtifact struct {
 	// Defaults to the latest released version of `gcr.io/kaniko-project/executor`.
 	Image string `yaml:"image,omitempty"`
 
+	// Destination is additional tags to push.
+	Destination []string `yaml:"destination,omitempty"`
+
 	// DigestFile to specify a file in the container. This file will receive the digest of a built image.
 	// This can be used to automatically track the exact image built by kaniko.
 	DigestFile string `yaml:"digestFile,omitempty"`


### PR DESCRIPTION
**Description**
We are using Skaffold to build images in our CI. We wanted to push multiple tags for one image so we implemented the use of the `--destination` kaniko's flag.

It would be used like this:
```yaml
apiVersion: skaffold/v4beta11
kind: Config
metadata:
  name: base-image
build:
  artifacts:
    - image: base
      kaniko:
        destination:
          - base:test-1
          - base:test-2
```
