### PR TITLE
feat(config): Enhance config list/set output

### DIFF
--- a/cmd/skaffold/app/cmd/config/list.go
+++ b/cmd/skaffold/app/cmd/config/list.go
@@ -44,7 +44,8 @@ func List(ctx context.Context, out io.Writer) error {
 		if err != nil {
 			return err
 		}
-		if contextConfig == nil { // empty config
+		if contextConfig == nil {
+			fmt.Fprintf(out, "No config found for сurrent context %q\n", kubecontext)
 			return nil
 		}
 		configYaml, err = yaml.Marshal(&contextConfig)

--- a/cmd/skaffold/app/cmd/config/list_test.go
+++ b/cmd/skaffold/app/cmd/config/list_test.go
@@ -19,6 +19,7 @@ package config
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -133,6 +134,7 @@ kubeContexts:
 					InsecureRegistries: []string{"mediocre.io"},
 				},
 			},
+			expectedOutput: fmt.Sprintf("No config found for сurrent context %q\n", "context-without-config"),
 		},
 		{
 			name:        "config has no values for global",
@@ -145,6 +147,7 @@ kubeContexts:
 					},
 				},
 			},
+			expectedOutput: fmt.Sprintf("No config found for сurrent context %q\n", "context-without-config"),
 		},
 		{
 			name:        "show all with empty config",


### PR DESCRIPTION
**Description**
Enhanced `config` `list`/`set` output. 
- `list`: it's not obvious what happens when there is no config because the command returns empty output, now it shows a correct message.
`No config found for сurrent context "stage-nbg3"`

- `set`: if you pass a wrong field name, it just says you passed a wrong field, but I think it'll be better to output what fields are valid:
  ```
  "test" is not a valid config field.
  Available fields are: debug-helpers-registry, update-check, survey, collect-metrics, update, kube-context, omitempty, 
  default-repo, local-cluster, kind-disable-load, k3d-disable-load, multi-level-repo, insecure-registries
  ```