### PR TITLE
fix: update debug skip probes annotation to be Kubernetes valid annotation

### DIFF
--- a/docs-v2/content/en/docs/workflows/debug.md
+++ b/docs-v2/content/en/docs/workflows/debug.md
@@ -391,13 +391,13 @@ an event that can be used by tools like IDEs to establish a debug session.
     being terminated and restarted.
 
 	The probe timeout value can be set on a per-podspec basis by setting
-	a `debug.cloud.google.com/probe/timeouts` annotation on the podspec's metadata
+	a `debug.cloud.google.com/probe-timeouts` annotation on the podspec's metadata
 	with a valid duration (see [Go's time.ParseDuration()](https://pkg.go.dev/time#ParseDuration)).
     This probe timeout-rewriting can be skipped entirely by using `skip`.  For example:
     ```yaml
     metadata:
       annotations:
-        debug.cloud.google.com/probe/timeouts: skip
+        debug.cloud.google.com/probe-timeouts: skip
     spec: ...
     ```
 

--- a/pkg/skaffold/debug/types/types.go
+++ b/pkg/skaffold/debug/types/types.go
@@ -27,7 +27,7 @@ const (
 
 	// DebugProbesAnnotation is the name of the podspec annotation that disables rewriting of probe timeouts.
 	// The annotation value should be `skip`.
-	DebugProbeTimeouts = "debug.cloud.google.com/probe/timeouts"
+	DebugProbeTimeouts = "debug.cloud.google.com/probe-timeouts"
 )
 
 // ContainerDebugConfiguration captures debugging information for a specific container.

--- a/pkg/skaffold/kubernetes/debugging/transform_test.go
+++ b/pkg/skaffold/kubernetes/debugging/transform_test.go
@@ -229,7 +229,7 @@ func TestRewriteProbes(t *testing.T) {
 			name: "skips pod with skip-probes annotation",
 			input: v1.Pod{
 				TypeMeta:   metav1.TypeMeta{APIVersion: v1.SchemeGroupVersion.Version, Kind: "Pod"},
-				ObjectMeta: metav1.ObjectMeta{Name: "podname", Annotations: map[string]string{"debug.cloud.google.com/probe/timeouts": `skip`}},
+				ObjectMeta: metav1.ObjectMeta{Name: "podname", Annotations: map[string]string{"debug.cloud.google.com/probe-timeouts": `skip`}},
 				Spec: v1.PodSpec{Containers: []v1.Container{{
 					Name:          "name1",
 					Image:         "image1",
@@ -240,7 +240,7 @@ func TestRewriteProbes(t *testing.T) {
 			name: "processes pod with probes annotation with explicit timeout",
 			input: v1.Pod{
 				TypeMeta:   metav1.TypeMeta{APIVersion: v1.SchemeGroupVersion.Version, Kind: "Pod"},
-				ObjectMeta: metav1.ObjectMeta{Name: "podname", Annotations: map[string]string{"debug.cloud.google.com/probe/timeouts": `1m`}},
+				ObjectMeta: metav1.ObjectMeta{Name: "podname", Annotations: map[string]string{"debug.cloud.google.com/probe-timeouts": `1m`}},
 				Spec: v1.PodSpec{Containers: []v1.Container{{
 					Name:          "name1",
 					Image:         "image1",
@@ -248,7 +248,7 @@ func TestRewriteProbes(t *testing.T) {
 			changed: false,
 			result: v1.Pod{
 				TypeMeta:   metav1.TypeMeta{APIVersion: v1.SchemeGroupVersion.Version, Kind: "Pod"},
-				ObjectMeta: metav1.ObjectMeta{Name: "podname", Annotations: map[string]string{"debug.cloud.google.com/probe/timeouts": `1m`}},
+				ObjectMeta: metav1.ObjectMeta{Name: "podname", Annotations: map[string]string{"debug.cloud.google.com/probe-timeouts": `1m`}},
 				Spec: v1.PodSpec{Containers: []v1.Container{{
 					Name:          "name1",
 					Image:         "image1",
@@ -258,7 +258,7 @@ func TestRewriteProbes(t *testing.T) {
 			name: "processes pod with probes annotation with invalid timeout",
 			input: v1.Pod{
 				TypeMeta:   metav1.TypeMeta{APIVersion: v1.SchemeGroupVersion.Version, Kind: "Pod"},
-				ObjectMeta: metav1.ObjectMeta{Name: "podname", Annotations: map[string]string{"debug.cloud.google.com/probe/timeouts": `on`}},
+				ObjectMeta: metav1.ObjectMeta{Name: "podname", Annotations: map[string]string{"debug.cloud.google.com/probe-timeouts": `on`}},
 				Spec: v1.PodSpec{Containers: []v1.Container{{
 					Name:          "name1",
 					Image:         "image1",
@@ -266,7 +266,7 @@ func TestRewriteProbes(t *testing.T) {
 			changed: false,
 			result: v1.Pod{
 				TypeMeta:   metav1.TypeMeta{APIVersion: v1.SchemeGroupVersion.Version, Kind: "Pod"},
-				ObjectMeta: metav1.ObjectMeta{Name: "podname", Annotations: map[string]string{"debug.cloud.google.com/probe/timeouts": `on`}},
+				ObjectMeta: metav1.ObjectMeta{Name: "podname", Annotations: map[string]string{"debug.cloud.google.com/probe-timeouts": `on`}},
 				Spec: v1.PodSpec{Containers: []v1.Container{{
 					Name:          "name1",
 					Image:         "image1",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #8962 <!-- tracking issues that this PR will close -->

**Description**
Current implementation of Skaffold uses annotation that is not valid on Kubernetes. Valid annotation can have at most one `/` in it. According to Kubernetes docs: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set

**User facing changes (remove if N/A)**
User will have to use now annotation:
```
debug.cloud.google.com/probe-timeouts: skip
```
instead of 
```
debug.cloud.google.com/probe/timeouts: skip
```

Fortunately, nothing should change for users as they weren't able to use this feature now, because of Kubernetes validation, which prevented them from using it

<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
