### PR TITLE
fix(kaniko): replaces kaniko --snapshotMode argument with --snapshot-mode

### DIFF
--- a/pkg/skaffold/build/gcb/kaniko_test.go
+++ b/pkg/skaffold/build/gcb/kaniko_test.go
@@ -324,7 +324,7 @@ func TestKanikoBuildSpec(t *testing.T) {
 				SnapshotMode:   "redo",
 			},
 			expectedArgs: []string{
-				"--snapshotMode", "redo",
+				"--snapshot-mode", "redo",
 			},
 		},
 		{

--- a/pkg/skaffold/build/kaniko/args_test.go
+++ b/pkg/skaffold/build/kaniko/args_test.go
@@ -328,7 +328,7 @@ func TestArgs(t *testing.T) {
 				SnapshotMode:   "redo",
 			},
 			expectedArgs: []string{
-				"--snapshotMode", "redo",
+				"--snapshot-mode", "redo",
 			},
 			wantErr: false,
 		},

--- a/pkg/skaffold/build/kaniko/types.go
+++ b/pkg/skaffold/build/kaniko/types.go
@@ -74,7 +74,7 @@ const (
 	// SkipUnusedStagesFlag additional flag
 	SkipUnusedStagesFlag = "--skip-unused-stages"
 	// SnapshotModeFlag additional flag
-	SnapshotModeFlag = "--snapshotMode"
+	SnapshotModeFlag = "--snapshot-mode"
 	// PushRetryFlag additional flag
 	PushRetryFlag = "--push-retry"
 	// TarPathFlag additional flag


### PR DESCRIPTION
Fixes: https://github.com/GoogleContainerTools/skaffold/issues/9453

**Description**
Fixes warning `Flag --snapshotMode is deprecated. Use: --snapshot-mode`
