### PR TITLE
feat: add generic BuildArgs for BuildpackArtifact

### DIFF
--- a/docs-v2/content/en/schemas/v4beta14.json
+++ b/docs-v2/content/en/schemas/v4beta14.json
@@ -994,6 +994,18 @@
     },
     "BuildpackArtifact": {
       "properties": {
+        "buildArgs": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "additional args passed to the `pack` build command.",
+          "x-intellij-html-description": "additional args passed to the <code>pack</code> build command.",
+          "default": "[]",
+          "examples": [
+            "[\"--network\", \"host\", \"--cache-image\", \"gcr.io/my-project/my-cache\"]"
+          ]
+        },
         "builder": {
           "type": "string",
           "description": "builder image used.",
@@ -1066,7 +1078,8 @@
         "clearCache",
         "projectDescriptor",
         "dependencies",
-        "volumes"
+        "volumes",
+        "buildArgs"
       ],
       "additionalProperties": false,
       "type": "object",

--- a/pkg/skaffold/build/gcb/buildpacks.go
+++ b/pkg/skaffold/build/gcb/buildpacks.go
@@ -48,6 +48,8 @@ func (b *Builder) buildpackBuildSpec(artifact *latest.BuildpackArtifact, tag str
 		args = append(args, "--trust-builder")
 	}
 
+	args = append(args, artifact.BuildArgs...)
+
 	env, err := misc.EvaluateEnv(artifact.Env)
 	if err != nil {
 		return cloudbuild.Build{}, fmt.Errorf("unable to evaluate env variables: %w", err)

--- a/pkg/skaffold/build/gcb/buildpacks_test.go
+++ b/pkg/skaffold/build/gcb/buildpacks_test.go
@@ -176,6 +176,21 @@ func TestBuildpackBuildSpec(t *testing.T) {
 				Images: []string{"img"},
 			},
 		},
+		{
+			description: "build args",
+			artifact: &latest.BuildpackArtifact{
+				Builder:           "builder",
+				ProjectDescriptor: "project.toml",
+				BuildArgs:         []string{"--network", "cloudbuild"},
+			},
+			expected: cloudbuild.Build{
+				Steps: []*cloudbuild.BuildStep{{
+					Name: "pack/image",
+					Args: []string{"pack", "build", "img", "--builder", "builder", "--network", "cloudbuild"},
+				}},
+				Images: []string{"img"},
+			},
+		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -1323,6 +1323,10 @@ type BuildpackArtifact struct {
 
 	// Volumes support mounting host volumes into the container.
 	Volumes []*BuildpackVolume `yaml:"volumes,omitempty"`
+
+	// BuildArgs are additional args passed to the `pack` build command.
+	// For example: `["--network", "host", "--cache-image", "gcr.io/my-project/my-cache"]`.
+	BuildArgs []string `yaml:"buildArgs,omitempty"`
 }
 
 // BuildpackDependencies *alpha* is used to specify dependencies for an artifact built by buildpacks.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #9744 <!-- tracking issues that this PR will close -->
**Related**: N/A
**Merge before/after**: N/A

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Adding generic BuildArgs []string field on BuildpackArtifact. This allows users to pass any additional args to `pack build` (e.g. --network, --cache-image) without requiring future schema changes.

Example problem: GCP CloudBuild application default credentials are only available on docker network "cloudbuild," hence we need to specify that network for build pack to access that network for proper workload identity authentication for access to things such as Artifact Registries.

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
Addition property available to set on buildpack image build configurations.
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->



<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
