### PR TITLE
fix(kubectl): Allow port-forwarding if there is nothing to deploy

### DIFF
--- a/pkg/skaffold/deploy/kubectl/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl.go
@@ -229,7 +229,7 @@ func (k *Deployer) Deploy(ctx context.Context, out io.Writer, builds []graph.Art
 	}
 
 	if len(manifests) == 0 {
-		return fmt.Errorf("nothing to deploy")
+		return nil
 	}
 
 	// Add debug transformations

--- a/pkg/skaffold/deploy/kubectl/kubectl_test.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl_test.go
@@ -54,10 +54,8 @@ func TestKubectlV1RenderDeploy(t *testing.T) {
 		envs                        map[string]string
 	}{
 		{
-			description:      "no manifest should error now since there is nothing to deploy",
+			description:      "no manifest should not error",
 			kubectl:          latest.KubectlDeploy{},
-			shouldErr:        true,
-			waitForDeletions: true,
 			commands: testutil.
 				CmdRunOutOnce("kubectl config view --minify -o jsonpath='{..namespace}'", "default"),
 		},
@@ -409,7 +407,7 @@ func TestKubectlRedeploy(t *testing.T) {
 			{ImageName: "leeroy-web", Tag: "leeroy-web:v1"},
 			{ImageName: "leeroy-app", Tag: "leeroy-app:v2"},
 		}, emptyManifestList)
-		t.CheckErrorContains("nothing to deploy", err)
+		t.CheckNoError(err)
 	})
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #9496

**Description**
If there is nothing to deploy, we can use skaffold for port-forwarding so there is no need to return error if there is nothing to deploy

