### PR TITLE
Use bazel info workspace to get workspace, check for MODULE.bazel

### DIFF
--- a/pkg/skaffold/tag/custom_template_test.go
+++ b/pkg/skaffold/tag/custom_template_test.go
@@ -149,12 +149,16 @@ func TestTagTemplate_GenerateTag(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.OSEnviron, func() []string { return env })
+			tmpDir := t.NewTempDir()
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunOut(
+				"bazel info workspace",
+				tmpDir.Root(),
+			).AndRunOut(
 				test.expectedQuery,
 				test.output,
 			))
 
-			t.NewTempDir().WriteFiles(test.files).Chdir()
+			tmpDir.WriteFiles(test.files).Chdir()
 			c, err := NewCustomTemplateTagger(runCtx, test.template, test.customMap)
 
 			t.CheckNoError(err)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #9444 <!-- tracking issues that this PR will close -->
**Related**: #9320, #9319 
**Merge before/after**: 

**Description**
1. Outsource bazel root detection to `bazel info workspace`
2. Allow multiple files to be declared as the Bazel root file, adding any found to deps. (1 chosen file now can be a set of several)
3. Update tests, which required separating the negative test from the positives.

Also tested on my actual repro to make sure it eliminated the very mysterious errors I was running into this morning :)
