### PR TITLE
feat(bin): Add graceful shutdown for helm command

### DIFF
--- a/pkg/skaffold/helm/bin.go
+++ b/pkg/skaffold/helm/bin.go
@@ -128,38 +128,12 @@ func generateHelmCommand(ctx context.Context, h Client, useSecrets bool, env []s
 		args = append([]string{"secrets"}, args...)
 	}
 
-	cmd := exec.Command("helm", args...)
-
-	// Set up context cancellation handler
-	go func() {
-		<-ctx.Done()
-
-		if cmd.Process != nil {
-			// Create a channel to detect if helm finishes cleanup
-			done := make(chan struct{})
-			go func() {
-				cmd.Wait()
-				close(done)
-			}()
-
-			// Send SIGINT for graceful shutdown
-			if err := cmd.Process.Signal(os.Interrupt); err != nil {
-				// Log error but continue to wait for timeout
-				fmt.Printf("Failed to send interrupt signal: %v\n", err)
-			}
-
-			// Wait for either cleanup completion or timeout
-			select {
-			case <-time.After(2 * time.Minute):
-				if err := cmd.Process.Kill(); err != nil {
-					fmt.Printf("Failed to kill process: %v\n", err)
-				}
-			case <-done:
-				fmt.Println("Helm cleanup completed")
-				return
-			}
-		}
-	}()
+	cmd := exec.CommandContext(ctx, "helm", args...)
+	cmd.Cancel = func() error {
+		fmt.Println("Terminating helm, giving it 2 minutes to clean up...")
+		return cmd.Process.Signal(os.Interrupt)
+	}
+	cmd.WaitDelay = 120 * time.Second
 
 	if len(env) > 0 {
 		cmd.Env = env


### PR DESCRIPTION
**Description**
Added graceful shutdown for helm command

the CommandContext kills the process when we cancel the context  
![image](https://github.com/user-attachments/assets/47d4679d-f40e-4a39-9039-e72a27bc6052)

it leads to an inconsistent state in helm charts, the helm left chart in "pending-install" state.  
![image](https://github.com/user-attachments/assets/aa128762-6ca1-4db2-b3b1-52688aab6590)


How to reproduce the issue:
1. start a deployment using the helm 
2. in the middle of the installation stop the process using `Ctrl/CMD + C`
3. check the release status using `helm status {releaseName}`, the status will be "pending-install"
4. try to deploy again and you won't be able to do it, because helm will return `helm another operation (install/upgrade/rollback) is in progress`


This fix gives the helm 15 seconds to rollback(if you pass `--atomic`) and/or save the actual(`failed`) state of the release