### PR TITLE
fix(cmd): fixed err output for delete and deploy commands

### DIFF
--- a/cmd/skaffold/app/cmd/delete.go
+++ b/cmd/skaffold/app/cmd/delete.go
@@ -55,7 +55,7 @@ func doDelete(ctx context.Context, out io.Writer) error {
 
 		manifestListByConfig, err := r.Render(ctx, io.Discard, bRes, false)
 		if err != nil {
-			return err
+			return fmt.Errorf("rendering manifests: %w", err)
 		}
 		return r.Cleanup(ctx, out, dryRun, manifestListByConfig, opts.Command)
 	})

--- a/cmd/skaffold/app/cmd/deploy.go
+++ b/cmd/skaffold/app/cmd/deploy.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/spf13/cobra"
@@ -54,7 +55,7 @@ func doDeploy(ctx context.Context, out io.Writer) error {
 		// Render
 		manifests, errR := r.Render(ctx, out, buildArtifacts, false)
 		if errR != nil {
-			return errR
+			return fmt.Errorf("rendering manifests: %w", errR)
 		}
 		return r.DeployAndLog(ctx, out, buildArtifacts, manifests)
 	})


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #9434 <!-- tracking issues that this PR will close -->

**Description**
Fixed error output if render stage failed for delete/deploy commands

**User facing changes**
**Before**: if delete/deploy failed on render it outputs only `exit status 1`
**After**: if delete/deploy failed on render it outputs full error

