### PR TITLE
demonstrate that remoteManifests rendering is broken

### DIFF
--- a/pkg/skaffold/kubernetes/manifest/images_test.go
+++ b/pkg/skaffold/kubernetes/manifest/images_test.go
@@ -125,7 +125,7 @@ spec:
 		fakeWarner := &warnings.Collect{}
 		t.Override(&warnings.Printf, fakeWarner.Warnf)
 
-		resultManifest, err := manifests.ReplaceRemoteManifestImages(context.TODO(), builds, NewResourceSelectorImages(TransformAllowlist, TransformDenylist))
+		resultManifest, err := manifests.ReplaceImages(context.TODO(), builds, NewResourceSelectorImages(TransformAllowlist, TransformDenylist))
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual(expected.String(), resultManifest.String(), testutil.YamlObj(t.T))


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
**Related**:
 #5855
 #5216

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
The method `ReplaceRemoteManifestImages` is no longer used anywhere except the test case modified in this PR. This is a hint that all manifests, even those from remote, go through `ReplaceImages`. So this one-line PR exists to demonstrate that a regression has taken place for remoteManifests by showing that it breaks a test case; but is *correct* to be broken, because the without the change in this PR the test is exercising an orphaned code path. 
The expectations outlined in the test case are real expectations that the community relies on for remote manifests. 

If I were a better Go programmer, I would love to also PR a fix for this, but I hope this PR make the issue easy to understand. 

TL;DR: If this test case were an integration test rather than a unit test, I think it would have started failing 2.5 years ago.


**User facing changes**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->
Before:
All tests pass, so we think there is no issue
After:
kubernetes/manifest unit tests fail, revealing the truth about how remoteManifests no longer work

**Follow-up Work (remove if N/A)**
The handling of remoteManifests needs some tune-up. 
Commits in #7603 and #7658 fully removed any _actual_ code paths to [ReplaceRemoteManifestImages](https://github.com/GoogleContainerTools/skaffold/blob/main/pkg/skaffold/kubernetes/manifest/images.go#L144). 

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
