### PR TITLE
fix: auto-activated by env can not match exactly

### DIFF
--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -1222,6 +1222,10 @@ type Activation struct {
 	// For example: `ENV=production`
 	Env string `yaml:"env,omitempty"`
 
+	// ExecMatch, if set to true, indicates that the expected value must exactly match the actual value in order for a match to be established.
+	// It uses regular expression matching for precise comparisons.
+	ExactMatch bool `yaml:"exactMatch,omitempty"`
+
 	// KubeContext is a Kubernetes context for which the profile is auto-activated.
 	// For example: `minikube`.
 	KubeContext string `yaml:"kubeContext,omitempty"`

--- a/pkg/skaffold/schema/profiles.go
+++ b/pkg/skaffold/schema/profiles.go
@@ -187,7 +187,7 @@ func isAllActivationsTriggered(profile latest.Profile, opts cfg.SkaffoldOptions)
 func isActivationTriggered(cond latest.Activation, opts cfg.SkaffoldOptions) (bool, error) {
 	command := isCommand(cond.Command, opts)
 
-	env, err := isEnv(cond.Env)
+	env, err := isEnv(cond.Env, cond.ExactMatch)
 	if err != nil {
 		return false, err
 	}
@@ -199,7 +199,7 @@ func isActivationTriggered(cond latest.Activation, opts cfg.SkaffoldOptions) (bo
 	return command && env && kubeContext, nil
 }
 
-func isEnv(env string) (bool, error) {
+func isEnv(env string, exactMatch bool) (bool, error) {
 	if env == "" {
 		return true, nil
 	}
@@ -216,8 +216,8 @@ func isEnv(env string) (bool, error) {
 
 	// Special case, since otherwise the regex substring check (`re.Compile("").MatchString(envValue)`)
 	// would always match which is most probably not what the user wanted.
-	if value == "" {
-		return envValue == "", nil
+	if value == "" || exactMatch {
+		return envValue == value, nil
 	}
 
 	return skutil.RegexEqual(value, envValue), nil

--- a/pkg/skaffold/schema/profiles_test.go
+++ b/pkg/skaffold/schema/profiles_test.go
@@ -557,6 +557,18 @@ func TestActivatedProfiles(t *testing.T) {
 			},
 			expected: []string{"activated", "also-activated", "regex-activated", "regex-activated-two", "regex-activated-substring-match"},
 		}, {
+			description: "Auto-activated by env variable which match exactly",
+			envs:        map[string]string{"KEY": "VALUE_12"},
+			opts: cfg.SkaffoldOptions{
+				ProfileAutoActivation: true,
+			},
+			profiles: []latest.Profile{
+				{Name: "activated", Activation: []latest.Activation{{Env: "KEY=VALUE_12", ExactMatch: true}}},
+				{Name: "not-activated-as-exact", Activation: []latest.Activation{{Env: "KEY=VALUE", ExactMatch: true}}},
+				{Name: "not-activated-two-as-exact", Activation: []latest.Activation{{Env: "KEY=VALUE_1", ExactMatch: true}}},
+			},
+			expected: []string{"activated"},
+		}, {
 			description: "Profile with multiple valid activations",
 			envs:        map[string]string{"KEY": "VALUE"},
 			opts: cfg.SkaffoldOptions{


### PR DESCRIPTION


**Description**
I often use env to automatically trigger the profile,  the env represent different business environments and I need to implement precise matching. 

For example, there are two environments called `cbt` and `cbtcn`, I want to accurately match one of them based on environment variables. However, when the environment variable is set to `cbtcn`, it matches both environments, which is not what I expect. 

**Changes**
I  found that auto-activated by env is fuzzy matched.  

so I want to add a new boolean field named exactMatch in the activation struct, which when set to true, would implement an exact match.
