### PR TITLE
feat: make ADC the default option for GCP authentication when using go-containerregistry

### DIFF
--- a/pkg/skaffold/docker/authenticators.go
+++ b/pkg/skaffold/docker/authenticators.go
@@ -17,12 +17,15 @@ limitations under the License.
 package docker
 
 import (
+	"context"
 	"strings"
 	"sync"
 
 	"github.com/docker/cli/cli/config"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/v1/google"
+
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/output/log"
 )
 
 var primaryKeychain = &Keychain{
@@ -76,17 +79,17 @@ func (a *lockedAuthenticator) Authorization() (*authn.AuthConfig, error) {
 }
 
 // Create a new authenticator for a given reference
-// 1. If `gcloud` is configured, we use google.NewGcloudAuthenticator(). It is more efficient because it reuses tokens.
+// 1. If `gcloud` is configured with given registry, we try to use a Google authenticator
 // 2. If something else is configured, we use that authenticator
 // 3. If nothing is configured, we check if `gcloud` can be used
 // 4. Default to anonymous
 func (a *Keychain) newAuthenticator(res authn.Resource) authn.Authenticator {
 	registry := res.RegistryStr()
 
-	// 1. Use google.NewGcloudAuthenticator() authenticator if `gcloud` is configured
+	// 1. Try getting a Google authenticator if docker config configured to use gcloud
 	cfg, err := config.Load(a.configDir)
 	if err == nil && cfg.CredentialHelpers[registry] == "gcloud" {
-		if auth, err := google.NewGcloudAuthenticator(); err == nil {
+		if auth := getGoogleAuthenticator(); auth != nil {
 			return auth
 		}
 	}
@@ -97,13 +100,46 @@ func (a *Keychain) newAuthenticator(res authn.Resource) authn.Authenticator {
 		return auth
 	}
 
-	// 3. Try gcloud for *.gcr.io
-	if registry == "gcr.io" || strings.HasSuffix(registry, ".gcr.io") {
-		if auth, err := google.NewGcloudAuthenticator(); err == nil {
+	// 3. Try Google authenticator for known registries (same logic used by go-containerregistry)
+	if isGoogleRegistry(registry) {
+		if auth := getGoogleAuthenticator(); auth != nil {
 			return auth
 		}
 	}
 
 	// 4. Default to anonymous
 	return authn.Anonymous
+}
+
+func getGoogleAuthenticator() authn.Authenticator {
+	// 1. First we try to create an authenticator that uses Application Default Credentials
+	auth, err := google.NewEnvAuthenticator()
+	if err == nil && auth != authn.Anonymous {
+		log.Entry(context.TODO()).Debugf("using Application Default Credentials authenticator")
+		return auth
+	}
+
+	if err != nil {
+		log.Entry(context.TODO()).Debugf("failed to get Application Default Credentials auth: %v", err)
+	}
+
+	// 2. Try to create authenticator that uses gcloud
+	auth, err = google.NewGcloudAuthenticator()
+	if err == nil && auth != authn.Anonymous {
+		log.Entry(context.TODO()).Debugf("using gcloud authenticator")
+		return auth
+	}
+
+	if err != nil {
+		log.Entry(context.TODO()).Debugf("failed to get gcloud auth: %v", err)
+	}
+
+	return nil
+}
+
+func isGoogleRegistry(host string) bool {
+	return host == "gcr.io" ||
+		strings.HasSuffix(host, ".gcr.io") ||
+		strings.HasSuffix(host, ".pkg.dev") ||
+		strings.HasSuffix(host, ".google.com")
 }


### PR DESCRIPTION
Related with:
- #7063
- #9457

**Description**
This is to remove the dependency with `gcloud` CLI when interacting with a  private Google Registry using the go-containerregistry libray. Changing the implementation of Skaffold's Keychain to first check if it can get the access token through Application Default Credentials, if not possible then it will fallback to use `gcloud` CLI.

I tried to use the [google.Keychain authenticator](https://github.com/GoogleContainerTools/skaffold/blob/b4dd93fbc3f1ea1ef39e25aa49f02dc649801148/vendor/github.com/google/go-containerregistry/pkg/v1/google/keychain.go#L15), but it will first check if the registry is a known Google registry, if not it will fail. This will be breaking a case where users have a custom domain pointing to a Google Registry and configured in their `.docker/config.json`:
```yaml
{
  "credHelpers": {
    "mydomain.com": "gcloud" # <- mydomain.com pointing to AR
  },
}
```
Looks like that case is possible according to https://cloud.google.com/blog/topics/developers-practitioners/hack-your-own-custom-domains-container-registry

Also extending logic to detect known Google Registries (so they don't need to be configured in `.docker/config.json`)

**Follow-up Work (remove if N/A)**
We're still missing more places to remove the `gcloud` dependency. More coming.