### PR TITLE
fix: change k8s job container creation logic to retain existing value…

### DIFF
--- a/pkg/skaffold/actions/k8sjob/task.go
+++ b/pkg/skaffold/actions/k8sjob/task.go
@@ -146,7 +146,26 @@ func (t Task) getK8SEnvVars(envVars []latest.VerifyEnvVar) (k8sEnvVar []corev1.E
 }
 
 func (t *Task) setManifestValues(c corev1.Container) {
-	t.jobManifest.Spec.Template.Spec.Containers = []corev1.Container{c}
+	if len(t.jobManifest.Spec.Template.Spec.Containers) == 0 {
+		t.jobManifest.Spec.Template.Spec.Containers = []corev1.Container{c}
+	} else {
+		if c.Name != "" {
+			t.jobManifest.Spec.Template.Spec.Containers[0].Name = c.Name
+		}
+		if c.Image != "" {
+			t.jobManifest.Spec.Template.Spec.Containers[0].Image = c.Image
+		}
+		if len(c.Command) > 0 {
+			t.jobManifest.Spec.Template.Spec.Containers[0].Command = c.Command
+		}
+		if len(c.Args) > 0 {
+			t.jobManifest.Spec.Template.Spec.Containers[0].Args = c.Args
+		}
+		if len(c.Env) > 0 {
+			t.jobManifest.Spec.Template.Spec.Containers[0].Env = c.Env
+		}
+	}
+
 	t.jobManifest.ObjectMeta.Name = t.Name()
 }
 


### PR DESCRIPTION
…s from job manifest

Fixes GoogleContainerTools/skaffold#9409

<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #9409  <!-- tracking issues that this PR will close -->
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
This changes the logic that applies the provided container properties for executing a custom action (when using a custom job manifest) so that only the provided values (if not empty) are overwritten, and the container is not replaced entirely. I have done an initial test and this does now allow the preservation of volumeMounts and other properties that are currently erased. 

Using the overrides config does not work here, as the overrides are applied prior to the logic that replaces the container.

This is a proposed solution for the referenced issue. Having looked under the hood while trying to debug this, I'm not exactly sure what the intended behavior was when providing a custom manifest, so I am open to other possible solutions - perhaps if a custom manifest is provided, the `containers` block should be unnecessary, since theoretically this should already be defined in the manifest?

This is currently requiring us to do a pretty extensive workaround to get this working with Cloud Deploy, as we need to run pre-deploy migrations for most of our services, and we have existing manifests that we need to use (the cut-down Container interface isn't sufficient for our purposes). 

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
This would change the current behavior (which appears to be a bug, at least according to what one would expect) when providing a custom job manifest for a Kubernetes custom action. For example: 
```yaml
customActions:
- name: db-migration
  containers:
  - name: db-migrate
    image: db-migration-image:latest
    command:
    - /bin/sh
    - -c
    - run-db-migration
  executionMode:
    kubernetesCluster:
      jobManifestPath: migration-job.yaml
```
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->

**Follow-up Work (remove if N/A)**
<!-- Mention any related follow up work to this PR. -->


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
