### PR TITLE
feat: helm concurrent deploys with cross dependency

### DIFF
--- a/docs-v2/content/en/schemas/v4beta12.json
+++ b/docs-v2/content/en/schemas/v4beta12.json
@@ -2369,6 +2369,15 @@
           "description": "if `true`, Skaffold will send `--create-namespace` flag to Helm CLI. `--create-namespace` flag is available in Helm since version 3.2. Defaults is `false`.",
           "x-intellij-html-description": "if <code>true</code>, Skaffold will send <code>--create-namespace</code> flag to Helm CLI. <code>--create-namespace</code> flag is available in Helm since version 3.2. Defaults is <code>false</code>."
         },
+        "dependsOn": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "specifies other helm packages that this HelmRelease depends on, ensuring proper ordering during deployment.",
+          "x-intellij-html-description": "specifies other helm packages that this HelmRelease depends on, ensuring proper ordering during deployment.",
+          "default": "[]"
+        },
         "name": {
           "type": "string",
           "description": "name of the Helm release. It accepts environment variables via the go template syntax.",
@@ -2484,7 +2493,8 @@
         "repo",
         "upgradeOnChange",
         "overrides",
-        "packaged"
+        "packaged",
+        "dependsOn"
       ],
       "additionalProperties": false,
       "type": "object",

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -1070,6 +1070,9 @@ type HelmRelease struct {
 
 	// Packaged parameters for packaging helm chart (`helm package`).
 	Packaged *HelmPackaged `yaml:"packaged,omitempty"`
+
+	// DependsOn specifies other helm packages that this HelmRelease depends on, ensuring proper ordering during deployment.
+	DependsOn []string `yaml:"dependsOn,omitempty"`
 }
 
 // HelmPackaged parameters for packaging helm chart (`helm package`).

--- a/testutil/concurrency/cmd_helper_with_concurrency_support.go
+++ b/testutil/concurrency/cmd_helper_with_concurrency_support.go
@@ -233,7 +233,7 @@ func (c *FakeCmdWithConcurrencySupport) RunCmd(_ context.Context, cmd *exec.Cmd)
 
 	r, err := c.popRunWithGivenCommand(command)
 	if err != nil {
-		c.t.Fatalf("unable to run RunCmd() with command %q", command)
+		c.t.Fatalf("unable to run RunCmd() with command %q: %q", command, err)
 	}
 
 	if r.output != nil {


### PR DESCRIPTION
Fixes: #5417

**Description**
This PR is adding a option for concurrent helm releases to wait for other helm charts.

```yaml
deploy:
  helm:
    concurrency: 3
    releases:
      - name: service1
        chartPath: charts/service1
      - name: service2
        chartPath: charts/service2
      - name: service3
        chartPath: charts/service3
        dependsOn:
          - service1
          - service2
```

On the following example, the `service3` will wait until helm deploy for `service1` and `service2` to finish. If some of those services fails, the `service3` deployment won't start.

**User facing changes**

User can add the `dependsOn` option to a helm release template.
