### PR TITLE
chore: update go version used in the published container

### DIFF
--- a/deploy/skaffold/Dockerfile.deps
+++ b/deploy/skaffold/Dockerfile.deps
@@ -163,5 +163,5 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
     jq \
     apt-transport-https && \
     rm -rf /var/lib/apt/lists/*
-COPY --from=golang:1.23.3 /usr/local/go /usr/local/go
+COPY --from=golang:1.23.4 /usr/local/go /usr/local/go
 ENV PATH /usr/local/go/bin:/root/go/bin:$PATH


### PR DESCRIPTION
Right now the postsubmit build is failing:

```
7.258 go: github.com/jedisct1/go-minisign in vendor/modules.txt requires go >= 1.23.4 (running go 1.23.3)
```