### PR TITLE
feat(kaniko): Add kaniko cache run layers flag

### DIFF
--- a/docs-v2/content/en/schemas/v4beta12.json
+++ b/docs-v2/content/en/schemas/v4beta12.json
@@ -2934,6 +2934,11 @@
           "x-intellij-html-description": "enables caching of copy layers.",
           "default": "false"
         },
+        "cacheRunLayers": {
+          "type": "boolean",
+          "description": "enables caching of run layers (default=true).",
+          "x-intellij-html-description": "enables caching of run layers (default=true)."
+        },
         "hostPath": {
           "type": "string",
           "description": "specifies a path on the host that is mounted to each pod as read only cache volume containing base images. If set, must exist on each node and prepopulated with kaniko-warmer.",
@@ -2954,7 +2959,8 @@
         "repo",
         "hostPath",
         "ttl",
-        "cacheCopyLayers"
+        "cacheCopyLayers",
+        "cacheRunLayers"
       ],
       "additionalProperties": false,
       "type": "object",

--- a/pkg/skaffold/build/gcb/kaniko_test.go
+++ b/pkg/skaffold/build/gcb/kaniko_test.go
@@ -18,6 +18,7 @@ package gcb
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"google.golang.org/api/cloudbuild/v1"
@@ -102,6 +103,28 @@ func TestKanikoBuildSpec(t *testing.T) {
 			expectedArgs: []string{
 				kaniko.CacheFlag,
 				kaniko.CacheCopyLayersFlag,
+			},
+		},
+		{
+			description: "with Cache Run Layers is false",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				Cache:          &latest.KanikoCache{CacheRunLayers: boolPtr(false)},
+			},
+			expectedArgs: []string{
+				kaniko.CacheFlag,
+				fmt.Sprintf("%s=%t", kaniko.CacheRunLayersFlag, false),
+			},
+		},
+		{
+			description: "with Cache Run Layers is true",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				Cache:          &latest.KanikoCache{CacheRunLayers: boolPtr(true)},
+			},
+			expectedArgs: []string{
+				kaniko.CacheFlag,
+				fmt.Sprintf("%s=%t", kaniko.CacheRunLayersFlag, true),
 			},
 		},
 		{
@@ -480,6 +503,10 @@ func TestKanikoBuildSpec(t *testing.T) {
 			t.CheckDeepEqual(expected, desc)
 		})
 	}
+}
+
+func boolPtr(b bool) *bool {
+	return &b
 }
 
 type mockArtifactStore map[string]string

--- a/pkg/skaffold/build/kaniko/args.go
+++ b/pkg/skaffold/build/kaniko/args.go
@@ -59,6 +59,9 @@ func Args(artifact *latest.KanikoArtifact, tag, context string) ([]string, error
 		if artifact.Cache.CacheCopyLayers {
 			args = append(args, CacheCopyLayersFlag)
 		}
+		if artifact.Cache.CacheRunLayers != nil {
+			args = append(args, fmt.Sprintf("%s=%t", CacheRunLayersFlag, *artifact.Cache.CacheRunLayers))
+		}
 	}
 
 	if artifact.Target != "" {

--- a/pkg/skaffold/build/kaniko/types.go
+++ b/pkg/skaffold/build/kaniko/types.go
@@ -23,6 +23,8 @@ const (
 	CacheFlag = "--cache"
 	// CacheCopyLayersFlag additional flag
 	CacheCopyLayersFlag = "--cache-copy-layers"
+	// CacheRunLayersFlag additional flag
+	CacheRunLayersFlag = "--cache-run-layers"
 	// CacheDirFlag additional flag
 	CacheDirFlag = "--cache-dir"
 	// CacheRepoFlag additional flag

--- a/pkg/skaffold/schema/defaults/defaults.go
+++ b/pkg/skaffold/schema/defaults/defaults.go
@@ -362,6 +362,9 @@ func setKanikoArtifactDefaults(a *latest.KanikoArtifact) {
 	a.DockerfilePath = valueOrDefault(a.DockerfilePath, constants.DefaultDockerfilePath)
 	a.InitImage = valueOrDefault(a.InitImage, constants.DefaultBusyboxImage)
 	a.DigestFile = valueOrDefault(a.DigestFile, constants.DefaultKanikoDigestFile)
+	if a.Cache != nil {
+		a.Cache.CacheRunLayers = valueOrDefaultBool(a.Cache.CacheRunLayers, true)
+	}
 	a.CopyMaxRetries = valueOrDefaultInt(a.CopyMaxRetries, kaniko.DefaultCopyMaxRetries)
 	a.CopyTimeout = valueOrDefault(a.CopyTimeout, kaniko.DefaultCopyTimeout)
 }
@@ -374,6 +377,13 @@ func valueOrDefault(v, def string) string {
 }
 
 func valueOrDefaultInt(v *int, def int) *int {
+	if v != nil {
+		return v
+	}
+	return &def
+}
+
+func valueOrDefaultBool(v *bool, def bool) *bool {
 	if v != nil {
 		return v
 	}

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -496,6 +496,8 @@ type KanikoCache struct {
 	TTL string `yaml:"ttl,omitempty"`
 	// CacheCopyLayers enables caching of copy layers.
 	CacheCopyLayers bool `yaml:"cacheCopyLayers,omitempty"`
+	// CacheRunLayers enables caching of run layers (default=true).
+	CacheRunLayers *bool `yaml:"cacheRunLayers,omitempty"`
 }
 
 // ClusterDetails *beta* describes how to do an on-cluster build.


### PR DESCRIPTION
**Merge current PR after 9464**:  https://github.com/GoogleContainerTools/skaffold/pull/9464

**Description**
Add `--cache-run-layers` flag for kaniko, by default it'll be `true` according to the official doc
https://github.com/GoogleContainerTools/kaniko/blob/main/README.md#flag---cache-run-layers

**User facing changes**
New config option for kaniko