### PR TITLE
fix: Set the client DialContext to the connhelper dialer DOCKER_HOST is present

### DIFF
--- a/pkg/skaffold/docker/client.go
+++ b/pkg/skaffold/docker/client.go
@@ -104,7 +104,11 @@ func newEnvAPIClient() ([]string, client.CommonAPIClient, error) {
 					DialContext: helper.Dialer,
 				},
 			}
-			opts = append(opts, client.WithHTTPClient(httpClient), client.WithHost(helper.Host))
+			opts = append(opts,
+				client.WithHTTPClient(httpClient),
+				client.WithHost(helper.Host),
+				client.WithDialContext(helper.Dialer),
+			)
 		} else {
 			opts = append(opts, client.FromEnv)
 		}


### PR DESCRIPTION
Summary: Fixes #9484

Fixes: #9484 

**Description**
This was tested with and without #9512 in place.

Test Plan: Tested skaffold over a ssh connection to minikube.