### PR TITLE
fix(config): Replace json tag with yaml for VerifyEnvVar

### DIFF
--- a/docs-v2/content/en/schemas/v4beta12.json
+++ b/docs-v2/content/en/schemas/v4beta12.json
@@ -4639,6 +4639,14 @@
           "x-intellij-html-description": "entrypoint array. Not executed within a shell. The container image's ENTRYPOINT is used if this is not provided.",
           "default": "[]"
         },
+        "env": {
+          "items": {
+            "$ref": "#/definitions/VerifyEnvVar"
+          },
+          "type": "array",
+          "description": "list of environment variables to set in the container.",
+          "x-intellij-html-description": "list of environment variables to set in the container."
+        },
         "image": {
           "type": "string",
           "description": "container image name.",
@@ -4654,7 +4662,8 @@
         "name",
         "image",
         "command",
-        "args"
+        "args",
+        "env"
       ],
       "additionalProperties": false,
       "type": "object",
@@ -4662,6 +4671,26 @@
       "x-intellij-html-description": "a list of tests to run on images that Skaffold builds."
     },
     "VerifyEnvVar": {
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "of the environment variable. Must be a C_IDENTIFIER.",
+          "x-intellij-html-description": "of the environment variable. Must be a C_IDENTIFIER."
+        },
+        "value": {
+          "type": "string",
+          "description": "of the environment variable.",
+          "x-intellij-html-description": "of the environment variable."
+        }
+      },
+      "preferredOrder": [
+        "name",
+        "value"
+      ],
+      "additionalProperties": false,
       "type": "object",
       "description": "represents an environment variable present in a Container.",
       "x-intellij-html-description": "represents an environment variable present in a Container."

--- a/pkg/skaffold/inspect/jobManifestPaths/modify_test.go
+++ b/pkg/skaffold/inspect/jobManifestPaths/modify_test.go
@@ -45,7 +45,9 @@ verify:
     container:
       name: foo
       image: foo
-      env: []
+      env:
+        - name: key
+          value: value
     executionMode:
       kubernetesCluster:
         jobManifestPath: modified-foo.yaml
@@ -60,6 +62,12 @@ verify:
 							Container: latest.VerifyContainer{
 								Name:  "foo",
 								Image: "foo",
+								Env: []latest.VerifyEnvVar{
+									{
+										Name:  "key",
+										Value: "value",
+									},
+								},
 							},
 							ExecutionMode: latest.VerifyExecutionModeConfig{
 								VerifyExecutionModeType: latest.VerifyExecutionModeType{
@@ -88,7 +96,6 @@ verify:
     container:
       name: foo
       image: foo
-      env: []
     executionMode:
       kubernetesCluster:
         jobManifestPath: verify-manifest.yaml
@@ -100,7 +107,6 @@ customActions:
     containers:
       - name: task1
         image: task1-img
-        env: []
   - name: action2
     executionMode:
       kubernetesCluster:
@@ -108,7 +114,6 @@ customActions:
     containers:
       - name: task2
         image: task2-img
-        env: []
 `,
 			originalCfg: latest.SkaffoldConfig{
 				APIVersion: "skaffold/v4beta5",
@@ -177,7 +182,6 @@ verify:
     container:
       name: foo
       image: foo
-      env: []
     executionMode:
       kubernetesCluster:
         jobManifestPath: modified-foo.yaml
@@ -189,7 +193,6 @@ customActions:
     containers:
       - name: task1
         image: task1-img
-        env: []
 `,
 			originalCfg: latest.SkaffoldConfig{
 				APIVersion: "skaffold/v4beta5",

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -724,16 +724,16 @@ type VerifyContainer struct {
 	// The container image's CMD is used if this is not provided.
 	Args []string `yaml:"args,omitempty"`
 	// Env is the list of environment variables to set in the container.
-	Env []VerifyEnvVar `json:"env,omitempty"`
+	Env []VerifyEnvVar `yaml:"env,omitempty"`
 }
 
 // VerifyEnvVar represents an environment variable present in a Container.
 type VerifyEnvVar struct {
 	// Name of the environment variable. Must be a C_IDENTIFIER.
-	Name string `json:"name" yamltags:"required"`
+	Name string `yaml:"name" yamltags:"required"`
 
-	// Value of the environment variable
-	Value string `json:"value"`
+	// Value of the environment variable.
+	Value string `yaml:"value"`
 }
 
 // RenderConfig contains all the configuration needed by the render steps.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #9557 

**Description**
Replaced `json` tag with `yaml` for `VerifyEnvVar`

**User facing changes**
**before**: there is no "env" property for a container
**after**: there is the "env" property for a container

