### PR TITLE
fix: emit CloudRunServiceReady event even if default url is disabled

### DIFF
--- a/pkg/skaffold/deploy/cloudrun/status.go
+++ b/pkg/skaffold/deploy/cloudrun/status.go
@@ -350,7 +350,7 @@ func (r *runServiceResource) reportSuccess() {
 		// event status
 		url = "-"
 	}
-		eventV2.CloudRunServiceReady(r.path, url, r.latestRevision)
+	eventV2.CloudRunServiceReady(r.path, url, r.latestRevision)
 }
 
 type runJobResource struct {

--- a/pkg/skaffold/deploy/cloudrun/status.go
+++ b/pkg/skaffold/deploy/cloudrun/status.go
@@ -302,10 +302,10 @@ func (s *Monitor) printStatusCheckSummary(out io.Writer, c *counter, r *runResou
 		return
 	}
 	eventV2.ResourceStatusCheckEventCompleted(r.resource.String(), curStatus.ae)
-	r.sub.reportSuccess()
 	if curStatus.ae.ErrCode != proto.StatusCode_STATUSCHECK_SUCCESS {
 		output.Default.Fprintln(out, fmt.Sprintf("Cloud Run %s %s failed with error: %s", r.resource.Type(), r.resource.Name(), curStatus.ae.Message))
 	} else {
+		r.sub.reportSuccess()
 		output.Default.Fprintln(out, fmt.Sprintf("Cloud Run %s %s finished: %s. %s", r.resource.Type(), r.resource.Name(), curStatus.ae.Message, c.remaining()))
 	}
 }
@@ -344,9 +344,13 @@ func (r *runServiceResource) getTerminalStatus(crClient *run.APIService) (*run.G
 	return ready, nil
 }
 func (r *runServiceResource) reportSuccess() {
-	if r.url != "" {
-		eventV2.CloudRunServiceReady(r.path, r.url, r.latestRevision)
+	url := r.url
+	if url == "" {
+		// a URL may not be present if the default URL is disabled. Use - instead of empty in case anyone is parsing the
+		// event status
+		url = "-"
 	}
+		eventV2.CloudRunServiceReady(r.path, url, r.latestRevision)
 }
 
 type runJobResource struct {

--- a/pkg/skaffold/deploy/cloudrun/status.go
+++ b/pkg/skaffold/deploy/cloudrun/status.go
@@ -345,11 +345,6 @@ func (r *runServiceResource) getTerminalStatus(crClient *run.APIService) (*run.G
 }
 func (r *runServiceResource) reportSuccess() {
 	url := r.url
-	if url == "" {
-		// a URL may not be present if the default URL is disabled. Use - instead of empty in case anyone is parsing the
-		// event status
-		url = "-"
-	}
 	eventV2.CloudRunServiceReady(r.path, url, r.latestRevision)
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #9522 <!-- tracking issues that this PR will close -->


**Description**
Only emit CloudRunServiceReady event if the status is success, and emit it even if no URL is present which could be the case if default-url-disabled is set to true

**User facing changes (remove if N/A)**
Before:
A creation or update of a service with annotation run.googleapis.com/default-url-disabled: true would not emit a CloudRunServiceReady event.
If an update of an existing service failed, CloudRunServiceReady event would be emitted.

After:
A CloudRunServiceReady event is only populated if the Ready condition is successful, and is populated even if the default URL is disabled.

