### PR TITLE
fix: Use docker image to build binary for different platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+GOVERSION ?= 1.23.4
 GOPATH ?= $(shell go env GOPATH)
 GOBIN ?= $(or $(shell go env GOBIN),$(GOPATH)/bin)
 GOOS ?= $(shell go env GOOS)
@@ -93,12 +94,33 @@ install: $(BUILD_DIR)/$(PROJECT)
 .PHONY: cross
 cross: $(foreach platform, $(SUPPORTED_PLATFORMS), $(BUILD_DIR)/$(PROJECT)-$(platform))
 
-$(BUILD_DIR)/$(PROJECT)-%: $(EMBEDDED_FILES_CHECK) $(GO_FILES) $(BUILD_DIR)
+.PHONY $(BUILD_DIR)/$(PROJECT)-%:
+$(BUILD_DIR)/$(PROJECT)-%:
+	$(eval os = $(firstword $(subst -, ,$*)))
+	$(eval goarch = $(lastword $(subst -, ,$(subst .exe,,$*))))
+	$(eval image_platform = $(shell \
+	if [[ $(os) == "darwin" ]]; then \
+	  echo darwin-arm64; \
+	elif [[ $(goarch) == "arm64" ]]; then \
+	  echo arm; \
+	else \
+	  echo main; \
+	fi \
+	))
+	@echo $(image_platform)
+	docker run --rm \
+	-v $(CURDIR):/skaffold \
+	-w /skaffold \
+	docker.elastic.co/beats-dev/golang-crossbuild:$(GOVERSION)-$(image_platform)-debian12 \
+	-p="$(os)/$(goarch)" \
+	--build-cmd="git config --global --add safe.directory /skaffold;make ./out/docker-skaffold-$(os)-$(goarch)"
+
+$(BUILD_DIR)/docker-$(PROJECT)-%: $(EMBEDDED_FILES_CHECK) $(GO_FILES) $(BUILD_DIR)
 	$(eval os = $(firstword $(subst -, ,$*)))
 	$(eval arch = $(lastword $(subst -, ,$(subst .exe,,$*))))
 	$(eval ldflags = $(GO_LDFLAGS) $(patsubst %,-extldflags \"%\",$(LDFLAGS_$(os))))
 	$(eval tags = $(GO_BUILD_TAGS) $(GO_BUILD_TAGS_$(os)) $(GO_BUILD_TAGS_$(os)_$(arch)))
-	GOOS=$(os) GOARCH=$(arch) CGO_ENABLED=1 go build -mod="vendor" -tags "$(tags)" -ldflags "$(ldflags)" -o $@ ./cmd/skaffold
+	CGO_ENABLED=1 go build -mod="vendor" -tags "$(tags)" -ldflags "$(ldflags)" -o $@ ./cmd/skaffold
 	(cd `dirname $@`; shasum -a 256 `basename $@`) | tee $@.sha256
 	file $@ || true
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #nnn <!-- tracking issues that this PR will close -->
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
An update to one of the skaffold dependencies introduced a new dependency on the runtime/cgo package, breaking the ability to built skafofld binaries for different platforms with the existing logic.

Although the official [golang](https://hub.docker.com/_/golang) docker images allow cross-compilation, it doesn't work when cgo is enabled. Although installing the  platform-specific is possible with the golang image, I instead opted to use  images from the  [elastic/crossbuild](https://github.com/elastic/golang-crossbuild) project which maintain docker images specifically designed for cross-compilation.

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
A new depedency on docker when building the skaffold binary for different platforms.

<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->

**Test**
The cross-compilation was tested with a github action running on mac here: #9658
**Follow-up Work (remove if N/A)**
<!-- Mention any related follow up work to this PR. -->


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
