### PR TITLE
fix(verify): use container name from configuration in verify tests

### DIFF
--- a/pkg/skaffold/verify/docker/verify.go
+++ b/pkg/skaffold/verify/docker/verify.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"math"
 	"path"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -48,6 +49,8 @@ import (
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/status"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/util"
 )
+
+var validContainerNameRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]*$`)
 
 // Verifier verifies deployments using Docker libs/CLI.
 type Verifier struct {
@@ -308,7 +311,7 @@ func (v *Verifier) getContainerName(ctx context.Context, imageName string, conta
 	name := containerName
 
 	// If no container name is provided, derive it from the image name
-	if name == "" {
+	if name == "" || !validContainerNameRegex.MatchString(name) {
 		name = path.Base(strings.Split(imageName, ":")[0])
 	}
 

--- a/pkg/skaffold/verify/docker/verify_test.go
+++ b/pkg/skaffold/verify/docker/verify_test.go
@@ -149,3 +149,44 @@ func Test_UseLocalImages(t *testing.T) {
 		t.CheckDeepEqual(expectedPullImgs, fDockerDaemon.PulledImages)
 	})
 }
+
+func TestGetContainerName(t *testing.T) {
+	ctx := context.TODO()
+
+	tests := []struct {
+		description   string
+		imageName     string
+		containerName string
+		expected      string
+	}{
+		{
+			description:   "container name specified",
+			imageName:     "gcr.io/cloud-builders/gcloud",
+			containerName: "custom-container",
+			expected:      "custom-container",
+		},
+		{
+			description:   "container name not specified",
+			imageName:     "gcr.io/cloud-builders/gcloud",
+			containerName: "",
+			expected:      "gcloud",
+		},
+	}
+
+	fakeDockerDaemon := &fakeDockerDaemon{
+		LocalDaemon: docker.NewLocalDaemon(&testutil.FakeAPIClient{}, nil, false, nil),
+	}
+
+	verifier := &Verifier{
+		client: fakeDockerDaemon,
+	}
+
+	for _, test := range tests {
+		testutil.Run(
+			t, test.description, func(t *testutil.T) {
+				actual := verifier.getContainerName(ctx, test.imageName, test.containerName)
+				t.CheckDeepEqual(test.expected, actual)
+			},
+		)
+	}
+}

--- a/pkg/skaffold/verify/docker/verify_test.go
+++ b/pkg/skaffold/verify/docker/verify_test.go
@@ -166,6 +166,12 @@ func TestGetContainerName(t *testing.T) {
 			expected:      "custom-container",
 		},
 		{
+			description:   "invalid container name specified",
+			imageName:     "gcr.io/cloud-builders/gcloud",
+			containerName: "gcr.io/cloud-builders/gcloud",
+			expected:      "gcloud",
+		},
+		{
 			description:   "container name not specified",
 			imageName:     "gcr.io/cloud-builders/gcloud",
 			containerName: "",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: https://github.com/GoogleContainerTools/skaffold/issues/9747

**Description**
Add using container name from configuration in verify tests


