### PR TITLE
chore: remove MAINTAINERS

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,7 +1,0 @@
-Brian de Alwis <bdealwis@google.com>
-David Gageot <david@gageot.net>
-Gaurav Ghosh <gaghosh@google.com>
-Marlon Gamez <marlongamez@google.com>
-Nick Kubala <nkubala@google.com>
-Tejal Desai <tejaldesai@google.com>
-Thomas Strömberg <tstromberg@google.com>


### PR DESCRIPTION
This info is in CODEOWNERS now.

Closes #9595.
