### PR TITLE
feat: Add support in Cloud Run for configuring tolerateFailuresUntilDeadline and disabling status checks

### DIFF
--- a/pkg/skaffold/deploy/cloudrun/deploy.go
+++ b/pkg/skaffold/deploy/cloudrun/deploy.go
@@ -69,6 +69,8 @@ type Deployer struct {
 	labeller            *label.DefaultLabeller
 	hookRunner          hooks.Runner
 	statusCheckDeadline time.Duration
+	// Whether or not to tolerate failures until the status check deadline is reached
+	tolerateFailures bool
 
 	Project string
 	Region  string
@@ -79,7 +81,7 @@ type Deployer struct {
 }
 
 // NewDeployer creates a new Deployer for Cloud Run from the Skaffold deploy config.
-func NewDeployer(cfg Config, labeller *label.DefaultLabeller, crDeploy *latest.CloudRunDeploy, configName string, statusCheckDeadline time.Duration) (*Deployer, error) {
+func NewDeployer(cfg Config, labeller *label.DefaultLabeller, crDeploy *latest.CloudRunDeploy, configName string, statusCheckDeadline time.Duration, tolerateFailures bool) (*Deployer, error) {
 	return &Deployer{
 		configName:     configName,
 		CloudRunDeploy: crDeploy,
@@ -92,6 +94,7 @@ func NewDeployer(cfg Config, labeller *label.DefaultLabeller, crDeploy *latest.C
 		hookRunner:          hooks.NewCloudRunDeployRunner(crDeploy.LifecycleHooks, hooks.NewDeployEnvOpts(labeller.GetRunID(), "", []string{})),
 		useGcpOptions:       true,
 		statusCheckDeadline: statusCheckDeadline,
+		tolerateFailures:    tolerateFailures,
 	}, nil
 }
 
@@ -182,7 +185,7 @@ func (d *Deployer) PostDeployHooks(ctx context.Context, out io.Writer) error {
 
 func (d *Deployer) getMonitor() *Monitor {
 	if d.monitor == nil {
-		d.monitor = NewMonitor(d.labeller, d.clientOptions, d.statusCheckDeadline)
+		d.monitor = NewMonitor(d.labeller, d.clientOptions, d.statusCheckDeadline, d.tolerateFailures)
 	}
 	return d.monitor
 }

--- a/pkg/skaffold/deploy/cloudrun/deploy_test.go
+++ b/pkg/skaffold/deploy/cloudrun/deploy_test.go
@@ -67,6 +67,7 @@ func TestDeployService(tOuter *testing.T) {
 			defaultProject:      "testProject",
 			region:              "us-central1",
 			expectedPath:        "/v1/projects/testProject/locations/us-central1/services",
+			statusCheck:         util.Ptr(true),
 			statusCheckDeadline: defaultStatusCheckDeadline,
 			toDeploy: &run.Service{
 				ApiVersion: "serving.knative.dev/v1",
@@ -81,6 +82,7 @@ func TestDeployService(tOuter *testing.T) {
 			defaultProject:      "testProject",
 			region:              "us-central1",
 			expectedPath:        "/v1/projects/testProject/locations/us-central1/services",
+			statusCheck:         util.Ptr(true),
 			statusCheckDeadline: 15 * time.Minute,
 			toDeploy: &run.Service{
 				ApiVersion: "serving.knative.dev/v1",
@@ -96,6 +98,7 @@ func TestDeployService(tOuter *testing.T) {
 			region:              "us-central1",
 			expectedPath:        "/v1/projects/testProject/locations/us-central1/services",
 			statusCheckDeadline: 15 * time.Minute,
+			statusCheck:         util.Ptr(true),
 			tolerateFailures:    true,
 			toDeploy: &run.Service{
 				ApiVersion: "serving.knative.dev/v1",
@@ -125,6 +128,7 @@ func TestDeployService(tOuter *testing.T) {
 			region:              "us-central1",
 			statusCheckDeadline: defaultStatusCheckDeadline,
 			expectedPath:        "/v1/projects/testProject/locations/us-central1/services",
+			statusCheck:         util.Ptr(true),
 			toDeploy: &run.Service{
 				ApiVersion: "serving.knative.dev/v1",
 				Kind:       "Service",
@@ -140,6 +144,7 @@ func TestDeployService(tOuter *testing.T) {
 			region:              "us-central1",
 			statusCheckDeadline: defaultStatusCheckDeadline,
 			httpErr:             http.StatusUnauthorized,
+			statusCheck:         util.Ptr(true),
 			toDeploy: &run.Service{
 				ApiVersion: "serving.knative.dev/v1",
 				Kind:       "Service",
@@ -154,6 +159,7 @@ func TestDeployService(tOuter *testing.T) {
 			description:         "test no project specified",
 			region:              "us-central1",
 			statusCheckDeadline: defaultStatusCheckDeadline,
+			statusCheck:         util.Ptr(true),
 			toDeploy: &run.Service{
 				ApiVersion: "serving.knative.dev/v1",
 				Kind:       "Service",

--- a/pkg/skaffold/deploy/cloudrun/deploy_test.go
+++ b/pkg/skaffold/deploy/cloudrun/deploy_test.go
@@ -56,6 +56,7 @@ func TestDeployService(tOuter *testing.T) {
 		defaultProject      string
 		region              string
 		statusCheckDeadline time.Duration
+		tolerateFailures    bool
 		expectedPath        string
 		httpErr             int
 		errCode             proto.StatusCode
@@ -80,6 +81,21 @@ func TestDeployService(tOuter *testing.T) {
 			region:              "us-central1",
 			expectedPath:        "/v1/projects/testProject/locations/us-central1/services",
 			statusCheckDeadline: 15 * time.Minute,
+			toDeploy: &run.Service{
+				ApiVersion: "serving.knative.dev/v1",
+				Kind:       "Service",
+				Metadata: &run.ObjectMeta{
+					Name: "test-service",
+				},
+			},
+		},
+		{
+			description:         "test deploy with tolerateFailures set to true",
+			defaultProject:      "testProject",
+			region:              "us-central1",
+			expectedPath:        "/v1/projects/testProject/locations/us-central1/services",
+			statusCheckDeadline: 15 * time.Minute,
+			tolerateFailures:    true,
 			toDeploy: &run.Service{
 				ApiVersion: "serving.knative.dev/v1",
 				Kind:       "Service",
@@ -168,7 +184,8 @@ func TestDeployService(tOuter *testing.T) {
 					ProjectID: test.defaultProject,
 					Region:    test.region},
 				configName,
-				test.statusCheckDeadline)
+				test.statusCheckDeadline,
+				test.tolerateFailures)
 			deployer.clientOptions = append(deployer.clientOptions, option.WithEndpoint(ts.URL), option.WithoutAuthentication())
 			deployer.useGcpOptions = false
 			manifestList, _ := json.Marshal(test.toDeploy)
@@ -348,7 +365,8 @@ func TestDeployJob(tOuter *testing.T) {
 					Region:    test.region,
 				},
 				configName,
-				defaultStatusCheckDeadline)
+				defaultStatusCheckDeadline,
+				false)
 			deployer.clientOptions = append(deployer.clientOptions, option.WithEndpoint(ts.URL), option.WithoutAuthentication())
 			deployer.useGcpOptions = false
 			manifestList, _ := k8syaml.Marshal(test.toDeploy)
@@ -514,7 +532,8 @@ func TestDeployRewrites(tOuter *testing.T) {
 					Region:    test.region,
 				},
 				"",
-				defaultStatusCheckDeadline)
+				defaultStatusCheckDeadline,
+				false)
 			deployer.clientOptions = append(deployer.clientOptions, option.WithEndpoint(ts.URL), option.WithoutAuthentication())
 			deployer.useGcpOptions = false
 			m, _ := json.Marshal(test.toDeploy)
@@ -608,7 +627,8 @@ func TestCleanupService(tOuter *testing.T) {
 					Region:    test.region,
 				},
 				configName,
-				defaultStatusCheckDeadline)
+				defaultStatusCheckDeadline,
+				false)
 			deployer.clientOptions = append(deployer.clientOptions, option.WithEndpoint(ts.URL), option.WithoutAuthentication())
 			deployer.useGcpOptions = false
 			manifestListByConfig := manifest.NewManifestListByConfig()
@@ -690,7 +710,8 @@ func TestCleanupJob(tOuter *testing.T) {
 					Region:    test.region,
 				},
 				configName,
-				defaultStatusCheckDeadline)
+				defaultStatusCheckDeadline,
+				false)
 			deployer.clientOptions = append(deployer.clientOptions, option.WithEndpoint(ts.URL), option.WithoutAuthentication())
 			deployer.useGcpOptions = false
 			manifestListByConfig := manifest.NewManifestListByConfig()
@@ -762,7 +783,8 @@ func TestCleanupMultipleResources(tOuter *testing.T) {
 					Region:    test.region,
 				},
 				configName,
-				defaultStatusCheckDeadline)
+				defaultStatusCheckDeadline,
+				false)
 			deployer.clientOptions = append(deployer.clientOptions, option.WithEndpoint(ts.URL), option.WithoutAuthentication())
 			deployer.useGcpOptions = false
 			manifestListByConfig := manifest.NewManifestListByConfig()

--- a/pkg/skaffold/deploy/cloudrun/deploy_test.go
+++ b/pkg/skaffold/deploy/cloudrun/deploy_test.go
@@ -57,6 +57,7 @@ func TestDeployService(tOuter *testing.T) {
 		region              string
 		statusCheckDeadline time.Duration
 		tolerateFailures    bool
+		statusCheck         *bool
 		expectedPath        string
 		httpErr             int
 		errCode             proto.StatusCode
@@ -96,6 +97,20 @@ func TestDeployService(tOuter *testing.T) {
 			expectedPath:        "/v1/projects/testProject/locations/us-central1/services",
 			statusCheckDeadline: 15 * time.Minute,
 			tolerateFailures:    true,
+			toDeploy: &run.Service{
+				ApiVersion: "serving.knative.dev/v1",
+				Kind:       "Service",
+				Metadata: &run.ObjectMeta{
+					Name: "test-service",
+				},
+			},
+		},
+		{
+			description:    "test deploy with statusCheck set to false",
+			defaultProject: "testProject",
+			region:         "us-central1",
+			expectedPath:   "/v1/projects/testProject/locations/us-central1/services",
+			statusCheck:    util.Ptr(false),
 			toDeploy: &run.Service{
 				ApiVersion: "serving.knative.dev/v1",
 				Kind:       "Service",
@@ -185,7 +200,8 @@ func TestDeployService(tOuter *testing.T) {
 					Region:    test.region},
 				configName,
 				test.statusCheckDeadline,
-				test.tolerateFailures)
+				test.tolerateFailures,
+				test.statusCheck)
 			deployer.clientOptions = append(deployer.clientOptions, option.WithEndpoint(ts.URL), option.WithoutAuthentication())
 			deployer.useGcpOptions = false
 			manifestList, _ := json.Marshal(test.toDeploy)
@@ -366,7 +382,8 @@ func TestDeployJob(tOuter *testing.T) {
 				},
 				configName,
 				defaultStatusCheckDeadline,
-				false)
+				false,
+				util.Ptr(true))
 			deployer.clientOptions = append(deployer.clientOptions, option.WithEndpoint(ts.URL), option.WithoutAuthentication())
 			deployer.useGcpOptions = false
 			manifestList, _ := k8syaml.Marshal(test.toDeploy)
@@ -533,7 +550,8 @@ func TestDeployRewrites(tOuter *testing.T) {
 				},
 				"",
 				defaultStatusCheckDeadline,
-				false)
+				false,
+				util.Ptr(true))
 			deployer.clientOptions = append(deployer.clientOptions, option.WithEndpoint(ts.URL), option.WithoutAuthentication())
 			deployer.useGcpOptions = false
 			m, _ := json.Marshal(test.toDeploy)
@@ -628,7 +646,8 @@ func TestCleanupService(tOuter *testing.T) {
 				},
 				configName,
 				defaultStatusCheckDeadline,
-				false)
+				false,
+				util.Ptr(true))
 			deployer.clientOptions = append(deployer.clientOptions, option.WithEndpoint(ts.URL), option.WithoutAuthentication())
 			deployer.useGcpOptions = false
 			manifestListByConfig := manifest.NewManifestListByConfig()
@@ -711,7 +730,8 @@ func TestCleanupJob(tOuter *testing.T) {
 				},
 				configName,
 				defaultStatusCheckDeadline,
-				false)
+				false,
+				util.Ptr(true))
 			deployer.clientOptions = append(deployer.clientOptions, option.WithEndpoint(ts.URL), option.WithoutAuthentication())
 			deployer.useGcpOptions = false
 			manifestListByConfig := manifest.NewManifestListByConfig()
@@ -784,7 +804,8 @@ func TestCleanupMultipleResources(tOuter *testing.T) {
 				},
 				configName,
 				defaultStatusCheckDeadline,
-				false)
+				false,
+				util.Ptr(true))
 			deployer.clientOptions = append(deployer.clientOptions, option.WithEndpoint(ts.URL), option.WithoutAuthentication())
 			deployer.useGcpOptions = false
 			manifestListByConfig := manifest.NewManifestListByConfig()

--- a/pkg/skaffold/deploy/cloudrun/status.go
+++ b/pkg/skaffold/deploy/cloudrun/status.go
@@ -50,15 +50,17 @@ type Monitor struct {
 	statusCheckDeadline time.Duration
 	pollPeriod          time.Duration
 	reportStatusTime    time.Duration
+	tolerateFailures    bool
 }
 
-func NewMonitor(labeller *label.DefaultLabeller, clientOptions []option.ClientOption, statusCheckDeadline time.Duration) *Monitor {
+func NewMonitor(labeller *label.DefaultLabeller, clientOptions []option.ClientOption, statusCheckDeadline time.Duration, tolerateFailures bool) *Monitor {
 	return &Monitor{
 		labeller:            labeller,
 		clientOptions:       clientOptions,
 		statusCheckDeadline: statusCheckDeadline,
 		pollPeriod:          defaultPollPeriod,
 		reportStatusTime:    defaultReportStatusTime,
+		tolerateFailures:    tolerateFailures,
 	}
 }
 

--- a/pkg/skaffold/deploy/cloudrun/status_test.go
+++ b/pkg/skaffold/deploy/cloudrun/status_test.go
@@ -96,11 +96,12 @@ func TestPrintSummaryStatus(t *testing.T) {
 }
 func TestPollServiceStatus(t *testing.T) {
 	tests := []struct {
-		description string
-		resource    RunResourceName
-		responses   []run.Service
-		expected    *proto.ActionableErr
-		fail        bool
+		description      string
+		resource         RunResourceName
+		responses        []run.Service
+		expected         *proto.ActionableErr
+		tolerateFailures bool
+		fail             bool
 	}{
 		{
 			description: "test basic check with one resource ready",
@@ -241,7 +242,16 @@ func TestPollServiceStatus(t *testing.T) {
 
 			resource := &runResource{resource: test.resource, sub: &runServiceResource{path: test.resource.String()}}
 			ctx := context.Background()
-			resource.pollResourceStatus(ctx, 5*time.Second, 1*time.Second, []option.ClientOption{option.WithEndpoint(ts.URL), option.WithoutAuthentication()}, false)
+			resource.pollResourceStatus(
+				ctx,
+				5*time.Second,
+				1*time.Second,
+				[]option.ClientOption{
+					option.WithEndpoint(ts.URL),
+					option.WithoutAuthentication(),
+				},
+				false,
+				false)
 			t.CheckDeepEqual(test.expected, resource.status.ae, protocmp.Transform())
 		})
 	}
@@ -352,7 +362,16 @@ func TestPollJobStatus(t *testing.T) {
 
 			resource := &runResource{resource: test.resource, sub: &runJobResource{path: test.resource.String()}}
 			ctx := context.Background()
-			resource.pollResourceStatus(ctx, 5*time.Second, 1*time.Second, []option.ClientOption{option.WithEndpoint(ts.URL), option.WithoutAuthentication()}, false)
+			resource.pollResourceStatus(
+				ctx,
+				5*time.Second,
+				1*time.Second,
+				[]option.ClientOption{
+					option.WithEndpoint(ts.URL),
+					option.WithoutAuthentication(),
+				},
+				false,
+				false)
 			t.CheckDeepEqual(test.expected, resource.status.ae, protocmp.Transform())
 		})
 	}

--- a/pkg/skaffold/deploy/cloudrun/status_test.go
+++ b/pkg/skaffold/deploy/cloudrun/status_test.go
@@ -84,7 +84,7 @@ func TestPrintSummaryStatus(t *testing.T) {
 				status:   Status{ae: test.ae},
 				sub:      &runServiceResource{path: test.resource.String()},
 			}
-			s := NewMonitor(labeller, []option.ClientOption{}, defaultStatusCheckDeadline)
+			s := NewMonitor(labeller, []option.ClientOption{}, defaultStatusCheckDeadline, false)
 			out := new(bytes.Buffer)
 			testEvent.InitializeState([]latest.Pipeline{{}})
 			c := newCounter(10)
@@ -428,7 +428,7 @@ func TestMonitorPrintStatus(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			testEvent.InitializeState([]latest.Pipeline{{}})
 
-			monitor := NewMonitor(labeller, []option.ClientOption{}, defaultStatusCheckDeadline)
+			monitor := NewMonitor(labeller, []option.ClientOption{}, defaultStatusCheckDeadline, false)
 			out := new(bytes.Buffer)
 			done := monitor.printStatus(test.resources, out)
 			if done != test.done {

--- a/pkg/skaffold/runner/deployer.go
+++ b/pkg/skaffold/runner/deployer.go
@@ -367,11 +367,8 @@ func getCloudRunDeployer(runCtx *runcontext.RunContext, labeller *label.DefaultL
 	}
 	statusCheckDeadline := maxStatusCheckDeadline(deployers)
 	tolerateFailures := runCtx.StatusCheckTolerateFailures()
-	// runcontext StatusCheck method returns the value set by the cli flag `--status-check`
+	// The runctx.StatusCheck() method returns the value set by the cli flag `--status-check`,
 	// which overrides the value set in the individual configs.
-	// if cliValue := d.RunContext.StatusCheck(); cliValue != nil {
-	// 	return cliValue
-	// }
 	if cliStatusCheck := runCtx.StatusCheck(); cliStatusCheck != nil {
 		enableStatusCheck = cliStatusCheck
 	}

--- a/pkg/skaffold/runner/deployer.go
+++ b/pkg/skaffold/runner/deployer.go
@@ -367,6 +367,7 @@ func getCloudRunDeployer(runCtx *runcontext.RunContext, labeller *label.DefaultL
 	}
 	statusCheckDeadline := maxStatusCheckDeadline(deployers)
 	tolerateFailures := runCtx.StatusCheckTolerateFailures()
+	enableStatusCheck := runCtx.StatusCheck()
 
 	lifecycleHooks := latest.CloudRunDeployHooks{}
 	if configName != "" {
@@ -384,7 +385,8 @@ func getCloudRunDeployer(runCtx *runcontext.RunContext, labeller *label.DefaultL
 		},
 		configName,
 		statusCheckDeadline,
-		tolerateFailures)
+		tolerateFailures,
+		enableStatusCheck)
 }
 
 // maxStatusCheckDeadline goes through each of the Deploy Configs and finds the

--- a/pkg/skaffold/runner/deployer_test.go
+++ b/pkg/skaffold/runner/deployer_test.go
@@ -129,7 +129,15 @@ func TestGetDeployer(tOuter *testing.T) {
 				},
 				expected: deploy.NewDeployerMux(
 					[]deploy.Deployer{
-						t.RequireNonNilResult(cloudrun.NewDeployer(&runcontext.RunContext{}, &label.DefaultLabeller{}, &latest.CloudRunDeploy{}, "default", 10*time.Minute)).(deploy.Deployer)},
+						t.RequireNonNilResult(cloudrun.NewDeployer(
+							&runcontext.RunContext{},
+							&label.DefaultLabeller{},
+							&latest.CloudRunDeploy{},
+							"default",
+							10*time.Minute,
+							false,
+							util.Ptr(true)),
+						).(deploy.Deployer)},
 					false),
 			},
 			{
@@ -144,7 +152,62 @@ func TestGetDeployer(tOuter *testing.T) {
 				},
 				expected: deploy.NewDeployerMux(
 					[]deploy.Deployer{
-						t.RequireNonNilResult(cloudrun.NewDeployer(&runcontext.RunContext{}, &label.DefaultLabeller{}, &latest.CloudRunDeploy{}, "default", 5*time.Minute)).(deploy.Deployer)},
+						t.RequireNonNilResult(cloudrun.NewDeployer(
+							&runcontext.RunContext{},
+							&label.DefaultLabeller{},
+							&latest.CloudRunDeploy{},
+							"default",
+							5*time.Minute,
+							false,
+							util.Ptr(true)),
+						).(deploy.Deployer)},
+					false),
+			},
+			{
+				description: "cloud run deployer with tolerateFailures set to true",
+				cfg: latest.Pipeline{
+					Deploy: latest.DeployConfig{
+						StatusCheckDeadlineSeconds:    900,
+						TolerateFailuresUntilDeadline: true,
+						DeployType: latest.DeployType{
+							CloudRunDeploy: &latest.CloudRunDeploy{},
+						},
+					},
+				},
+				expected: deploy.NewDeployerMux(
+					[]deploy.Deployer{
+						t.RequireNonNilResult(cloudrun.NewDeployer(
+							&runcontext.RunContext{},
+							&label.DefaultLabeller{},
+							&latest.CloudRunDeploy{},
+							"default",
+							15*time.Minute,
+							true,
+							util.Ptr(true)),
+						).(deploy.Deployer)},
+					false),
+			},
+			{
+				description: "cloud run deployer with statusCheck disabled",
+				cfg: latest.Pipeline{
+					Deploy: latest.DeployConfig{
+						StatusCheck: util.Ptr(false),
+						DeployType: latest.DeployType{
+							CloudRunDeploy: &latest.CloudRunDeploy{},
+						},
+					},
+				},
+				expected: deploy.NewDeployerMux(
+					[]deploy.Deployer{
+						t.RequireNonNilResult(cloudrun.NewDeployer(
+							&runcontext.RunContext{},
+							&label.DefaultLabeller{},
+							&latest.CloudRunDeploy{},
+							"default",
+							10*time.Minute,
+							false,
+							util.Ptr(false)),
+						).(deploy.Deployer)},
 					false),
 			},
 			{
@@ -290,7 +353,18 @@ func TestGetDeployer(tOuter *testing.T) {
 						},
 					},
 				},
-				expected:          t.RequireNonNilResult(cloudrun.NewDeployer(&runcontext.RunContext{}, &label.DefaultLabeller{}, &latest.CloudRunDeploy{ProjectID: "TestProject", Region: "us-central1"}, "default", 10*time.Minute)).(deploy.Deployer),
+				expected: t.RequireNonNilResult(cloudrun.NewDeployer(
+					&runcontext.RunContext{},
+					&label.DefaultLabeller{},
+					&latest.CloudRunDeploy{
+						ProjectID: "TestProject",
+						Region:    "us-central1",
+					},
+					"default",
+					10*time.Minute,
+					false,
+					util.Ptr(true)),
+				).(deploy.Deployer),
 				deepCheckDeployer: true,
 			},
 			{

--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -173,7 +173,8 @@ func (ps Pipelines) TransformDenyList() []latest.ResourceFilter {
 
 func (ps Pipelines) StatusCheckTolerateFailures() bool {
 	failureTolerance := false
-	// set the group status check deadline to maximum of any individually specified value
+	// If any of the configs have tolerateFailuresUntilDeadline to true, set
+	// the value to true.
 	for _, p := range ps.pipelines {
 		if p.Deploy.TolerateFailuresUntilDeadline {
 			failureTolerance = true

--- a/pkg/skaffold/status/status.go
+++ b/pkg/skaffold/status/status.go
@@ -29,6 +29,8 @@ type Monitor interface {
 	Reset()
 }
 
+// NoopMonitor is used if status checking has been disabled, either via the CLI
+// or via the Skaffold config.
 type NoopMonitor struct{}
 
 func (n *NoopMonitor) Check(context.Context, io.Writer) error { return nil }


### PR DESCRIPTION
Fixes: #9794

**Description**
feat: Add support for Cloud Run for configuring `tolerateFailuresUntilDeadline` and disabling status checks, as is done with Kubernetes resources.


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
