### PR TITLE
fix(helm): Add expand env template for dependsOn, fix concurrent installation

### DIFF
--- a/pkg/skaffold/deploy/helm/util.go
+++ b/pkg/skaffold/deploy/helm/util.go
@@ -19,19 +19,13 @@ package helm
 import (
 	"fmt"
 
-	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/helm"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/latest"
-	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/util"
 )
 
 func BuildDependencyGraph(releases []latest.HelmRelease) (map[string][]string, error) {
 	dependencyGraph := make(map[string][]string)
 	for _, r := range releases {
-		releaseName, err := util.ExpandEnvTemplateOrFail(r.Name, nil)
-		if err != nil {
-			return nil, helm.UserErr(fmt.Sprintf("cannot expand release name %q", r.Name), err)
-		}
-		dependencyGraph[releaseName] = r.DependsOn
+		dependencyGraph[r.Name] = r.DependsOn
 	}
 
 	return dependencyGraph, nil

--- a/pkg/skaffold/deploy/helm/util_test.go
+++ b/pkg/skaffold/deploy/helm/util_test.go
@@ -67,11 +67,15 @@ func TestBuildDependencyGraph(t *testing.T) {
 			},
 		},
 		{
-			description: "invalid release name template",
+			description: "simple dependency graph with placeholder in name",
 			releases: []latest.HelmRelease{
-				{Name: "{{.Invalid}}"},
+				{Name: "release1-{{.Service}}", DependsOn: []string{"release2-{{.Service}}"}},
+				{Name: "release2-{{.Service}}", DependsOn: []string{}},
 			},
-			shouldErr: true,
+			expected: map[string][]string{
+				"release1-{{.Service}}": {"release2-{{.Service}}"},
+				"release2-{{.Service}}": {},
+			},
 		},
 	}
 


### PR DESCRIPTION
**Description**
1. Fixed the releases installation order to keep the original order for each level, it needs at least to keep the old behavior, because the v2.14.0 changed the order. 
2. Fixed an issue with the [dependsOn](https://skaffold.dev/docs/references/yaml/#manifests-helm-releases-dependsOn), we don't expand the chart's name. Now we use env in the dependsOn chart's name, example:
```
    deploy:
      helm:
        concurrency: 0 #no-limit
        releases:
          - name: my-service-{{.MYUSER}}
            remoteChart: repo/php-nginx
            upgradeOnChange: true
            version: ~4.30.0
            setValues:
              image.pullPolicy: IfNotPresent
            wait: true
            dependsOn:
              - my-cron-{{.MYUSER}}
          - name: my-cron-{{.MYUSER}}
            remoteChart: repo/php-nginx
            upgradeOnChange: true
            version: ~4.30.0
            setValues:
              image.pullPolicy: IfNotPresent
            wait: true
```