### PR TITLE
Update PrintNamespacesList to break on YAML file separator '---' followed by a new line.

### DIFF
--- a/pkg/skaffold/inspect/namespaces/list.go
+++ b/pkg/skaffold/inspect/namespaces/list.go
@@ -53,7 +53,7 @@ func PrintNamespacesList(ctx context.Context, out io.Writer, manifestFile string
 	decoder := scheme.Codecs.UniversalDeserializer()
 
 	resourceToInfoMap := map[string][]resourceInfo{}
-	for _, resourceYAML := range strings.Split(string(b), "---") {
+	for _, resourceYAML := range strings.Split(string(b), "---\n") {
 		// skip empty documents, `Decode` will fail on them
 		if len(resourceYAML) == 0 {
 			continue

--- a/pkg/skaffold/inspect/namespaces/list_test.go
+++ b/pkg/skaffold/inspect/namespaces/list_test.go
@@ -61,7 +61,7 @@ kind: Deployment
 metadata:
   labels:
     app: leeroy-app
-  name: leeroy-app
+  name: leeroy-app---rel01
   namespace: manifest-namespace
 spec:
   replicas: 1
@@ -119,7 +119,7 @@ func TestPrintTestsList(t *testing.T) {
 		{
 			description: "print all deployment namespaces where the manifest has a namespace set but it is also set via the kubectl flag deploy config",
 			manifest:    manifestWithNamespace,
-			expected:    `{"resourceToInfoMap":{"apps/v1, Kind=Deployment":[{"name":"leeroy-app","namespace":"manifest-namespace"}]}}` + "\n",
+			expected:    `{"resourceToInfoMap":{"apps/v1, Kind=Deployment":[{"name":"leeroy-app---rel01","namespace":"manifest-namespace"}]}}` + "\n",
 			profiles:    []string{"baz-flag-ns"},
 			module:      []string{"cfg-with-default-namespace"},
 		},


### PR DESCRIPTION
Multiple manifests may be defined in a single YAML file. `---` is used to separate the different manifests.

Before:
PrintNamespacesList breaks on `---` to get each manifest individually and then find the namespace in it.
If any string in the manifest (say the deployment name is "hello---world") then it will break on that as well and try to read the namespace of a jumbled manifest.


After:
PrintNamespacesList breaks on `---\n`.