### PR TITLE
fix: Handle `StandalonePods` `Succeeded` case when checking status

### DIFF
--- a/pkg/skaffold/kubernetes/status/resource/deployment.go
+++ b/pkg/skaffold/kubernetes/status/resource/deployment.go
@@ -166,6 +166,8 @@ func (r *Resource) checkStandalonePodsStatus(ctx context.Context, cfg kubectl.Co
 			if podReady, _ := strconv.ParseBool(string(b)); !podReady {
 				pendingPods = append(pendingPods, pod.Name())
 			}
+		case "Succeeded":
+			log.Entry(ctx).Debugf("pod '%s' succeeded - ignoring", pod.Name())
 		default:
 			pendingPods = append(pendingPods, pod.Name())
 		}

--- a/pkg/skaffold/kubernetes/status/resource/deployment.go
+++ b/pkg/skaffold/kubernetes/status/resource/deployment.go
@@ -239,6 +239,10 @@ func (r *Resource) CheckStatus(ctx context.Context, cfg kubectl.Config) {
 	// See https://github.com/GoogleCloudPlatform/cloud-code-vscode-internal/issues/5277
 	if ae.ErrCode == proto.StatusCode_STATUSCHECK_SUCCESS {
 		for _, pod := range r.resources {
+			if pod.Status() == "Succeeded" {
+				continue // Skip terminated pods
+			}
+
 			eventV2.ResourceStatusCheckEventCompletedMessage(
 				pod.String(),
 				fmt.Sprintf("%s %s: running.\n", tabHeader, pod.String()),


### PR DESCRIPTION
**Description**
When Skaffold checks a standalone pod's status (method `checkStandalonePodsStatus`) , it currently only considers `Failed` and `Running` state, any other status will lead the pod to be systematically added to the `pendingPods` collection.

According to [the documentation](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/), a pod can be in 5 different states: `Pending`, `Running`, `Succeeded`, `Failed` or `Unknown`.

While it make sense for `Pending` or `Unknown` pods to be added to the `pendingPods` collection, I think it does not for the `Succeeded` ones (pods that terminated successfully)

This PR introduces a tiny change which just skips `Succeeded` pods.

**Tests**

I tried to look at other test and could only find:
* unit tests on `CheckStatus` that don't involve `StandalonePods` resource
* `TestPollServiceStatus`, `TestPollJobStatus`, `TestPollDeployment`, none of which involve `StandalonePods` resource

Please let me know if I've missed it, I'd be happy to add test on it.

Thanks!