### PR TITLE
chore: bump go version from 1.22 to 1.23

### DIFF
--- a/.github/workflows/integration-linux.yml
+++ b/.github/workflows/integration-linux.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22.*
+        go-version: 1.23.*
       id: go
 
     # Retrieve build locations with `go env`

--- a/.github/workflows/linters-checks.yml
+++ b/.github/workflows/linters-checks.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.*
+          go-version: 1.23.*
         id: go
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/performance-comparison.yml
+++ b/.github/workflows/performance-comparison.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22.*
+        go-version: 1.23.*
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/unit-tests-darwin.yml
+++ b/.github/workflows/unit-tests-darwin.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22.*
+        go-version: 1.23.*
       id: go
 
     # Retrieve build locations with `go env`

--- a/.github/workflows/unit-tests-linux.yml
+++ b/.github/workflows/unit-tests-linux.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22.*
+        go-version: 1.23.*
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/unit-tests-windows.yml
+++ b/.github/workflows/unit-tests-windows.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22.*
+        go-version: 1.23.*
       id: go
 
     # Retrieve build locations with `go env`

--- a/.github/workflows/verify-examples.yml
+++ b/.github/workflows/verify-examples.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22.*
+        go-version: 1.23.*
       id: go
 
     # Skip changes not affecting examples or integration/examples

--- a/cmd/skaffold/app/cmd/inspect_config_dependencies.go
+++ b/cmd/skaffold/app/cmd/inspect_config_dependencies.go
@@ -43,7 +43,7 @@ func cmdConfigDependenciesAdd() *cobra.Command {
 		WithArgs(func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				errMsg := "`config-dependencies add` requires exactly one file path argument"
-				olog.Entry(context.TODO()).Errorf(errMsg)
+				olog.Entry(context.TODO()).Error(errMsg)
 				return errors.New(errMsg)
 			}
 			return nil

--- a/deploy/skaffold/Dockerfile.deps
+++ b/deploy/skaffold/Dockerfile.deps
@@ -163,5 +163,5 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
     jq \
     apt-transport-https && \
     rm -rf /var/lib/apt/lists/*
-COPY --from=golang:1.22.4 /usr/local/go /usr/local/go
+COPY --from=golang:1.23.3 /usr/local/go /usr/local/go
 ENV PATH /usr/local/go/bin:/root/go/bin:$PATH

--- a/deploy/skaffold/Dockerfile.deps.slim
+++ b/deploy/skaffold/Dockerfile.deps.slim
@@ -104,5 +104,5 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
     jq \
     apt-transport-https && \
     rm -rf /var/lib/apt/lists/*
-COPY --from=golang:1.22.4 /usr/local/go /usr/local/go
+COPY --from=golang:1.23.3 /usr/local/go /usr/local/go
 ENV PATH /usr/local/go/bin:/root/go/bin:$PATH

--- a/fs/assets/credits_generated/github.com/hashicorp/hcl/go.mod
+++ b/fs/assets/credits_generated/github.com/hashicorp/hcl/go.mod
@@ -1,5 +1,5 @@
 module github.com/hashicorp/hcl
 
-go 1.22
+go 1.23
 
 require github.com/davecgh/go-spew v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleContainerTools/skaffold/v2
 
-go 1.22
+go 1.23
 
 // these require code change may remove these later
 exclude (

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -18,7 +18,7 @@ set -e -o pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 BIN=${DIR}/bin
-VERSION=1.57.1
+VERSION=1.62.0
 
 function install_linter() {
   echo "Installing GolangCI-Lint"

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.22
+go 1.23
 
 require (
 	github.com/corneliusweig/release-notes v0.0.0-20191014214505-0be5c7c66752

--- a/hack/versions/pkg/diff/godiff_test.go
+++ b/hack/versions/pkg/diff/godiff_test.go
@@ -248,7 +248,7 @@ type TestStructure struct {
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.same, diff == "")
 			if test.same != (diff == "") {
-				t.Errorf(diff)
+				t.Error(diff)
 			}
 		})
 	}

--- a/hack/versions/pkg/diff/godiff_test.go
+++ b/hack/versions/pkg/diff/godiff_test.go
@@ -284,7 +284,7 @@ func TestCompareSchemas(t *testing.T) {
 			t.CheckNoError(err)
 			t.CheckDeepEqual(test.a == test.b, diff == "")
 			if diff != "" && test.a == test.b {
-				t.Errorf(diff)
+				t.Error(diff)
 			}
 		})
 	}

--- a/integration/build_test.go
+++ b/integration/build_test.go
@@ -308,7 +308,7 @@ func setupGitRepo(t *testing.T, dir string) {
 		cmd := exec.Command("git", args...)
 		cmd.Dir = dir
 		if buf, err := util.RunCmdOut(context.Background(), cmd); err != nil {
-			t.Logf(string(buf))
+			t.Log(string(buf))
 			t.Fatal(err)
 		}
 	}

--- a/integration/skaffold/helper.go
+++ b/integration/skaffold/helper.go
@@ -317,7 +317,7 @@ func (b *RunBuilder) RunOrFailOutput(t *testing.T) []byte {
 	out, err := cmd.Output()
 	if err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {
-			defer t.Errorf(string(ee.Stderr))
+			defer t.Error(string(ee.Stderr))
 		}
 		t.Fatalf("skaffold %s: %v, %s", b.command, err, out)
 	}
@@ -339,7 +339,7 @@ func (b *RunBuilder) RunWithStdoutAndStderrOrFail(t *testing.T, stdout, stderr i
 	err := cmd.Run()
 	if err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {
-			defer t.Errorf(string(ee.Stderr))
+			defer t.Error(string(ee.Stderr))
 		}
 		t.Fatalf("skaffold %s: %v, %s", b.command, err, stderr)
 	}

--- a/pkg/diag/validator/validator.go
+++ b/pkg/diag/validator/validator.go
@@ -18,6 +18,7 @@ package validator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"regexp"
@@ -161,7 +162,7 @@ func getPodStatus(pod *v1.Pod) (proto.StatusCode, []string, error) {
 
 	if c, ok := isPodStatusUnknown(pod); ok {
 		log.Entry(context.TODO()).Debugf("Pod %q condition status of type %s is unknown", pod.Name, c.Type)
-		return proto.StatusCode_STATUSCHECK_UNKNOWN, nil, fmt.Errorf(c.Message)
+		return proto.StatusCode_STATUSCHECK_UNKNOWN, nil, errors.New(c.Message)
 	}
 
 	log.Entry(context.TODO()).Debugf("Unable to determine current service state of pod %q", pod.Name)

--- a/pkg/skaffold/deploy/cloudrun/deploy_test.go
+++ b/pkg/skaffold/deploy/cloudrun/deploy_test.go
@@ -712,7 +712,7 @@ func TestCleanupMultipleResources(tOuter *testing.T) {
 			}
 			for key, val := range test.expectedPath {
 				if val > 0 {
-					t.Fatalf("Missing expected call for path " + key)
+					t.Fatalf("Missing expected call for path %s", key)
 				}
 			}
 		})

--- a/pkg/skaffold/deploy/helm/helm.go
+++ b/pkg/skaffold/deploy/helm/helm.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -439,7 +440,7 @@ func (h *Deployer) Cleanup(ctx context.Context, out io.Writer, dryRun bool, _ ma
 	}
 
 	if len(errMsgs) != 0 {
-		return deployerr.CleanupErr(fmt.Errorf(strings.Join(errMsgs, "\n")))
+		return deployerr.CleanupErr(errors.New(strings.Join(errMsgs, "\n")))
 	}
 	return nil
 }

--- a/pkg/skaffold/filemon/changes.go
+++ b/pkg/skaffold/filemon/changes.go
@@ -117,13 +117,13 @@ func sortEvents(e Events) {
 }
 
 func logEvents(e Events) {
-	if e.Added != nil && len(e.Added) > 0 {
+	if len(e.Added) > 0 {
 		log.Entry(context.TODO()).Infof("files added: %v", e.Added)
 	}
-	if e.Modified != nil && len(e.Modified) > 0 {
+	if len(e.Modified) > 0 {
 		log.Entry(context.TODO()).Infof("files modified: %v", e.Modified)
 	}
-	if e.Deleted != nil && len(e.Deleted) > 0 {
+	if len(e.Deleted) > 0 {
 		log.Entry(context.TODO()).Infof("files deleted: %v", e.Deleted)
 	}
 }

--- a/pkg/skaffold/gcs/gsutil.go
+++ b/pkg/skaffold/gcs/gsutil.go
@@ -21,6 +21,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -122,7 +123,7 @@ func getPerSourceDir(g latest.GoogleCloudStorageInfo) (string, error) {
 // syncDisabledErr returns error to use when remote sync is turned off by the user and the Google Cloud Storage object doesn't exist inside the cache directory.
 func syncDisabledErr(g latest.GoogleCloudStorageInfo, cacheDir string) error {
 	msg := fmt.Sprintf("cache directory %q for Google Cloud Storage source %q does not exist and remote cache sync is explicitly disabled via flag `--sync-remote-cache`", cacheDir, g.Source)
-	return sErrors.NewError(fmt.Errorf(msg),
+	return sErrors.NewError(errors.New(msg),
 		&proto.ActionableErr{
 			Message: msg,
 			ErrCode: proto.StatusCode_CONFIG_REMOTE_REPO_CACHE_NOT_FOUND_ERR,

--- a/pkg/skaffold/git/errors.go
+++ b/pkg/skaffold/git/errors.go
@@ -17,6 +17,7 @@ limitations under the License.
 package git
 
 import (
+	"errors"
 	"fmt"
 
 	sErrors "github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/errors"
@@ -26,7 +27,7 @@ import (
 // SyncDisabledErr returns error when git repository sync is turned off by the user but the repository clone doesn't exist inside the cache directory.
 func SyncDisabledErr(g Config, repoCacheDir string) error {
 	msg := fmt.Sprintf("cache directory %q for repository %q at ref %q does not exist, and repository sync is explicitly disabled via flag `--sync-remote-cache`", repoCacheDir, g.Repo, g.Ref)
-	return sErrors.NewError(fmt.Errorf(msg),
+	return sErrors.NewError(errors.New(msg),
 		&proto.ActionableErr{
 			Message: msg,
 			ErrCode: proto.StatusCode_CONFIG_REMOTE_REPO_CACHE_NOT_FOUND_ERR,

--- a/pkg/skaffold/inspect/errors.go
+++ b/pkg/skaffold/inspect/errors.go
@@ -17,6 +17,7 @@ limitations under the License.
 package inspect
 
 import (
+	"errors"
 	"fmt"
 
 	sErrors "github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/errors"
@@ -31,7 +32,7 @@ func BuildEnvAlreadyExists(b BuildEnv, filename string, profile string) error {
 	} else {
 		msg = fmt.Sprintf("trying to create a %q build environment definition that already exists, in profile %q in file %s", b, profile, filename)
 	}
-	return sErrors.NewError(fmt.Errorf(msg),
+	return sErrors.NewError(errors.New(msg),
 		&proto.ActionableErr{
 			Message: msg,
 			ErrCode: proto.StatusCode_INSPECT_BUILD_ENV_ALREADY_EXISTS_ERR,

--- a/pkg/skaffold/inspect/errors.go
+++ b/pkg/skaffold/inspect/errors.go
@@ -53,7 +53,7 @@ func BuildEnvNotFound(b BuildEnv, filename string, profile string) error {
 	} else {
 		msg = fmt.Sprintf("trying to modify a %q build environment definition that doesn't exist, in profile %q in file %s", b, profile, filename)
 	}
-	return sErrors.NewError(fmt.Errorf(msg),
+	return sErrors.NewError(errors.New(msg),
 		&proto.ActionableErr{
 			Message: msg,
 			ErrCode: proto.StatusCode_INSPECT_BUILD_ENV_INCORRECT_TYPE_ERR,
@@ -69,7 +69,7 @@ func BuildEnvNotFound(b BuildEnv, filename string, profile string) error {
 // ProfileNotFound specifies that the target profile doesn't exist
 func ProfileNotFound(profile string) error {
 	msg := fmt.Sprintf("trying to modify a profile %q that doesn't exist", profile)
-	return sErrors.NewError(fmt.Errorf(msg),
+	return sErrors.NewError(errors.New(msg),
 		&proto.ActionableErr{
 			Message: msg,
 			ErrCode: proto.StatusCode_INSPECT_PROFILE_NOT_FOUND_ERR,

--- a/pkg/skaffold/kubernetes/status/resource/status.go
+++ b/pkg/skaffold/kubernetes/status/resource/status.go
@@ -17,7 +17,7 @@ limitations under the License.
 package resource
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/GoogleContainerTools/skaffold/v2/proto/v1"
 )
@@ -32,7 +32,7 @@ func (rs Status) Error() error {
 	if rs.ae.ErrCode == proto.StatusCode_STATUSCHECK_SUCCESS {
 		return nil
 	}
-	return fmt.Errorf(rs.ae.Message)
+	return errors.New(rs.ae.Message)
 }
 
 func (rs Status) ActionableError() *proto.ActionableErr {

--- a/pkg/skaffold/lsp/handler.go
+++ b/pkg/skaffold/lsp/handler.go
@@ -100,7 +100,7 @@ func GetHandler(conn jsonrpc2.Conn, out io.Writer, opts config.SkaffoldOptions, 
 			err := recover()
 			if err != nil {
 				log.Entry(ctx).Errorf("recovered from panic at %s: %v\n", req.Method(), err)
-				log.Entry(ctx).Errorf("stacktrace from panic: \n" + string(debug.Stack()))
+				log.Entry(ctx).Errorf("stacktrace from panic: \n%s", string(debug.Stack()))
 			}
 		}()
 		log.Entry(ctx).Debugf("req.Method():  %q\n", req.Method())
@@ -192,6 +192,7 @@ func GetHandler(conn jsonrpc2.Conn, out io.Writer, opts config.SkaffoldOptions, 
 	}
 }
 
+//nolint:unparam
 func (h *Handler) updateDocument(ctx context.Context, documentURI, content string) error {
 	h.documentManager.UpdateDocument(documentURI, content)
 	log.Entry(ctx).Debugf("updated document for %q with %d chars\n", documentURI, len(content))

--- a/pkg/skaffold/parser/config_test.go
+++ b/pkg/skaffold/parser/config_test.go
@@ -1459,7 +1459,7 @@ func TestConfigLocationsParse(t *testing.T) {
 				for _, filter := range filters {
 					expectedNode, err = expectedNode.Pipe(filter)
 					if err != nil {
-						t.Fatalf(err.Error())
+						t.Fatal(err.Error())
 					}
 				}
 				if expectedNode == nil {
@@ -1539,7 +1539,7 @@ func TestConfigLocationsLocate(t *testing.T) {
 			fp := t.TempFile("skaffoldyaml-", []byte(test.skaffoldYamlText))
 			cfgs, err := GetConfigSet(context.TODO(), config.SkaffoldOptions{ConfigurationFile: fp, Profiles: test.profiles})
 			if err != nil {
-				t.Fatalf(err.Error())
+				t.Fatal(err.Error())
 			}
 			artifact0Location := cfgs.Locate(cfgs[0].SkaffoldConfig.Build.Artifacts[0])
 			artifact0Location.SourceFile = ""

--- a/pkg/skaffold/parser/config_test.go
+++ b/pkg/skaffold/parser/config_test.go
@@ -1445,11 +1445,11 @@ func TestConfigLocationsParse(t *testing.T) {
 			fp := t.TempFile("skaffoldyaml-", []byte(test.skaffoldYamlText))
 			cfgs, err := GetConfigSet(context.TODO(), config.SkaffoldOptions{ConfigurationFile: fp, Profiles: test.profiles})
 			if err != nil {
-				t.Fatalf(err.Error())
+				t.Fatal(err.Error())
 			}
 			root, err := kyaml.Parse(test.skaffoldYamlText)
 			if err != nil {
-				t.Fatalf(err.Error())
+				t.Fatal(err.Error())
 			}
 			var seen bool
 			for _, filters := range test.expected {

--- a/pkg/skaffold/render/renderer/helm/helm.go
+++ b/pkg/skaffold/render/renderer/helm/helm.go
@@ -19,6 +19,7 @@ package helm
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -221,7 +222,7 @@ func (h Helm) generateHelmManifest(ctx context.Context, builds []graph.Artifact,
 	}
 
 	if err != nil {
-		return nil, helm.UserErr("std out err", fmt.Errorf(outBuffer.String(), fmt.Errorf(errorMsg)))
+		return nil, helm.UserErr("std out err", fmt.Errorf(outBuffer.String(), errors.New(errorMsg)))
 	}
 
 	return outBuffer.Bytes(), nil

--- a/pkg/skaffold/render/renderer/helm/helm.go
+++ b/pkg/skaffold/render/renderer/helm/helm.go
@@ -208,7 +208,7 @@ func (h Helm) generateHelmManifest(ctx context.Context, builds []graph.Artifact,
 	if !release.SkipBuildDependencies && release.ChartPath != "" {
 		log.Entry(ctx).Info("Building helm dependencies...")
 		if err := helm.ExecWithStdoutAndStderr(ctx, h, io.Discard, errBuffer, false, env, "dep", "build", release.ChartPath); err != nil {
-			log.Entry(ctx).Infof(errBuffer.String())
+			log.Entry(ctx).Info(errBuffer.String())
 			return nil, helm.UserErr("building helm dependencies", err)
 		}
 	}
@@ -217,7 +217,7 @@ func (h Helm) generateHelmManifest(ctx context.Context, builds []graph.Artifact,
 	errorMsg := errBuffer.String()
 
 	if len(errorMsg) > 0 {
-		log.Entry(ctx).Infof(errorMsg)
+		log.Entry(ctx).Info(errorMsg)
 	}
 
 	if err != nil {

--- a/pkg/skaffold/render/transform/transform.go
+++ b/pkg/skaffold/render/transform/transform.go
@@ -117,7 +117,7 @@ func (v *Transformer) Append(ts ...latest.Transformer) error {
 }
 
 func (v *Transformer) IsEmpty() bool {
-	return v.config == nil || len(v.config) == 0
+	return len(v.config) == 0
 }
 
 func (v *Transformer) Transform(ctx context.Context, ml manifest.ManifestList) (manifest.ManifestList, error) {

--- a/pkg/skaffold/render/validate/validate.go
+++ b/pkg/skaffold/render/validate/validate.go
@@ -77,7 +77,7 @@ func (v Validator) GetDeclarativeValidators() []kptfile.Function {
 }
 
 func (v Validator) Validate(ctx context.Context, ml manifest.ManifestList) error {
-	if v.kptFn == nil || len(v.kptFn) == 0 {
+	if len(v.kptFn) == 0 {
 		return nil
 	}
 

--- a/pkg/skaffold/schema/errors/errors.go
+++ b/pkg/skaffold/schema/errors/errors.go
@@ -17,6 +17,7 @@ limitations under the License.
 package errors
 
 import (
+	"errors"
 	"fmt"
 
 	sErrors "github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/errors"
@@ -65,7 +66,7 @@ func DependencyConfigFileNotFoundErr(depFile, parentFile string, err error) erro
 // BadConfigFilterErr specifies no configs matched the configs filter
 func BadConfigFilterErr(filter []string) error {
 	msg := fmt.Sprintf("did not find any configs matching selection %v", filter)
-	return sErrors.NewError(fmt.Errorf(msg),
+	return sErrors.NewError(errors.New(msg),
 		&proto.ActionableErr{
 			Message: msg,
 			ErrCode: proto.StatusCode_CONFIG_BAD_FILTER_ERR,
@@ -81,7 +82,7 @@ func BadConfigFilterErr(filter []string) error {
 // ZeroConfigsParsedErr specifies that the config file is empty
 func ZeroConfigsParsedErr(file string) error {
 	msg := fmt.Sprintf("failed to get any valid configs from file %q", file)
-	return sErrors.NewError(fmt.Errorf(msg),
+	return sErrors.NewError(errors.New(msg),
 		&proto.ActionableErr{
 			Message: msg,
 			ErrCode: proto.StatusCode_CONFIG_ZERO_FOUND_ERR,
@@ -91,7 +92,7 @@ func ZeroConfigsParsedErr(file string) error {
 // DuplicateConfigNamesInSameFileErr specifies that multiple configs have the same name in current config file
 func DuplicateConfigNamesInSameFileErr(config, file string) error {
 	msg := fmt.Sprintf("multiple skaffold configs named %q found in file %q", config, file)
-	return sErrors.NewError(fmt.Errorf(msg),
+	return sErrors.NewError(errors.New(msg),
 		&proto.ActionableErr{
 			Message: msg,
 			ErrCode: proto.StatusCode_CONFIG_DUPLICATE_NAMES_SAME_FILE_ERR,
@@ -107,7 +108,7 @@ func DuplicateConfigNamesInSameFileErr(config, file string) error {
 // DuplicateConfigNamesAcrossFilesErr specifies that multiple configs have the same name in different files
 func DuplicateConfigNamesAcrossFilesErr(config, file1, file2 string) error {
 	msg := fmt.Sprintf("skaffold config named %q found in multiple files: %q and %q", config, file1, file2)
-	return sErrors.NewError(fmt.Errorf(msg),
+	return sErrors.NewError(errors.New(msg),
 		&proto.ActionableErr{
 			Message: msg,
 			ErrCode: proto.StatusCode_CONFIG_DUPLICATE_NAMES_ACROSS_FILES_ERR,
@@ -156,7 +157,7 @@ func ConfigSetAbsFilePathsErr(config, file string, err error) error {
 // ConfigProfilesNotMatchedErr specifies that the profiles selected via the `--profile` flag could not be matched against any config
 func ConfigProfilesNotMatchedErr(profiles []string) error {
 	msg := fmt.Sprintf("profile selection %q did not match those defined in any configurations", profiles)
-	return sErrors.NewError(fmt.Errorf(msg),
+	return sErrors.NewError(errors.New(msg),
 		&proto.ActionableErr{
 			Message: msg,
 			ErrCode: proto.StatusCode_CONFIG_PROFILES_NOT_FOUND_ERR,
@@ -172,7 +173,7 @@ func ConfigProfilesNotMatchedErr(profiles []string) error {
 // ConfigProfileConflictErr specifies that the same config is imported with different set of profiles.
 func ConfigProfileConflictErr(config, file string) error {
 	msg := fmt.Sprintf("config %q defined in file %q imported multiple times with different set of profiles", config, file)
-	return sErrors.NewError(fmt.Errorf(msg),
+	return sErrors.NewError(errors.New(msg),
 		&proto.ActionableErr{
 			Message: msg,
 			ErrCode: proto.StatusCode_CONFIG_MULTI_IMPORT_PROFILE_CONFLICT_ERR,
@@ -188,7 +189,7 @@ func ConfigProfileConflictErr(config, file string) error {
 // ConfigUnknownAPIVersionErr specifies that the config API version doesn't match any known versions.
 func ConfigUnknownAPIVersionErr(version string) error {
 	msg := fmt.Sprintf("unknown skaffold config API version %q", version)
-	return sErrors.NewError(fmt.Errorf(msg),
+	return sErrors.NewError(errors.New(msg),
 		&proto.ActionableErr{
 			Message: msg,
 			ErrCode: proto.StatusCode_CONFIG_UNKNOWN_API_VERSION_ERR,
@@ -204,7 +205,7 @@ func ConfigUnknownAPIVersionErr(version string) error {
 // SkaffoldConfigUpgradeErr specifies that skaffold config needs to be upgraded to the latest version.
 func SkaffoldConfigUpgradeErr(currentVersion, targetVersion string) error {
 	msg := fmt.Sprintf("skaffold cannot auto-upgrade the config from version %s to version %s", currentVersion, targetVersion)
-	return sErrors.NewError(fmt.Errorf(msg),
+	return sErrors.NewError(errors.New(msg),
 		&proto.ActionableErr{
 			Message: msg,
 			ErrCode: proto.StatusCode_CONFIG_UPGRADE_ERR,

--- a/pkg/skaffold/schema/validation/validation.go
+++ b/pkg/skaffold/schema/validation/validation.go
@@ -109,7 +109,7 @@ func Process(configs parser.SkaffoldConfigSet, validateConfig Options) error {
 		messages = append(messages, err.Error.Error())
 	}
 	if len(messages) != 0 {
-		return fmt.Errorf(strings.Join(messages, "\n"))
+		return errors.New(strings.Join(messages, "\n"))
 	}
 	return nil
 }
@@ -133,7 +133,7 @@ func ProcessWithRunContext(ctx context.Context, runCtx *runcontext.RunContext) e
 	for _, err := range errs {
 		messages = append(messages, err.Error())
 	}
-	return fmt.Errorf(strings.Join(messages, " \n "))
+	return errors.New(strings.Join(messages, " \n "))
 }
 
 // validateTaggingPolicy checks that the tagging policy is valid in combination with other options.
@@ -142,7 +142,7 @@ func validateTaggingPolicy(cfg *parser.SkaffoldConfigEntry, bc latest.BuildConfi
 		// sha256 just uses `latest` tag, so tryImportMissing will virtually always succeed (#4889)
 		if bc.LocalBuild.TryImportMissing && bc.TagPolicy.ShaTagger != nil {
 			cfgErrs = append(cfgErrs, ErrorWithLocation{
-				Error:    fmt.Errorf("tagging policy 'sha256' can not be used when 'tryImportMissing' is enabled"),
+				Error:    errors.New("tagging policy 'sha256' can not be used when 'tryImportMissing' is enabled"),
 				Location: cfg.YAMLInfos.Locate(cfg.Build.TagPolicy.ShaTagger),
 			})
 		}
@@ -327,7 +327,7 @@ func extractContainerNameFromNetworkMode(mode string) (string, error) {
 		return id, nil
 	}
 	errMsg := fmt.Sprintf("extracting container name from a non valid container network mode '%s'", mode)
-	return "", sErrors.NewError(fmt.Errorf(errMsg),
+	return "", sErrors.NewError(errors.New(errMsg),
 		&proto.ActionableErr{
 			Message: errMsg,
 			ErrCode: proto.StatusCode_INIT_DOCKER_NETWORK_INVALID_MODE,
@@ -354,7 +354,7 @@ func validateDockerContainerExpression(image string, id string) error {
 	containerRegExp := regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9_.-]*$")
 	if !containerRegExp.MatchString(id) {
 		errMsg := fmt.Sprintf("artifact %s has invalid container name '%s'", image, id)
-		return sErrors.NewError(fmt.Errorf(errMsg),
+		return sErrors.NewError(errors.New(errMsg),
 			&proto.ActionableErr{
 				Message: errMsg,
 				ErrCode: proto.StatusCode_INIT_DOCKER_NETWORK_INVALID_CONTAINER_NAME,
@@ -399,7 +399,7 @@ func validateVerifyTestsExistOnVerifyCommand(runCtx *runcontext.RunContext) []er
 		tcs = append(tcs, pipeline.Verify...)
 	}
 	if len(tcs) == 0 && runCtx.Opts.Command == "verify" {
-		errs = append(errs, fmt.Errorf("verify command expects non-zero number of test cases"))
+		errs = append(errs, errors.New("verify command expects non-zero number of test cases"))
 	}
 	return errs
 }
@@ -459,7 +459,7 @@ func validateDockerNetworkContainerExists(ctx context.Context, artifacts []*late
 				}
 			}
 			errMsg := fmt.Sprintf("container '%s' not found, required by image '%s' for docker network stack sharing", id, a.ImageName)
-			errs = append(errs, sErrors.NewError(fmt.Errorf(errMsg),
+			errs = append(errs, sErrors.NewError(errors.New(errMsg),
 				&proto.ActionableErr{
 					Message: errMsg,
 					ErrCode: proto.StatusCode_INIT_DOCKER_NETWORK_CONTAINER_DOES_NOT_EXIST,
@@ -874,7 +874,7 @@ func validateKubectlManifests(configs parser.SkaffoldConfigSet) (errs []ErrorWit
 				// TODO(aaron-prindle) parse the manifest node to extract exact correct line # for the value here (currently it is the parent obj)
 				msg := fmt.Sprintf("Manifest file %q referenced in skaffold config could not be found", pattern)
 				errMsg := wrapWithContext(c, ErrorWithLocation{
-					Error:    fmt.Errorf(msg),
+					Error:    errors.New(msg),
 					Location: c.YAMLInfos.Locate(&c.Render.RawK8s),
 				})
 				errs = append(errs, ErrorWithLocation{
@@ -920,7 +920,7 @@ func validateLocationSetForCloudRun(rCtx *runcontext.RunContext) []error {
 		}
 	}
 	if runDeployer && !hasLocation {
-		return []error{sErrors.NewError(fmt.Errorf("location must be specified with Cloud Run Deployer"),
+		return []error{sErrors.NewError(errors.New("location must be specified with Cloud Run Deployer"),
 			&proto.ActionableErr{
 				Message: "Cloud Run Location is not specified",
 				ErrCode: proto.StatusCode_INIT_CLOUD_RUN_LOCATION_ERROR,

--- a/pkg/skaffold/survey/survey.go
+++ b/pkg/skaffold/survey/survey.go
@@ -109,7 +109,7 @@ func recentlyPrompted(gc *sConfig.SurveyConfig) bool {
 
 func (s *Runner) DisplaySurveyPrompt(out io.Writer, id string) error {
 	if sc, ok := getSurvey(id); ok {
-		output.Green.Fprintf(out, sc.prompt())
+		output.Green.Fprintf(out, "%s", sc.prompt())
 		return updateSurveyPrompted(s.configFile)
 	}
 	return nil

--- a/pkg/skaffold/sync/syncer_mux.go
+++ b/pkg/skaffold/sync/syncer_mux.go
@@ -49,7 +49,7 @@ func (s SyncerMux) Sync(ctx context.Context, out io.Writer, item *Item) error {
 		}
 
 		// Otherwise log the error as a warning
-		log.Entry(ctx).Warnf(err.Error())
+		log.Entry(ctx).Warn(err.Error())
 	}
 
 	return nil

--- a/pkg/skaffold/tags/paths.go
+++ b/pkg/skaffold/tags/paths.go
@@ -18,6 +18,7 @@ package tags
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"reflect"
@@ -37,7 +38,7 @@ func MakeFilePathsAbsolute(s interface{}, base string) error {
 	for _, err := range errs {
 		messages = append(messages, err.Error())
 	}
-	return fmt.Errorf(strings.Join(messages, " | "))
+	return errors.New(strings.Join(messages, " | "))
 }
 
 func makeFilePathsAbsolute(config interface{}, base string) []error {

--- a/pkg/skaffold/test/custom/custom_test.go
+++ b/pkg/skaffold/test/custom/custom_test.go
@@ -18,7 +18,7 @@ package custom
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"io"
 	"path/filepath"
 	"runtime"
@@ -115,7 +115,7 @@ func TestCustomCommandError(t *testing.T) {
 			if runtime.GOOS == Windows {
 				command = test.expectedWindowsCmd
 			}
-			t.Override(&util.DefaultExecCommand, testutil.CmdRunErr(command, fmt.Errorf(test.expectedError)))
+			t.Override(&util.DefaultExecCommand, testutil.CmdRunErr(command, errors.New(test.expectedError)))
 			t.Override(&docker.NewAPIClient, func(context.Context, docker.Config) (docker.LocalDaemon, error) {
 				return fakeLocalDaemonWithExtraEnv([]string{}), nil
 			})

--- a/pkg/skaffold/update/update.go
+++ b/pkg/skaffold/update/update.go
@@ -103,5 +103,5 @@ func DownloadLatestVersion() (string, error) {
 }
 
 func releaseURL(v semver.Version) string {
-	return fmt.Sprintf("https://github.com/GoogleContainerTools/skaffold/releases/tag/v" + v.String())
+	return fmt.Sprintf("https://github.com/GoogleContainerTools/skaffold/releases/tag/v%s", v.String())
 }


### PR DESCRIPTION
bump go version from 1.22 to 1.23
