### PR TITLE
fix: Make defaultNamespace warning more useful

### DIFF
--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -284,8 +284,8 @@ func (rc *RunContext) GetNamespace() string {
 	var defaultNamespace string
 	for _, p := range rc.GetPipelines() {
 		if p.Deploy.KubectlDeploy != nil && p.Deploy.KubectlDeploy.DefaultNamespace != nil {
-			if defaultNamespace != "" {
-				log.Entry(context.TODO()).Warn("multiple deploy.kubectl.defaultNamespace values set, only last pipeline's value will be used")
+			if defaultNamespace != "" && defaultNamespace != *p.Deploy.KubectlDeploy.DefaultNamespace {
+				log.Entry(context.TODO()).Warnf("multiple deploy.kubectl.defaultNamespace values set (%s, %s), only last pipeline's value will be used", defaultNamespace, *p.Deploy.KubectlDeploy.DefaultNamespace)
 			}
 			defaultNamespace = *p.Deploy.KubectlDeploy.DefaultNamespace
 		}


### PR DESCRIPTION
**Related**: [_Relevant tracking issues, for context_](https://github.com/GoogleContainerTools/skaffold/issues/8941)

**Description**
Previously warning was printed in any case of multiple `defaultNamespace`s. Now it only gets printed when there are actual different namespaces configured. Also mentions said namespaces.
