### PR TITLE
feat(verify.go): Add pod fail reason and message to output

### DIFF
--- a/pkg/skaffold/verify/k8sjob/verify.go
+++ b/pkg/skaffold/verify/k8sjob/verify.go
@@ -279,7 +279,20 @@ func (v *Verifier) watchJob(ctx context.Context, clientset k8sclient.Interface, 
 				break
 			}
 			if pod.Status.Phase == corev1.PodFailed {
-				podErr = errors.New(fmt.Sprintf("%q running job %q errored during run", tc.Name, job.Name))
+				failReason := pod.Status.Reason
+				if failReason == "" {
+					failReason = "<empty>"
+				}
+
+				failMessage := pod.Status.Message
+				if failMessage == "" {
+					failMessage = "<empty>"
+				}
+
+				podErr = errors.New(fmt.Sprintf(
+					"%q running job %q errored during run: reason=%q, message=%q",
+					tc.Name, job.Name, failReason, failMessage,
+				))
 				break
 			}
 

--- a/pkg/skaffold/verify/k8sjob/verify.go
+++ b/pkg/skaffold/verify/k8sjob/verify.go
@@ -289,10 +289,10 @@ func (v *Verifier) watchJob(ctx context.Context, clientset k8sclient.Interface, 
 					failMessage = "<empty>"
 				}
 
-				podErr = errors.New(fmt.Sprintf(
+				podErr = fmt.Errorf(
 					"%q running job %q errored during run: reason=%q, message=%q",
 					tc.Name, job.Name, failReason, failMessage,
-				))
+				)
 				break
 			}
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: https://github.com/GoogleContainerTools/skaffold/issues/9587

**Description**
Add pod fail details Into the `watchJob` method of the verifier

**User facing changes**
before: no details - `%q running job %q errored during run`
after: fail details - `%q running job %q errored during run: reason=%q, message=%q`


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
