### PR TITLE
feat: Add network option to BuildpackArtifact

### DIFF
--- a/docs-v2/content/en/schemas/v4beta12.json
+++ b/docs-v2/content/en/schemas/v4beta12.json
@@ -1031,6 +1031,11 @@
             "[\"key1=value1\", \"key2=value2\", \"key3={{.ENV_VARIABLE}}\"]"
           ]
         },
+        "network": {
+          "type": "string",
+          "description": "configure network settings of the build containers. The value of Network is handed directly to the docker client. For valid values of this field see: https://docs.docker.com/network/#network-drivers.",
+          "x-intellij-html-description": "configure network settings of the build containers. The value of Network is handed directly to the docker client. For valid values of this field see: https://docs.docker.com/network/#network-drivers."
+        },
         "projectDescriptor": {
           "type": "string",
           "description": "path to the project descriptor file.",
@@ -1066,7 +1071,8 @@
         "clearCache",
         "projectDescriptor",
         "dependencies",
-        "volumes"
+        "volumes",
+        "network"
       ],
       "additionalProperties": false,
       "type": "object",

--- a/pkg/skaffold/build/buildpacks/lifecycle.go
+++ b/pkg/skaffold/build/buildpacks/lifecycle.go
@@ -247,5 +247,6 @@ func containerConfig(artifact *latest.BuildpackArtifact) (pack.ContainerConfig, 
 		vols = append(vols, spec)
 	}
 
-	return pack.ContainerConfig{Volumes: vols}, nil
+
+	return pack.ContainerConfig{Volumes: vols, Network: artifact.Network}, nil
 }

--- a/pkg/skaffold/build/buildpacks/lifecycle_test.go
+++ b/pkg/skaffold/build/buildpacks/lifecycle_test.go
@@ -59,9 +59,22 @@ func TestContainerConfig(t *testing.T) {
 	tests := []struct {
 		description string
 		volumes     []*latest.BuildpackVolume
+		network     string
 		shouldErr   bool
 		expected    pack.ContainerConfig
 	}{
+		{
+			description: "only network",
+			volumes:     []*latest.BuildpackVolume{},
+			network:    "host",
+			expected:    pack.ContainerConfig{Network: "host"},
+		},
+		{
+			description: "network and volume",
+			volumes:     []*latest.BuildpackVolume{{Host: "/foo", Target: "/bar"}},
+			network:    "host",
+			expected:    pack.ContainerConfig{Volumes: []string{"/foo:/bar"}, Network: "host"},
+		},
 		{
 			description: "single volume with no options",
 			volumes:     []*latest.BuildpackVolume{{Host: "/foo", Target: "/bar"}},
@@ -96,6 +109,7 @@ func TestContainerConfig(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			artifact := latest.BuildpackArtifact{
 				Volumes: test.volumes,
+				Network: test.network,
 			}
 			result, err := containerConfig(&artifact)
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, result)

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -1304,6 +1304,11 @@ type BuildpackArtifact struct {
 
 	// Volumes support mounting host volumes into the container.
 	Volumes []*BuildpackVolume `yaml:"volumes,omitempty"`
+
+	// Network configure network settings of the build containers.
+	// The value of Network is handed directly to the docker client.
+	// For valid values of this field see: https://docs.docker.com/network/#network-drivers.
+	Network string `yaml:"network,omitempty"`
 }
 
 // BuildpackDependencies *alpha* is used to specify dependencies for an artifact built by buildpacks.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: https://kubernetes.slack.com/archives/CABQMSZA6/p1731095108637869

**Description** 
Add `network` to the `BuildpackArtifact` so the user can configure network settings of the build containers.

**User facing changes**
**Before**: no way to specify network for the buildpacks
**After**: there is a way to specify network for the buildpacks
