### PR TITLE
feat: add buildDependenciesSkipRefresh option to HelmRelease to pass --skip-refresh to helm dep bulid

### DIFF
--- a/docs-v2/content/en/schemas/v4beta12.json
+++ b/docs-v2/content/en/schemas/v4beta12.json
@@ -2365,12 +2365,6 @@
         "name"
       ],
       "properties": {
-        "buildDependenciesSkipRefresh": {
-          "type": "boolean",
-          "description": "should the refresh of already built dependencies be skipped. Ignored when `skipBuildDependencies` is `false`.",
-          "x-intellij-html-description": "should the refresh of already built dependencies be skipped. Ignored when <code>skipBuildDependencies</code> is <code>false</code>.",
-          "default": "false"
-        },
         "chartPath": {
           "type": "string",
           "description": "local path to a packaged Helm chart or an unpacked Helm chart directory.",
@@ -2448,6 +2442,12 @@
           "x-intellij-html-description": "should build dependencies be skipped. Ignored for <code>remoteChart</code>.",
           "default": "false"
         },
+        "skipBuildDependenciesRefresh": {
+          "type": "boolean",
+          "description": "determines whether the refresh of already built dependencies should be skipped. If set to `true`, passes `--skip-refresh` flag to `helm dep build` command. Ignored when `skipBuildDependencies` is `false`.",
+          "x-intellij-html-description": "determines whether the refresh of already built dependencies should be skipped. If set to <code>true</code>, passes <code>--skip-refresh</code> flag to <code>helm dep build</code> command. Ignored when <code>skipBuildDependencies</code> is <code>false</code>.",
+          "default": "false"
+        },
         "skipTests": {
           "type": "boolean",
           "description": "should ignore helm test during manifests generation.",
@@ -2500,7 +2500,7 @@
         "wait",
         "recreatePods",
         "skipBuildDependencies",
-        "buildDependenciesSkipRefresh",
+        "skipBuildDependenciesRefresh",
         "skipTests",
         "useHelmSecrets",
         "repo",

--- a/docs-v2/content/en/schemas/v4beta12.json
+++ b/docs-v2/content/en/schemas/v4beta12.json
@@ -2365,6 +2365,12 @@
         "name"
       ],
       "properties": {
+        "buildDependenciesSkipRefresh": {
+          "type": "boolean",
+          "description": "should the refresh of already built dependencies be skipped. Ignored when `skipBuildDependencies` is `false`.",
+          "x-intellij-html-description": "should the refresh of already built dependencies be skipped. Ignored when <code>skipBuildDependencies</code> is <code>false</code>.",
+          "default": "false"
+        },
         "chartPath": {
           "type": "string",
           "description": "local path to a packaged Helm chart or an unpacked Helm chart directory.",
@@ -2494,6 +2500,7 @@
         "wait",
         "recreatePods",
         "skipBuildDependencies",
+        "buildDependenciesSkipRefresh",
         "skipTests",
         "useHelmSecrets",
         "repo",

--- a/pkg/skaffold/render/renderer/helm/helm.go
+++ b/pkg/skaffold/render/renderer/helm/helm.go
@@ -179,7 +179,7 @@ func (h Helm) generateHelmManifest(ctx context.Context, builds []graph.Artifact,
 			return nil, helm.UserErr("cannot marshal overrides to create overrides values.yaml", err)
 		}
 
-		if err := os.WriteFile(constants.HelmOverridesFilename, overrides, 0o666); err != nil {
+		if err := os.WriteFile(constants.HelmOverridesFilename, overrides, 0666); err != nil {
 			return nil, helm.UserErr(fmt.Sprintf("cannot create file %q", constants.HelmOverridesFilename), err)
 		}
 

--- a/pkg/skaffold/render/renderer/helm/helm.go
+++ b/pkg/skaffold/render/renderer/helm/helm.go
@@ -208,7 +208,11 @@ func (h Helm) generateHelmManifest(ctx context.Context, builds []graph.Artifact,
 	// Build Chart dependencies, but allow a user to skip it.
 	if !release.SkipBuildDependencies && release.ChartPath != "" {
 		log.Entry(ctx).Info("Building helm dependencies...")
-		if err := helm.ExecWithStdoutAndStderr(ctx, h, io.Discard, errBuffer, false, env, "dep", "build", release.ChartPath); err != nil {
+		cmdArgs := []string{"dep", "build", release.ChartPath}
+		if release.BuildDependenciesSkipRefresh {
+			cmdArgs = []string{"dep", "build", "--skip-refresh", release.ChartPath}
+		}
+		if err := helm.ExecWithStdoutAndStderr(ctx, h, io.Discard, errBuffer, false, env, cmdArgs...); err != nil {
 			log.Entry(ctx).Info(errBuffer.String())
 			return nil, helm.UserErr("building helm dependencies", err)
 		}

--- a/pkg/skaffold/render/renderer/helm/helm_test.go
+++ b/pkg/skaffold/render/renderer/helm/helm_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2025 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helm
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/v2/testutil"
+)
+
+func TestBuildDepBuildArgs(t *testing.T) {
+	tests := []struct {
+		description                  string
+		skipBuildDependenciesRefresh bool
+		expected                     []string
+	}{
+		{
+			description:                  "build args without skipBuildDependenciesRefresh",
+			skipBuildDependenciesRefresh: false,
+			expected:                     []string{"dep", "build"},
+		},
+		{
+			description:                  "build args with skipBuildDependenciesRefresh",
+			skipBuildDependenciesRefresh: true,
+			expected:                     []string{"dep", "build", "--skip-refresh"},
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			args := buildDepBuildArgs(test.skipBuildDependenciesRefresh)
+			t.CheckDeepEqual(test.expected, args)
+		})
+	}
+}

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -1050,9 +1050,10 @@ type HelmRelease struct {
 	// Ignored for `remoteChart`.
 	SkipBuildDependencies bool `yaml:"skipBuildDependencies,omitempty"`
 
-	// BuildDependenciesSkipRefresh should the refresh of already built dependencies be skipped.
+	// SkipBuildDependenciesRefresh determines whether the refresh of already built dependencies should be skipped.
+	// If set to `true`, passes `--skip-refresh` flag to `helm dep build` command.
 	// Ignored when `skipBuildDependencies` is `false`.
-	BuildDependenciesSkipRefresh bool `yaml:"buildDependenciesSkipRefresh,omitempty"`
+	SkipBuildDependenciesRefresh bool `yaml:"skipBuildDependenciesRefresh,omitempty"`
 
 	// SkipTests should ignore helm test during manifests generation.
 	// Defaults to `false`
@@ -1860,7 +1861,6 @@ func (clusterDetails *ClusterDetails) UnmarshalYAML(value *yaml.Node) error {
 	// Unmarshal the remaining values
 	aux := (*ClusterDetailsForUnmarshaling)(clusterDetails)
 	err = yaml.Unmarshal(remaining, aux)
-
 	if err != nil {
 		return err
 	}
@@ -1887,7 +1887,6 @@ func (ka *KanikoArtifact) UnmarshalYAML(value *yaml.Node) error {
 	// Unmarshal the remaining values
 	aux := (*KanikoArtifactForUnmarshaling)(ka)
 	err = yaml.Unmarshal(remaining, aux)
-
 	if err != nil {
 		return err
 	}

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -1050,6 +1050,10 @@ type HelmRelease struct {
 	// Ignored for `remoteChart`.
 	SkipBuildDependencies bool `yaml:"skipBuildDependencies,omitempty"`
 
+	// BuildDependenciesSkipRefresh should the refresh of already built dependencies be skipped.
+	// Ignored when `skipBuildDependencies` is `false`.
+	BuildDependenciesSkipRefresh bool `yaml:"buildDependenciesSkipRefresh,omitempty"`
+
 	// SkipTests should ignore helm test during manifests generation.
 	// Defaults to `false`
 	SkipTests bool `yaml:"skipTests,omitempty"`


### PR DESCRIPTION
<!-- Include if applicable: -->
Fixes: https://github.com/GoogleContainerTools/skaffold/issues/8413

**Description**
This adds a new configuration option `buildDependenciesSkipRefresh ` to skaffold render config.

**User facing changes**
Users can now supply a new option in the helm config for skaffold render when using helm as a renderer
