### PR TITLE
docs: Make --no-prune documentation clearer

### DIFF
--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -283,7 +283,7 @@ var flagRegistry = []Flag{
 	},
 	{
 		Name:          "no-prune",
-		Usage:         "Skip removing images and containers built by Skaffold",
+		Usage:         "Skip removing images and containers built by Skaffold during cleanup after dev or debug mode",
 		Value:         &opts.NoPrune,
 		DefValue:      false,
 		FlagAddMethod: "BoolVar",

--- a/docs-v2/content/en/docs/references/cli/_index.md
+++ b/docs-v2/content/en/docs/references/cli/_index.md
@@ -631,7 +631,7 @@ Options:
 	Runs deployments in the specified namespace. When used with 'render' command, renders manifests contain the namespace
 
     --no-prune=false:
-	Skip removing images and containers built by Skaffold
+	Skip removing images and containers built by Skaffold during cleanup after dev or debug mode
 
     --no-prune-children=false:
 	Skip removing layers reused by Skaffold
@@ -1158,7 +1158,7 @@ Options:
 	Runs deployments in the specified namespace. When used with 'render' command, renders manifests contain the namespace
 
     --no-prune=false:
-	Skip removing images and containers built by Skaffold
+	Skip removing images and containers built by Skaffold during cleanup after dev or debug mode
 
     --no-prune-children=false:
 	Skip removing layers reused by Skaffold
@@ -1856,7 +1856,7 @@ Options:
 	Runs deployments in the specified namespace. When used with 'render' command, renders manifests contain the namespace
 
     --no-prune=false:
-	Skip removing images and containers built by Skaffold
+	Skip removing images and containers built by Skaffold during cleanup after dev or debug mode
 
     --no-prune-children=false:
 	Skip removing layers reused by Skaffold


### PR DESCRIPTION
**Description**

The word "prune" is used in multiple contexts and by adding the clarification confusion can be ruled out.

Fixes: #9783