### PR TITLE
Bugfix: Only prune images if changed

### DIFF
--- a/pkg/skaffold/build/local/local.go
+++ b/pkg/skaffold/build/local/local.go
@@ -113,8 +113,15 @@ func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, a *latest.Ar
 		go func() {
 			if len(artifacts) > 0 {
 				bgCtx := context.Background()
-				id, _ := b.getImageIDForTag(bgCtx, artifacts[0].Tag)
-				b.localPruner.runPrune(bgCtx, []string{id})
+				id, err := b.getImageIDForTag(bgCtx, artifacts[0].Tag)
+				if err != nil {
+					log.Entry(bgCtx).Debugf("failed to get image ID for tag %s, err: %v", artifacts[0].Tag, err)
+					return
+				}
+				// only prune if the image changed
+				if id != imageID {
+					b.localPruner.runPrune(bgCtx, []string{id})
+				}
 			}
 		}()
 	}

--- a/pkg/skaffold/build/local/local_test.go
+++ b/pkg/skaffold/build/local/local_test.go
@@ -20,13 +20,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
 	"io"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/client"
 

--- a/pkg/skaffold/build/local/local_test.go
+++ b/pkg/skaffold/build/local/local_test.go
@@ -19,8 +19,12 @@ package local
 import (
 	"context"
 	"errors"
+	"fmt"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/client"
@@ -53,17 +57,26 @@ func (t testAuthHelper) GetAllAuthConfigs(context.Context) (map[string]registry.
 	return nil, nil
 }
 
+type previousArtifact struct {
+	ImageName string
+	Tag       string
+	ImageID   string
+}
+
 func TestLocalRun(t *testing.T) {
 	tests := []struct {
-		description      string
-		api              *testutil.FakeAPIClient
-		tag              string
-		artifact         *latest.Artifact
-		expected         string
-		expectedWarnings []string
-		expectedPushed   map[string]string
-		pushImages       bool
-		shouldErr        bool
+		description       string
+		api               *testutil.FakeAPIClient
+		tag               string
+		artifact          *latest.Artifact
+		previousArtifacts []previousArtifact
+		mode              config.RunMode
+		expected          string
+		expectedWarnings  []string
+		expectedPushed    map[string]string
+		expectedPruned    []string
+		pushImages        bool
+		shouldErr         bool
 	}{
 		{
 			description: "single build (local)",
@@ -219,14 +232,66 @@ func TestLocalRun(t *testing.T) {
 			pushImages: false,
 			shouldErr:  true,
 		},
+		{
+			description: "dev mode prunes previous artifacts",
+			artifact: &latest.Artifact{
+				ImageName: "gcr.io/test/image",
+				ArtifactType: latest.ArtifactType{
+					DockerArtifact: &latest.DockerArtifact{},
+				},
+			},
+			previousArtifacts: []previousArtifact{
+				{
+					ImageName: "gcr.io/test/image",
+					Tag:       "gcr.io/test/image:1",
+					ImageID:   "sha256:0",
+				},
+			},
+			tag:            "gcr.io/test/image:tag",
+			api:            &testutil.FakeAPIClient{},
+			pushImages:     false,
+			mode:           config.RunModes.Dev,
+			expected:       "gcr.io/test/image:1",
+			expectedPruned: []string{"sha256:0"},
+		},
+		{
+			description: "dev mode doesn't prune previous artifact if image ID is the same",
+			artifact: &latest.Artifact{
+				ImageName: "gcr.io/test/image",
+				ArtifactType: latest.ArtifactType{
+					DockerArtifact: &latest.DockerArtifact{},
+				},
+			},
+			previousArtifacts: []previousArtifact{
+				{
+					ImageName: "gcr.io/test/image",
+					Tag:       "gcr.io/test/image:1",
+					ImageID:   "sha256:1",
+				},
+			},
+			tag:            "gcr.io/test/image:tag",
+			api:            &testutil.FakeAPIClient{},
+			pushImages:     false,
+			mode:           config.RunModes.Dev,
+			expected:       "gcr.io/test/image:1",
+			expectedPruned: nil,
+		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&docker.DefaultAuthHelper, testAuthHelper{})
 			fakeWarner := &warnings.Collect{}
 			t.Override(&warnings.Printf, fakeWarner.Warnf)
+			imageIds := map[string]string{}
+			for _, a := range test.previousArtifacts {
+				imageIds[a.Tag] = a.ImageID
+			}
+			fDockerDaemon := &fakeDockerDaemon{
+				LocalDaemon: docker.NewLocalDaemon(test.api, nil, false, nil),
+				ImageIds:    imageIds,
+			}
 			t.Override(&docker.NewAPIClient, func(context.Context, docker.Config) (docker.LocalDaemon, error) {
-				return fakeLocalDaemon(test.api), nil
+				return fDockerDaemon, nil
 			})
 			t.Override(&docker.EvalBuildArgsWithEnv, func(_ config.RunMode, _ string, _ string, args map[string]*string, _ map[string]*string, _ map[string]string) (map[string]*string, error) {
 				return args, nil
@@ -239,7 +304,11 @@ func TestLocalRun(t *testing.T) {
 					},
 				}}})
 
-			builder, err := NewBuilder(context.Background(), &mockBuilderContext{artifactStore: build.NewArtifactStore()}, &latest.LocalBuild{
+			artifactStore := mockArtifactStore{}
+			for _, a := range test.previousArtifacts {
+				artifactStore[a.ImageName] = a.Tag
+			}
+			builder, err := NewBuilder(context.Background(), &mockBuilderContext{artifactStore: artifactStore, mode: test.mode}, &latest.LocalBuild{
 				Push:        util.Ptr(test.pushImages),
 				Concurrency: &constants.DefaultLocalConcurrency,
 			})
@@ -249,6 +318,16 @@ func TestLocalRun(t *testing.T) {
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, res)
 			t.CheckDeepEqual(test.expectedWarnings, fakeWarner.Warnings)
 			t.CheckDeepEqual(test.expectedPushed, test.api.Pushed())
+			if len(test.expectedPruned) > 0 {
+				// wait for completion of the prune operation which happens in a goroutine
+				numAttempts := 0
+				for len(fDockerDaemon.PrunedImages) == 0 && numAttempts < 10 {
+					time.Sleep(10 * time.Millisecond)
+					numAttempts++
+					println(numAttempts)
+				}
+				t.CheckDeepEqual(test.expectedPruned, fDockerDaemon.PrunedImages)
+			}
 		})
 	}
 }
@@ -463,4 +542,49 @@ func (c *mockBuilderContext) SourceDependenciesResolver() graph.SourceDependenci
 		return c.sourceDepsResolver()
 	}
 	return nil
+}
+
+type mockArtifactStore map[string]string
+
+func (m mockArtifactStore) GetImageTag(imageName string) (string, bool) {
+	v, ok := m[imageName]
+	if !ok {
+		return "", false
+	}
+	return v, ok
+}
+func (m mockArtifactStore) Record(a *latest.Artifact, tag string) { m[a.ImageName] = tag }
+func (m mockArtifactStore) GetArtifacts(s []*latest.Artifact) ([]graph.Artifact, error) {
+	var builds []graph.Artifact
+	for _, a := range s {
+		t, found := m.GetImageTag(a.ImageName)
+		if !found {
+			return nil, fmt.Errorf("failed to retrieve build result for image %s", a.ImageName)
+		}
+		builds = append(builds, graph.Artifact{ImageName: a.ImageName, Tag: t, RuntimeType: a.RuntimeType})
+	}
+	return builds, nil
+}
+
+type fakeDockerDaemon struct {
+	docker.LocalDaemon
+
+	ImageIds     map[string]string
+	PrunedImages []string
+}
+
+func (fd *fakeDockerDaemon) ImageInspectWithRaw(_ context.Context, image string) (types.ImageInspect, []byte, error) {
+	imageId := fd.ImageIds[image]
+	return types.ImageInspect{
+		Config: &container.Config{},
+		ID:     imageId,
+	}, []byte{}, nil
+}
+
+func (fd *fakeDockerDaemon) Prune(_ context.Context, images []string, _ bool) ([]string, error) {
+	var pruned []string
+	for _, img := range images {
+		fd.PrunedImages = append(fd.PrunedImages, img)
+	}
+	return pruned, nil
 }


### PR DESCRIPTION
I hope I understood this right...

**Description**
I observed that when using `skaffold dev`, when images were re-built because the dependencies defined in Skaffold changed (I use ko), but didn't result in a new image ID (because the contents hadn't changed - due to dependencies being too broad), then the previous image would be pruned. This means that images which aren't currently in use, like those used by k8s Jobs and CronJobs are removed, causing the deployment to fail.

**Solution**
Now we check whether the image ID of the existing artifact changed before removing it. Because if it's the same then we should keep it.

I tested this solution locally and seems to fix my problem.

Related: #9251