### PR TITLE
fix: port-forward error logs `failed to port forward`

### DIFF
--- a/pkg/skaffold/kubectl/exec_windows.go
+++ b/pkg/skaffold/kubectl/exec_windows.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"sync"
+	"sync/atomic"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -65,6 +67,9 @@ func (c *Cmd) Start() error {
 	// Use `unsafe` to extract the process handle.
 	processHandle := (*struct {
 		Pid    int
+		mode   uint8 // processMode
+		state  atomic.Uint64
+		sigMu  sync.RWMutex
 		handle windows.Handle
 	})(unsafe.Pointer(c.Process)).handle
 

--- a/pkg/skaffold/kubectl/exec_windows_test.go
+++ b/pkg/skaffold/kubectl/exec_windows_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Skaffold Authors
+Copyright 2025 The Skaffold Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/skaffold/kubectl/exec_windows_test.go
+++ b/pkg/skaffold/kubectl/exec_windows_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"context"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/windows"
+)
+
+func TestGetHandleFromProcess(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("getHandleFromProcess only works on Windows")
+	}
+
+	ctx := context.TODO()
+	c := CommandContext(ctx, "kubectl", "--help")
+	err := c.Cmd.Start()
+	assert.Nil(t, err, "could not start command")
+
+	h, err := getHandleFromProcess(c.Process)
+	assert.NotEqual(t, h, windows.InvalidHandle, "handle is invalid")
+	assert.Nil(t, err, "could not get handle from process")
+
+	err = c.Cmd.Wait()
+	assert.Nil(t, err, "could not wait command")
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #9710

**Description**
Golang has changed os.Process structure since 1.23
[cs.opensource.google/go/go/+/refs/tags/go1.22.0:src/os/exec.go;l=21](https://cs.opensource.google/go/go/+/refs/tags/go1.22.0:src/os/exec.go;l=21)
[cs.opensource.google/go/go/+/refs/tags/go1.23.0:src/os/exec.go;l=58](https://cs.opensource.google/go/go/+/refs/tags/go1.23.0:src/os/exec.go;l=58)

so this unpack doesn't work, lead to `failed to port-forward` message loop.