### PR TITLE
fix: Update the k8s Job container logic for custom actions to match v…

### DIFF
--- a/pkg/skaffold/actions/k8sjob/task_test.go
+++ b/pkg/skaffold/actions/k8sjob/task_test.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2024 The Skaffold Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package k8sjob
 
 import (

--- a/pkg/skaffold/actions/k8sjob/task_test.go
+++ b/pkg/skaffold/actions/k8sjob/task_test.go
@@ -1,10 +1,11 @@
 /*
 Copyright 2024 The Skaffold Authors
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/skaffold/actions/k8sjob/task_test.go
+++ b/pkg/skaffold/actions/k8sjob/task_test.go
@@ -1,0 +1,116 @@
+package k8sjob
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/v2/testutil"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestPatchToK8sContainer(t *testing.T) {
+	tests := []struct {
+		description     string
+		actionContainer corev1.Container
+		k8sContainer    corev1.Container
+		expected        corev1.Container
+	}{
+		{
+			description: "update all fields",
+			actionContainer: corev1.Container{
+				Image:   "my-image:latest",
+				Command: []string{"/bin/bash"},
+				Args:    []string{"-c", "echo hello world"},
+				Name:    "my-container",
+				Env: []corev1.EnvVar{
+					{Name: "FOO", Value: "BAR"},
+				},
+			},
+			k8sContainer: corev1.Container{},
+			expected: corev1.Container{
+				Image:   "my-image:latest",
+				Command: []string{"/bin/bash"},
+				Args:    []string{"-c", "echo hello world"},
+				Name:    "my-container",
+				Env: []corev1.EnvVar{
+					{Name: "FOO", Value: "BAR"},
+				},
+			},
+		},
+		{
+			description: "update image",
+			actionContainer: corev1.Container{
+				Image: "my-new-image:latest",
+			},
+			k8sContainer: corev1.Container{
+				Image: "my-image:latest",
+			},
+			expected: corev1.Container{
+				Image: "my-new-image:latest",
+			},
+		},
+		{
+			description: "update command",
+			actionContainer: corev1.Container{
+				Command: []string{"/bin/ls"},
+			},
+			k8sContainer: corev1.Container{
+				Command: []string{"/bin/bash"},
+			},
+			expected: corev1.Container{
+				Command: []string{"/bin/ls"},
+			},
+		},
+		{
+			description: "update args",
+			actionContainer: corev1.Container{
+				Args: []string{"-l"},
+			},
+			k8sContainer: corev1.Container{
+				Args: []string{"-c", "echo hello world"},
+			},
+			expected: corev1.Container{
+				Args: []string{"-l"},
+			},
+		},
+		{
+			description: "update name",
+			actionContainer: corev1.Container{
+				Name: "my-new-container",
+			},
+			k8sContainer: corev1.Container{
+				Name: "my-container",
+			},
+			expected: corev1.Container{
+				Name: "my-new-container",
+			},
+		},
+		{
+			description: "update env",
+			actionContainer: corev1.Container{
+				Env: []corev1.EnvVar{
+					{Name: "FOO", Value: "BARR"},
+					{Name: "BAZ", Value: "QUX"},
+				},
+			},
+			k8sContainer: corev1.Container{
+				Env: []corev1.EnvVar{
+					{Name: "FOO", Value: "BAR"},
+				},
+			},
+			// Duplicate name should be ok, as the last writer should win.
+			expected: corev1.Container{
+				Env: []corev1.EnvVar{
+					{Name: "FOO", Value: "BAR"},
+					{Name: "FOO", Value: "BARR"},
+					{Name: "BAZ", Value: "QUX"},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			patchToK8sContainer(test.actionContainer, &test.k8sContainer)
+			t.CheckDeepEqual(test.expected, test.k8sContainer)
+		})
+	}
+}

--- a/pkg/skaffold/actions/k8sjob/task_test.go
+++ b/pkg/skaffold/actions/k8sjob/task_test.go
@@ -18,8 +18,9 @@ package k8sjob
 import (
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/v2/testutil"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/GoogleContainerTools/skaffold/v2/testutil"
 )
 
 func TestPatchToK8sContainer(t *testing.T) {


### PR DESCRIPTION
…erify

<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes https://github.com/GoogleContainerTools/skaffold/issues/9409

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
This PR updates the logic when it comes to custom actions with a provided Job manifest to be similar to [verify](https://github.com/GoogleContainerTools/skaffold/blob/414ab983b1c775cd09a1cdfd22c9919e8e759afc/pkg/skaffold/verify/k8sjob/verify.go#L385). What this means is that any container fields defined in the Job manifest that are not configurable in the customActions stanza are kept, e.g. `volumes`.  It also appends env vars rather than replacing to be consistent with verify as well.

Frankly, I'm not sure why the Job execution for verify and custom actions were implemented in two different places which caused these deviations. I suspect there are other ways in which they differ, just from a quick glance at the two implementations.

Unfortunately, it also looks like executing the k8s Jobs for verify and custom actions lacks unit testing. In order to get this in I've just gone ahead and added a *very* basic test for the container patching logic, same as what exists for verify [here](https://github.com/GoogleContainerTools/skaffold/blob/414ab983b1c775cd09a1cdfd22c9919e8e759afc/pkg/skaffold/verify/k8sjob/verify_test.go#L28).

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->
Any fields that are defined in the Job container manifest that are not configurable in the customActions container stanza will be kept. In other words, any fields that are **not** name, image, command, or args.

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
