### PR TITLE
fix: Helm deploy was not working with variable templatinging chart path

### DIFF
--- a/pkg/skaffold/deploy/helm/helm.go
+++ b/pkg/skaffold/deploy/helm/helm.go
@@ -398,11 +398,11 @@ func (h *Deployer) Dependencies() ([]string, error) {
 			return true, nil
 		}
 
-		expanded_path, e := util.ExpandEnvTemplateOrFail(release.ChartPath, nil)
+		expandedPath, e := util.ExpandEnvTemplateOrFail(release.ChartPath, nil)
 		if e != nil {
 			return deps, helm.UserErr("issue expanding variable", e)
 		}
-		if err := walk.From(expanded_path).When(isDep).AppendPaths(&deps); err != nil {
+		if err := walk.From(expandedPath).When(isDep).AppendPaths(&deps); err != nil {
 			return deps, helm.UserErr("issue walking releases", err)
 		}
 	}

--- a/pkg/skaffold/deploy/helm/helm.go
+++ b/pkg/skaffold/deploy/helm/helm.go
@@ -398,7 +398,11 @@ func (h *Deployer) Dependencies() ([]string, error) {
 			return true, nil
 		}
 
-		if err := walk.From(release.ChartPath).When(isDep).AppendPaths(&deps); err != nil {
+		expanded_path, e := util.ExpandEnvTemplateOrFail(release.ChartPath, nil)
+		if e != nil {
+			return deps, helm.UserErr("issue expanding variable", e)
+		}
+		if err := walk.From(expanded_path).When(isDep).AppendPaths(&deps); err != nil {
 			return deps, helm.UserErr("issue walking releases", err)
 		}
 	}


### PR DESCRIPTION
I believe the chartPath property is supposed to be a templatable field.

In my use I have helm charts in a separate git repo from the application where the skaffold.yaml is. We defined a skaffold.env.template file, that we add to git and then on checkout we copy this to skaffold.env and modify as needed, so the path to the location to the other repo with a helm chart is a variable. and this skaffold.env file is added to the .gitignore

We noticed that we were getting
listing files: issue walking releases: lstat {{.HELM_REPO}}/helm/app/chart/path: no such file or directory

This PR fixes this issue.

<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #nnn <!-- tracking issues that this PR will close -->
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->

**Follow-up Work (remove if N/A)**
<!-- Mention any related follow up work to this PR. -->


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
