### PR TITLE
fix: first and last image won't be detected as known image, do not add single quote to the jsonpath (#9448)

### DIFF
--- a/pkg/skaffold/kubernetes/loader/load.go
+++ b/pkg/skaffold/kubernetes/loader/load.go
@@ -168,7 +168,7 @@ func (i *ImageLoader) loadImages(ctx context.Context, out io.Writer, artifacts [
 }
 
 func findKnownImages(ctx context.Context, cli *kubectl.CLI) ([]string, error) {
-	nodeGetOut, err := cli.RunOut(ctx, "get", "nodes", `-ojsonpath='{@.items[*].status.images[*].names[*]}'`)
+	nodeGetOut, err := cli.RunOut(ctx, "get", "nodes", `-ojsonpath={@.items[*].status.images[*].names[*]}`)
 	if err != nil {
 		return nil, fmt.Errorf("unable to inspect the nodes: %w", err)
 	}

--- a/pkg/skaffold/kubernetes/loader/load_test.go
+++ b/pkg/skaffold/kubernetes/loader/load_test.go
@@ -46,7 +46,7 @@ func TestLoadImagesInKindNodes(t *testing.T) {
 			cluster:     "kind",
 			deployed:    []graph.Artifact{{Tag: "tag1"}},
 			commands: testutil.
-				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
+				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath={@.items[*].status.images[*].names[*]}", "").
 				AndRunOut("kind load docker-image --name kind tag1", "output: image loaded"),
 		},
 		{
@@ -54,7 +54,7 @@ func TestLoadImagesInKindNodes(t *testing.T) {
 			cluster:     "other-kind",
 			deployed:    []graph.Artifact{{Tag: "tag1"}, {Tag: "tag2"}},
 			commands: testutil.
-				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "docker.io/library/tag1").
+				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath={@.items[*].status.images[*].names[*]}", "docker.io/library/tag1").
 				AndRunOut("kind load docker-image --name other-kind tag2", "output: image loaded"),
 		},
 		{
@@ -62,13 +62,13 @@ func TestLoadImagesInKindNodes(t *testing.T) {
 			cluster:     "kind",
 			deployed:    []graph.Artifact{{Tag: "tag0"}, {Tag: "docker.io/library/tag1"}, {Tag: "docker.io/tag2"}, {Tag: "gcr.io/test/tag3"}, {Tag: "someregistry.com/tag4"}},
 			commands: testutil.
-				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "docker.io/library/tag0 docker.io/library/tag1 docker.io/library/tag2 gcr.io/test/tag3 someregistry.com/tag4"),
+				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath={@.items[*].status.images[*].names[*]}", "docker.io/library/tag0 docker.io/library/tag1 docker.io/library/tag2 gcr.io/test/tag3 someregistry.com/tag4"),
 		},
 		{
 			description: "inspect error",
 			deployed:    []graph.Artifact{{Tag: "tag"}},
 			commands: testutil.
-				CmdRunOutErr("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "", errors.New("BUG")),
+				CmdRunOutErr("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath={@.items[*].status.images[*].names[*]}", "", errors.New("BUG")),
 			shouldErr:     true,
 			expectedError: "unable to inspect",
 		},
@@ -77,7 +77,7 @@ func TestLoadImagesInKindNodes(t *testing.T) {
 			cluster:     "kind",
 			deployed:    []graph.Artifact{{Tag: "tag"}},
 			commands: testutil.
-				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
+				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath={@.items[*].status.images[*].names[*]}", "").
 				AndRunOutErr("kind load docker-image --name kind tag", "output: error!", errors.New("BUG")),
 			shouldErr:     true,
 			expectedError: "output: error!",
@@ -100,7 +100,7 @@ func TestLoadImagesInK3dNodes(t *testing.T) {
 			cluster:     "k3d",
 			deployed:    []graph.Artifact{{Tag: "tag1"}},
 			commands: testutil.
-				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
+				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath={@.items[*].status.images[*].names[*]}", "").
 				AndRunOut("k3d image import --cluster k3d tag1", "output: image loaded"),
 		},
 		{
@@ -108,7 +108,7 @@ func TestLoadImagesInK3dNodes(t *testing.T) {
 			cluster:     "other-k3d",
 			deployed:    []graph.Artifact{{Tag: "tag1"}, {Tag: "tag2"}},
 			commands: testutil.
-				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "docker.io/library/tag1").
+				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath={@.items[*].status.images[*].names[*]}", "docker.io/library/tag1").
 				AndRunOut("k3d image import --cluster other-k3d tag2", "output: image loaded"),
 		},
 		{
@@ -116,13 +116,13 @@ func TestLoadImagesInK3dNodes(t *testing.T) {
 			cluster:     "k3d",
 			deployed:    []graph.Artifact{{Tag: "tag0"}, {Tag: "docker.io/library/tag1"}, {Tag: "docker.io/tag2"}, {Tag: "gcr.io/test/tag3"}, {Tag: "someregistry.com/tag4"}},
 			commands: testutil.
-				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "docker.io/library/tag0 docker.io/library/tag1 docker.io/library/tag2 gcr.io/test/tag3 someregistry.com/tag4"),
+				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath={@.items[*].status.images[*].names[*]}", "docker.io/library/tag0 docker.io/library/tag1 docker.io/library/tag2 gcr.io/test/tag3 someregistry.com/tag4"),
 		},
 		{
 			description: "inspect error",
 			deployed:    []graph.Artifact{{Tag: "tag"}},
 			commands: testutil.
-				CmdRunOutErr("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "", errors.New("BUG")),
+				CmdRunOutErr("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath={@.items[*].status.images[*].names[*]}", "", errors.New("BUG")),
 			shouldErr:     true,
 			expectedError: "unable to inspect",
 		},
@@ -131,7 +131,7 @@ func TestLoadImagesInK3dNodes(t *testing.T) {
 			cluster:     "k3d",
 			deployed:    []graph.Artifact{{Tag: "tag"}},
 			commands: testutil.
-				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
+				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath={@.items[*].status.images[*].names[*]}", "").
 				AndRunOutErr("k3d image import --cluster k3d tag", "output: error!", errors.New("BUG")),
 			shouldErr:     true,
 			expectedError: "output: error!",


### PR DESCRIPTION
Fixes: #9448
**Related**: None
**Merge before/after**: None

**Description**
It's not necessary to add single quote to the ojsonpath parameter since Go exec Cmd won't run it in a shell and does not expand any patterns as described in the documentation: https://pkg.go.dev/os/exec#pkg-overview

With the single quote added (the original implementation) JSON path algorithm will add the single quote to string so that the result of the findKnownImages will start and end with a single quote and the list will be something like this (please note the first and last character which is a single quote):

```
'docker.io/library/service:e1aab03877e36438a59d1832b4e1e69dc3f990527e3e37e177cbc91a88a5b653
docker.io/rancher/klipper-helm@sha256:87db3ad354905e6d31e420476467aefcd8f37d071a8f1c8a904f4743162ae546
docker.io/rancher/klipper-helm:v0.8.3-build20240228
docker.io/rancher/mirrored-library-traefik@sha256:ca9c8fbe001070c546a75184e3fd7f08c3e47dfc1e89bff6fe2edd302accfaec
docker.io/rancher/mirrored-library-traefik:2.10.5
docker.io/rancher/mirrored-metrics-server@sha256:20b8b36f8cac9e25aa2a0ff35147b13643bfec603e7e7480886632330a3bbc59
docker.io/rancher/mirrored-metrics-server:v0.7.0
docker.io/rancher/local-path-provisioner@sha256:aee53cadc62bd023911e7f077877d047c5b3c269f9bba25724d558654f43cea0
docker.io/rancher/local-path-provisioner:v0.0.26
docker.io/rancher/mirrored-coredns-coredns@sha256:a11fafae1f8037cbbd66c5afa40ba2423936b72b4fd50a7034a7e8b955163594
docker.io/rancher/mirrored-coredns-coredns:1.10.1
docker.io/rancher/klipper-lb@sha256:558dcf96bf0800d9977ef46dca18411752618cd9dd06daeb99460c0a301d0a60
docker.io/rancher/klipper-lb:v0.4.7
docker.io/rancher/mirrored-pause@sha256:74c4244427b7312c5b901fe0f67cbc53683d06f4f24c6faee65d4182bf0fa893
docker.io/rancher/mirrored-pause:3.6'
```

Instead of

```
docker.io/library/service:e1aab03877e36438a59d1832b4e1e69dc3f990527e3e37e177cbc91a88a5b653
docker.io/rancher/klipper-helm@sha256:87db3ad354905e6d31e420476467aefcd8f37d071a8f1c8a904f4743162ae546
docker.io/rancher/klipper-helm:v0.8.3-build20240228
docker.io/rancher/mirrored-library-traefik@sha256:ca9c8fbe001070c546a75184e3fd7f08c3e47dfc1e89bff6fe2edd302accfaec
docker.io/rancher/mirrored-library-traefik:2.10.5
docker.io/rancher/mirrored-metrics-server@sha256:20b8b36f8cac9e25aa2a0ff35147b13643bfec603e7e7480886632330a3bbc59
docker.io/rancher/mirrored-metrics-server:v0.7.0
docker.io/rancher/local-path-provisioner@sha256:aee53cadc62bd023911e7f077877d047c5b3c269f9bba25724d558654f43cea0
docker.io/rancher/local-path-provisioner:v0.0.26
docker.io/rancher/mirrored-coredns-coredns@sha256:a11fafae1f8037cbbd66c5afa40ba2423936b72b4fd50a7034a7e8b955163594
docker.io/rancher/mirrored-coredns-coredns:1.10.1
docker.io/rancher/klipper-lb@sha256:558dcf96bf0800d9977ef46dca18411752618cd9dd06daeb99460c0a301d0a60
docker.io/rancher/klipper-lb:v0.4.7
docker.io/rancher/mirrored-pause@sha256:74c4244427b7312c5b901fe0f67cbc53683d06f4f24c6faee65d4182bf0fa893
docker.io/rancher/mirrored-pause:3.6
```

If the string of an image tag contains single quote then the `stringslice.Contains(knownImages, normalizedImageRef.String())` won't match it in the `loadImages` so we will load it again which is not necessary.

**User facing changes**
This will fix the problem described in #9448 and the startup time will be significantly faster in case of one of the images is the first or the last one in the list.