### PR TITLE
fix(homepage): fix gem icon

### DIFF
--- a/docs-v2/content/en/_index.html
+++ b/docs-v2/content/en/_index.html
@@ -98,7 +98,7 @@ linkTitle = "Skaffold"
 
 <div class="col-lg-3 mb-5 mb-lg-0 text-center">
     <div class="mb-4 h1">
-        <i class="far fa-gem"></i>
+        <i class="fas fa-gem"></i>
     </div>
     <h4 class="h3 mb-4">Feature Rich</h4>
     <p class="mb-0 text-left">Skaffold has many essential features for container & Kubernetes development, including


### PR DESCRIPTION
**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->

Quick fix for the `fa-gem` icon on homepage.

**User facing changes (remove if N/A)**
<img width="544" alt="image" src="https://github.com/user-attachments/assets/e32d3c0d-0d01-4b34-9fde-df113a218714">
