### PR TITLE
fix: fix lifecycle version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/bmatcuk/doublestar v1.3.4
 	github.com/buildpacks/imgutil v0.0.0-20250224200932-4dcbf829e753
-	github.com/buildpacks/lifecycle v0.20.6
+	github.com/buildpacks/lifecycle v0.20.5
 	github.com/buildpacks/pack v0.37.0
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/containerd/containerd v1.7.27

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -335,7 +335,7 @@ github.com/buildpacks/imgutil/layout
 github.com/buildpacks/imgutil/layout/sparse
 github.com/buildpacks/imgutil/local
 github.com/buildpacks/imgutil/remote
-# github.com/buildpacks/lifecycle v0.20.6 => github.com/buildpacks/lifecycle v0.20.5
+# github.com/buildpacks/lifecycle v0.20.5 => github.com/buildpacks/lifecycle v0.20.5
 ## explicit; go 1.23
 github.com/buildpacks/lifecycle/api
 github.com/buildpacks/lifecycle/archive


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

Fixes: In go.mod the lifecycle version should be v20.0.5 no v.20.0.6.


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
