### PR TITLE
feat: transform imagePullPolicy when using local cluster

### DIFF
--- a/pkg/skaffold/deploy/kubectl/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl.go
@@ -241,6 +241,17 @@ func (k *Deployer) Deploy(ctx context.Context, out io.Writer, builds []graph.Art
 		return err
 	}
 
+	cluster, err := config.GetCluster(ctx, config.GetClusterOpts{})
+	if err != nil {
+		return err
+	}
+	if cluster.Local {
+		manifests, err = manifests.ReplaceImagePullPolicy(manifest.NewResourceSelectorImagePullPolicy())
+		if err != nil {
+			return err
+		}
+	}
+
 	childCtx, endTrace = instrumentation.StartTrace(ctx, "Deploy_LoadImages")
 	if err := k.imageLoader.LoadImages(childCtx, out, k.localImages, k.originalImages, builds); err != nil {
 		endTrace(instrumentation.TraceEndError(err))

--- a/pkg/skaffold/kubernetes/manifest/image_pull_policy.go
+++ b/pkg/skaffold/kubernetes/manifest/image_pull_policy.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manifest
+
+import apimachinery "k8s.io/apimachinery/pkg/runtime/schema"
+
+// resourceSelectorImagePullPolicy selects PodSpecs for transforming the imagePullPolicy field
+// based on allowlist and denylist rules for their GroupKind and navigation path.
+type resourceSelectorImagePullPolicy struct{}
+
+func NewResourceSelectorImagePullPolicy() ResourceSelector {
+	return &resourceSelectorImagePullPolicy{}
+}
+
+// allowByGroupKind checks if a GroupKind is allowed for transformation.
+// It allows GroupKinds in the allowlist unless they are in the denylist with ".*" in PodSpec paths, which blocks all PodSpecs.
+func (rs *resourceSelectorImagePullPolicy) allowByGroupKind(gk apimachinery.GroupKind) bool {
+	if _, allowed := TransformAllowlist[gk]; allowed {
+		if rf, disallowed := TransformDenylist[gk]; disallowed {
+			for _, s := range rf.PodSpec {
+				if s == ".*" {
+					return false
+				}
+			}
+		}
+		return true
+	}
+	return false
+}
+
+// allowByNavpath checks if a GroupKind's PodSpec path (navpath) allows transformation.
+// It blocks transformation if the path matches a denylist entry or ".*".
+// If not denied, it permits transformation if the path matches an allowlist entry or ".*".
+func (rs *resourceSelectorImagePullPolicy) allowByNavpath(gk apimachinery.GroupKind, navpath string, k string) (string, bool) {
+	if rf, ok := TransformDenylist[gk]; ok {
+		for _, denypath := range rf.PodSpec {
+			if denypath == ".*" || navpath == denypath {
+				return "", false
+			}
+		}
+	}
+	if rf, ok := TransformAllowlist[gk]; ok {
+		for _, allowpath := range rf.PodSpec {
+			if allowpath == ".*" || navpath == allowpath {
+				return "", true
+			}
+		}
+	}
+	return "", false
+}
+
+func (l *ManifestList) ReplaceImagePullPolicy(rs ResourceSelector) (ManifestList, error) {
+	r := &imagePullPolicyReplacer{}
+	return l.Visit(r, rs)
+}
+
+// imagePullPolicyReplacer implements FieldVisitor and modifies the "imagePullPolicy" field in Kubernetes manifests.
+type imagePullPolicyReplacer struct{}
+
+// Visit sets the value of the "imagePullPolicy" field in a Kubernetes manifest to "Never".
+func (i *imagePullPolicyReplacer) Visit(gk apimachinery.GroupKind, navpath string, o map[string]interface{}, k string, v interface{}, rs ResourceSelector) bool {
+	const imagePullPolicyField = "imagePullPolicy"
+	if _, allowed := rs.allowByNavpath(gk, navpath, k); !allowed {
+		return true
+	}
+	if k != imagePullPolicyField {
+		return true
+	}
+	if _, ok := v.(string); !ok {
+		return true
+	}
+	o[imagePullPolicyField] = "Never"
+	return false
+}

--- a/pkg/skaffold/kubernetes/manifest/image_pull_policy_test.go
+++ b/pkg/skaffold/kubernetes/manifest/image_pull_policy_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manifest
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/v2/testutil"
+)
+
+func TestReplaceImagePullPolicy(t *testing.T) {
+	manifests := ManifestList{[]byte(`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: replace-imagePullPolicy
+spec:
+  containers:
+  - image: gcr.io/k8s-skaffold/example@sha256:81daf011d63b68cfa514ddab7741a1adddd59d3264118dfb0fd9266328bb8883
+    name: if-not-present
+    imagePullPolicy: IfNotPresent
+  - image: gcr.io/k8s-skaffold/example@sha256:81daf011d63b68cfa514ddab7741a1adddd59d3264118dfb0fd9266328bb8883
+    name: always
+    imagePullPolicy: Always
+  - image: gcr.io/k8s-skaffold/example@sha256:81daf011d63b68cfa514ddab7741a1adddd59d3264118dfb0fd9266328bb8883
+    name: never
+    imagePullPolicy: Never
+`)}
+
+	expected := ManifestList{[]byte(`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: replace-imagePullPolicy
+spec:
+  containers:
+  - image: gcr.io/k8s-skaffold/example@sha256:81daf011d63b68cfa514ddab7741a1adddd59d3264118dfb0fd9266328bb8883
+    name: if-not-present
+    imagePullPolicy: Never
+  - image: gcr.io/k8s-skaffold/example@sha256:81daf011d63b68cfa514ddab7741a1adddd59d3264118dfb0fd9266328bb8883
+    name: always
+    imagePullPolicy: Never
+  - image: gcr.io/k8s-skaffold/example@sha256:81daf011d63b68cfa514ddab7741a1adddd59d3264118dfb0fd9266328bb8883
+    name: never
+    imagePullPolicy: Never
+`)}
+
+	testutil.Run(t, "", func(t *testutil.T) {
+		resultManifest, err := manifests.ReplaceImagePullPolicy(NewResourceSelectorImagePullPolicy())
+		t.CheckNoError(err)
+		t.CheckDeepEqual(expected.String(), resultManifest.String(), testutil.YamlObj(t.T))
+	})
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Relates to #6992

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Introduces a `ReplaceImagePullPolicy` function to update the `imagePullPolicy` field in Kubernetes manifests to `Never` when running on a local cluster. This prevents deployment errors that occur when `imagePullPolicy` is set to `Always`, as detailed in #6992.

**User facing changes**

Files to reproduce:

- Dockerfile

  ```Dockerfile
  FROM nginx:alpine
  ```
- pod.yaml

  ```yaml
  apiVersion: v1
  kind: Pod
  metadata:
    name: nginx
  spec:
    containers:
    - name: nginx
      image: nginx:alpine
      imagePullPolicy: Always
  ```
- skaffold.yaml

  ```yaml
  apiVersion: skaffold/v4beta11
  kind: Config
  metadata:
    name: nginx
  build:
    artifacts:
      - image: nginx
        context: .
        docker:
          dockerfile: Dockerfile
  manifests:
    rawYaml:
     - ./pod.yaml
  ```

Before:
<img width="1302" alt="failed" src="https://github.com/user-attachments/assets/dc1f82e3-4986-4646-892a-5a286e5aa88d">

After:
<img width="1010" alt="success" src="https://github.com/user-attachments/assets/cda4314a-845f-4bc1-87ca-e6609a1a0f1a">

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
