### PR TITLE
fix: kustomize render should workwith inline patches

### DIFF
--- a/pkg/skaffold/render/renderer/kustomize/kustomize.go
+++ b/pkg/skaffold/render/renderer/kustomize/kustomize.go
@@ -383,6 +383,9 @@ func (k Kustomize) mirrorValidators(kusDir string, fs TmpFS, validators []string
 
 func (k Kustomize) mirrorPatches(kusDir string, fs TmpFS, patches []types.Patch) error {
 	for _, patch := range patches {
+		if patch.Path == "" {
+			continue
+		}
 		if err := k.mirrorFile(kusDir, fs, patch.Path); err != nil {
 			return err
 		}


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #9731 <!-- tracking issues that this PR will close -->


**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Kustomize supports inline patches where the patch content is put inside the kustomization file as a single string. There is a bug in Skaffold where it will successfully render the Kustomization if the `--set` flag is not set.


### Before

```bash
skaffold render -p dev --set="foo=bar"
read /Users/REDACTED/tmp/kustomize_example/overlays/prod: is a directory
```

### After

```bash
$ skaffold render -p dev --set="foo=bar"
apiVersion: v1
data:
  foo: bar!
kind: ConfigMap
metadata:
  name: prod-basa
---
apiVersion: v1
kind: Pod
metadata:
  labels:
    app: myapp
  name: prod-myapp-pod
spec:
  containers:
    - image: nginx:123
      name: nginx
```