### PR TITLE
ci: requiring two org members to approve for PR merge; preventing in org sock puppet accounts

### DIFF
--- a/.github/workflows/members.json
+++ b/.github/workflows/members.json
@@ -1,0 +1,233 @@
+[
+  {
+    "login": "aaron-prindle"
+  },
+  {
+    "login": "akulkapoor-google"
+  },
+  {
+    "login": "alicejli"
+  },
+  {
+    "login": "alphanota"
+  },
+  {
+    "login": "bendory"
+  },
+  {
+    "login": "blakeli0"
+  },
+  {
+    "login": "bobcallaway"
+  },
+  {
+    "login": "bobcatfish"
+  },
+  {
+    "login": "briandealwis"
+  },
+  {
+    "login": "burkedavison"
+  },
+  {
+    "login": "Camila-B"
+  },
+  {
+    "login": "chanseokoh"
+  },
+  {
+    "login": "ChrisGe4"
+  },
+  {
+    "login": "ChristopherFry"
+  },
+  {
+    "login": "chuangw6"
+  },
+  {
+    "login": "container-tools-bot"
+  },
+  {
+    "login": "cvgw"
+  },
+  {
+    "login": "dangazineu"
+  },
+  {
+    "login": "Darien-Lin"
+  },
+  {
+    "login": "diegomarquezp"
+  },
+  {
+    "login": "distroless-bot"
+  },
+  {
+    "login": "donmccasland"
+  },
+  {
+    "login": "droot"
+  },
+  {
+    "login": "ericzzzzzzz"
+  },
+  {
+    "login": "etefera"
+  },
+  {
+    "login": "gcp-runtimes-bot"
+  },
+  {
+    "login": "google-admin"
+  },
+  {
+    "login": "google-ospo-team"
+  },
+  {
+    "login": "googlebot"
+  },
+  {
+    "login": "gsquared94"
+  },
+  {
+    "login": "haiyanmeng"
+  },
+  {
+    "login": "henrybell"
+  },
+  {
+    "login": "inferno-chromium"
+  },
+  {
+    "login": "janetkuo"
+  },
+  {
+    "login": "jduncan-rva"
+  },
+  {
+    "login": "JeromeJu"
+  },
+  {
+    "login": "jinseopkim0"
+  },
+  {
+    "login": "JoeWang1127"
+  },
+  {
+    "login": "johnbelamaric"
+  },
+  {
+    "login": "joycebrum"
+  },
+  {
+    "login": "justinsb"
+  },
+  {
+    "login": "karlkfi"
+  },
+  {
+    "login": "katiexzhang"
+  },
+  {
+    "login": "kmaydeo"
+  },
+  {
+    "login": "kokoro-team"
+  },
+  {
+    "login": "ldetmer"
+  },
+  {
+    "login": "linde"
+  },
+  {
+    "login": "loosebazooka"
+  },
+  {
+    "login": "loudej"
+  },
+  {
+    "login": "louisjimenez"
+  },
+  {
+    "login": "lqiu96"
+  },
+  {
+    "login": "maggieneterval"
+  },
+  {
+    "login": "MarlonGamez"
+  },
+  {
+    "login": "matthewmichihara"
+  },
+  {
+    "login": "mattsanta"
+  },
+  {
+    "login": "medyagh"
+  },
+  {
+    "login": "meltsufin"
+  },
+  {
+    "login": "menahyouyeah"
+  },
+  {
+    "login": "mikebz"
+  },
+  {
+    "login": "minikube-bot"
+  },
+  {
+    "login": "mortent"
+  },
+  {
+    "login": "mpeddada1"
+  },
+  {
+    "login": "nan-yu"
+  },
+  {
+    "login": "natasha41575"
+  },
+  {
+    "login": "plumpy"
+  },
+  {
+    "login": "renzodavid9"
+  },
+  {
+    "login": "rquitales"
+  },
+  {
+    "login": "sdowell"
+  },
+  {
+    "login": "seans3"
+  },
+  {
+    "login": "spencersugarman"
+  },
+  {
+    "login": "spowelljr"
+  },
+  {
+    "login": "suztomo"
+  },
+  {
+    "login": "SvenMM"
+  },
+  {
+    "login": "tiffanny29631"
+  },
+  {
+    "login": "Yongxuanzhang"
+  },
+  {
+    "login": "yuwenma"
+  },
+  {
+    "login": "zhumin8"
+  }
+]

--- a/.github/workflows/multi-approvers.yml
+++ b/.github/workflows/multi-approvers.yml
@@ -1,0 +1,31 @@
+name: 'multi-approvers'
+
+on:
+  pull_request:
+    types:
+      - 'opened'
+      - 'edited'
+      - 'reopened'
+      - 'synchronize'
+      - 'ready_for_review'
+      - 'review_requested'
+      - 'review_request_removed'
+  pull_request_review:
+    types:
+      - 'submitted'
+      - 'dismissed'
+
+permissions:
+  actions: 'write'
+  contents: 'read'
+  pull-requests: 'read'
+
+concurrency:
+  group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  multi-approvers:
+    uses: 'abcxyz/pkg/.github/workflows/multi-approvers.yml@main'
+    with:
+      org-members-path: '.github/workflows/members.json'


### PR DESCRIPTION
**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
This adds multi-approver workflow following this: https://github.com/abcxyz/pkg?tab=readme-ov-file#multi-approversyml.
This prevents in-org sock puppet accounts. 


