### PR TITLE
[bug]: Support helm depBuild flags for helm deploys

### DIFF
--- a/pkg/skaffold/deploy/helm/helm.go
+++ b/pkg/skaffold/deploy/helm/helm.go
@@ -562,7 +562,10 @@ func (h *Deployer) deployRelease(ctx context.Context, out io.Writer, releaseName
 	if !r.SkipBuildDependencies && r.ChartPath != "" {
 		olog.Entry(ctx).Info("Building helm dependencies...")
 
-		if err := helm.Exec(ctx, h, out, false, nil, "dep", "build", r.ChartPath); err != nil {
+		args := []string{"dep", "build", r.ChartPath}
+		args = append(args, h.Flags.DepBuild...)
+
+		if err := helm.Exec(ctx, h, out, false, nil, args...); err != nil {
 			return nil, nil, helm.UserErr("building helm dependencies", err)
 		}
 	}


### PR DESCRIPTION
Related: #8413, #9696

**Description**
The helm depBuild flags were added in the most recent version of skaffold, but
they are currently only supported when using helm to render and not supported
when using helm to deploy. This ensures that the flags are applied on deploy
too.

**User facing changes (remove if N/A)**
The flag is already a part of the schema, it was just ignored before this.
