### PR TITLE
feat: Optimized fs walker and util.IsEmptyDir

### DIFF
--- a/pkg/skaffold/docker/dependencies.go
+++ b/pkg/skaffold/docker/dependencies.go
@@ -268,7 +268,8 @@ func WalkWorkspace(workspace string, excludes, deps []string) (map[string]bool, 
 			if err != nil {
 				return err
 			}
-			if util.IsEmptyDir(path) || !info.IsDir() {
+
+			if !info.IsDir() || util.IsEmptyDir(path) {
 				files[relPath] = true
 			}
 
@@ -277,5 +278,6 @@ func WalkWorkspace(workspace string, excludes, deps []string) (map[string]bool, 
 			return nil, fmt.Errorf("walking %q: %w", absFrom, err)
 		}
 	}
+
 	return files, nil
 }

--- a/pkg/skaffold/docker/syncmap.go
+++ b/pkg/skaffold/docker/syncmap.go
@@ -77,13 +77,12 @@ func walkWorkspaceWithDestinations(workspace string, excludes []string, fts []Fr
 		switch mode := fi.Mode(); {
 		case mode.IsDir():
 			keepFile := func(path string, info walk.Dirent) (bool, error) {
-				if info.IsDir() && path == absFrom {
-					return true, nil
+				if info.IsDir() {
+					if path == absFrom || util.IsEmptyDir(path) {
+						return true, nil
+					}
 				}
 
-				if util.IsEmptyDir(path) {
-					return true, nil
-				}
 				ignored, err := dockerIgnored(path, info)
 				if err != nil {
 					return false, err

--- a/pkg/skaffold/util/util.go
+++ b/pkg/skaffold/util/util.go
@@ -284,7 +284,7 @@ func IsEmptyDir(path string) bool {
 		return false
 	}
 	defer d.Close()
-	if _, err := d.ReadDir(1); err == io.EOF {
+	if _, err := d.Readdirnames(1); err == io.EOF {
 		return true
 	}
 	return false


### PR DESCRIPTION
**Description**
1. Optimized file system walker, it used to make 80k(in my case) IO operations, because in the condition `util.IsEmptyDir` was before `!info.IsDir()`, though there is no reason to make IO operation to check is the directory empty if it's not a directory. 
2. Optimized  utils.IsEmptyDir, it used to fetch all information about the directory while we just need to check if it has anything in it, so now it fetches only name

**User facing changes**
*before* - It makes N extra IO operations, where N - is docker context files count
*after* - It doesn't make extra IO operations. 

p.s. this changes optimized fs walker by 50% on my laptop
