### PR TITLE
feat: Optimize helm deploy by using goroutines

### DIFF
--- a/docs-v2/content/en/schemas/v4beta12.json
+++ b/docs-v2/content/en/schemas/v4beta12.json
@@ -3296,6 +3296,12 @@
     },
     "LegacyHelmDeploy": {
       "properties": {
+        "concurrency": {
+          "type": "integer",
+          "description": "how many packages can be installed concurrently. 0 means \"no-limit\".",
+          "x-intellij-html-description": "how many packages can be installed concurrently. 0 means &quot;no-limit&quot;.",
+          "default": "1"
+        },
         "flags": {
           "$ref": "#/definitions/HelmDeployFlags",
           "description": "additional option flags that are passed on the command line to `helm`.",
@@ -3316,6 +3322,7 @@
         }
       },
       "preferredOrder": [
+        "concurrency",
         "releases",
         "flags",
         "hooks"

--- a/pkg/skaffold/config/util.go
+++ b/pkg/skaffold/config/util.go
@@ -301,11 +301,15 @@ func IsMixedPlatformCluster(ctx context.Context, kubeContext string) bool {
 	if err != nil || nodes == nil {
 		return false
 	}
-	set := make(map[string]interface{})
+	set := make(map[string]struct{})
 	for _, n := range nodes.Items {
 		set[fmt.Sprintf("%s/%s", n.Status.NodeInfo.OperatingSystem, n.Status.NodeInfo.Architecture)] = struct{}{}
+
+		if len(set) > 1 {
+			return true
+		}
 	}
-	return len(set) > 1
+	return false
 }
 
 // IsKindCluster checks that the given `kubeContext` is talking to `kind`.

--- a/pkg/skaffold/deploy/helm/helm_test.go
+++ b/pkg/skaffold/deploy/helm/helm_test.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/v2/testutil/concurrency"
 	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -48,6 +47,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/warnings"
 	"github.com/GoogleContainerTools/skaffold/v2/testutil"
+	"github.com/GoogleContainerTools/skaffold/v2/testutil/concurrency"
 )
 
 var testBuilds = []graph.Artifact{{

--- a/pkg/skaffold/schema/defaults/defaults.go
+++ b/pkg/skaffold/schema/defaults/defaults.go
@@ -46,6 +46,7 @@ func Set(c *latest.SkaffoldConfig) error {
 	defaultToLocalBuild(c)
 	setDefaultTagger(c)
 	setDefaultLogsConfig(c)
+	setHelmDefaults(c)
 
 	for _, a := range c.Build.Artifacts {
 		setDefaultWorkspace(a)
@@ -111,6 +112,17 @@ func Set(c *latest.SkaffoldConfig) error {
 
 	setDefaultTestWorkspace(c)
 	return nil
+}
+
+func setHelmDefaults(c *latest.SkaffoldConfig) {
+	if c.Deploy.LegacyHelmDeploy == nil {
+		return
+	}
+
+	if c.Deploy.LegacyHelmDeploy.Concurrency == nil {
+		defaultConcurrency := 1
+		c.Deploy.LegacyHelmDeploy.Concurrency = &defaultConcurrency
+	}
 }
 
 // SetDefaultRenderer sets the default manifests to rawYaml.

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -963,6 +963,10 @@ type KubectlFlags struct {
 
 // LegacyHelmDeploy *beta* uses the `helm` CLI to apply the charts to the cluster.
 type LegacyHelmDeploy struct {
+	// Concurrency is how many packages can be installed concurrently. 0 means "no-limit".
+	// Defaults to `1`.
+	Concurrency *int `yaml:"concurrency,omitempty"`
+
 	// Releases is a list of Helm releases.
 	Releases []HelmRelease `yaml:"releases,omitempty"`
 


### PR DESCRIPTION
**Description**
1. Optimized helm install by using goroutines which reduced deploy time by more than 50% 
2. Added config option to control the concurrency, by default it keeps current logic - sequential installation
3. Minor fixes

in my case:
before: _Deploy completed in **3 minutes 52.351** seconds_
after: _Deploy completed in **1 minute 57.148** seconds_

colleague:
before: _Deploy completed in _4 minutes 4.594_ seconds_
after: _Deploy completed in **53.423** seconds_