### PR TITLE
chore: Fix BuildContextCompressionLevel description, output the level

### DIFF
--- a/docs-v2/content/en/schemas/v4beta12.json
+++ b/docs-v2/content/en/schemas/v4beta12.json
@@ -2672,8 +2672,9 @@
         },
         "buildContextCompressionLevel": {
           "type": "integer",
-          "description": "gzip compression level(0-9) for the build context. Defaults to 1 (BestSpeed). 0: NoCompression. 1: BestSpeed. 9: BestCompression. -1: DefaultCompression. -2: HuffmanOnly.",
-          "x-intellij-html-description": "gzip compression level(0-9) for the build context. Defaults to 1 (BestSpeed). 0: NoCompression. 1: BestSpeed. 9: BestCompression. -1: DefaultCompression. -2: HuffmanOnly."
+          "description": "gzip compression level(0-9) for the build context. 0: NoCompression. 1: BestSpeed. 9: BestCompression. -1: DefaultCompression. -2: HuffmanOnly.",
+          "x-intellij-html-description": "gzip compression level(0-9) for the build context. 0: NoCompression. 1: BestSpeed. 9: BestCompression. -1: DefaultCompression. -2: HuffmanOnly.",
+          "default": "1"
         },
         "cache": {
           "$ref": "#/definitions/KanikoCache",

--- a/docs-v2/content/en/schemas/v4beta12.json
+++ b/docs-v2/content/en/schemas/v4beta12.json
@@ -2672,9 +2672,8 @@
         },
         "buildContextCompressionLevel": {
           "type": "integer",
-          "description": "gzip compression level for the build context.",
-          "x-intellij-html-description": "gzip compression level for the build context.",
-          "default": "1"
+          "description": "gzip compression level(0-9) for the build context. Defaults to 1 (BestSpeed). 0: NoCompression. 1: BestSpeed. 9: BestCompression. -1: DefaultCompression. -2: HuffmanOnly.",
+          "x-intellij-html-description": "gzip compression level(0-9) for the build context. Defaults to 1 (BestSpeed). 0: NoCompression. 1: BestSpeed. 9: BestCompression. -1: DefaultCompression. -2: HuffmanOnly."
         },
         "cache": {
           "$ref": "#/definitions/KanikoCache",

--- a/pkg/skaffold/build/cluster/kaniko.go
+++ b/pkg/skaffold/build/cluster/kaniko.go
@@ -139,6 +139,7 @@ func (b *Builder) copyKanikoBuildContext(ctx context.Context, out io.Writer, wor
 	errs := make(chan error, 1)
 	buildCtxReader, buildCtxWriter := io.Pipe()
 	gzipWriter, err := gzip.NewWriterLevel(buildCtxWriter, *artifact.BuildContextCompressionLevel)
+	log.Entry(ctx).Infof("Using gzip compression level %d", *artifact.BuildContextCompressionLevel)
 
 	if err != nil {
 		return fmt.Errorf("creating gzip writer: %w", err)

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -1555,13 +1555,13 @@ type KanikoArtifact struct {
 	// Defaults to 5 minutes (`5m`).
 	CopyTimeout string `yaml:"copyTimeout,omitempty"`
 
-	// BuildContextCompressionLevel is the gzip compression level for the build context.
-	// Defaults to `1`.
-	// 0: NoCompression
-	// 1: BestSpeed
-	// 9: BestCompression
-	// -1: DefaultCompression
-	// -2: HuffmanOnly
+	// BuildContextCompressionLevel is the gzip compression level(0-9) for the build context.
+	// Defaults to 1 (BestSpeed).
+	// 0: NoCompression.
+	// 1: BestSpeed.
+	// 9: BestCompression.
+	// -1: DefaultCompression.
+	// -2: HuffmanOnly.
 	BuildContextCompressionLevel *int `yaml:"buildContextCompressionLevel,omitempty"`
 }
 

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -1556,12 +1556,12 @@ type KanikoArtifact struct {
 	CopyTimeout string `yaml:"copyTimeout,omitempty"`
 
 	// BuildContextCompressionLevel is the gzip compression level(0-9) for the build context.
-	// Defaults to 1 (BestSpeed).
 	// 0: NoCompression.
 	// 1: BestSpeed.
 	// 9: BestCompression.
 	// -1: DefaultCompression.
 	// -2: HuffmanOnly.
+	// Defaults to `1`.
 	BuildContextCompressionLevel *int `yaml:"buildContextCompressionLevel,omitempty"`
 }
 


### PR DESCRIPTION
**Description**
1. Fixed `BuildContextCompressionLevel` description
2. Add logging for the compression level - `using gzip compression level {level}`