### PR TITLE
chore: allow dependabot to upgrade more dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,71 +7,68 @@ updates:
   - directory: "/"
     package-ecosystem: "gomod"
     schedule:
-      interval: "daily"
-    # Security updates have their own PR limit, so setting this to 0 will only
-    # allow security updates through.
-    open-pull-requests-limit: 0
+      interval: "weekly"
 
   # check for updates to github actions
   - directory: "/"
     package-ecosystem: "github-actions"
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   - directory: "/integration/examples"
     package-ecosystem: "npm"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - directory: "/integration/examples"
     package-ecosystem: "bundler"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - directory: "/integration/examples"
     package-ecosystem: "composer"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - directory: "/integration/examples"
     package-ecosystem: "pip"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - directory: "/integration/examples"
     package-ecosystem: "maven"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - directory: "/integration/examples"
     package-ecosystem: "gradle"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - directory: "/integration/examples"
     package-ecosystem: "gomod"
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   - directory: "/examples"
     package-ecosystem: "npm"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - directory: "/examples"
     package-ecosystem: "bundler"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - directory: "/examples"
     package-ecosystem: "composer"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - directory: "/examples"
     package-ecosystem: "pip"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - directory: "/examples"
     package-ecosystem: "maven"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - directory: "/examples"
     package-ecosystem: "gradle"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - directory: "/examples"
     package-ecosystem: "gomod"
     schedule:
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
It had been configured to only allow security updates. Now that we've updated all the core dependencies, let it keep things up to date.

Only have it run once a week since there will be many more updates now.
