### PR TITLE
fix: Update PrintNamespacesList to use a YAML parser for multiple manifest files (#9825)

### DIFF
--- a/pkg/skaffold/inspect/namespaces/list.go
+++ b/pkg/skaffold/inspect/namespaces/list.go
@@ -17,12 +17,14 @@ limitations under the License.
 package inspect
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"io"
 	"log"
 	"os"
-	"strings"
 
+	"gopkg.in/yaml.v3"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/kubectl/pkg/scheme"
 
@@ -47,23 +49,39 @@ func PrintNamespacesList(ctx context.Context, out io.Writer, manifestFile string
 		return err
 	}
 
+	// Create a YAML decoder to handle multiple documents.
+	yamlDecoder := yaml.NewDecoder(bytes.NewReader(b))
+
 	// Create a runtime.Decoder from the Codecs field within
 	// k8s.io/client-go that's pre-loaded with the schemas for all
 	// the standard Kubernetes resource types.
-	decoder := scheme.Codecs.UniversalDeserializer()
+	k8sDecoder := scheme.Codecs.UniversalDeserializer()
 
 	resourceToInfoMap := map[string][]resourceInfo{}
-	for _, resourceYAML := range strings.Split(string(b), "---") {
+	for {
+		var value any
+		err := yamlDecoder.Decode(&value)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		valueBytes, err := yaml.Marshal(value)
+		if err != nil {
+			return err
+		}
+
 		// skip empty documents, `Decode` will fail on them
-		if len(resourceYAML) == 0 {
+		if len(valueBytes) == 0 {
 			continue
 		}
 		// - obj is the API object (e.g., Deployment)
 		// - groupVersionKind is a generic object that allows
 		//   detecting the API type we are dealing with, for
 		//   accurate type casting later.
-		obj, groupVersionKind, err := decoder.Decode(
-			[]byte(resourceYAML),
+		obj, groupVersionKind, err := k8sDecoder.Decode(
+			valueBytes,
 			nil,
 			nil)
 		if err != nil {
@@ -93,7 +111,10 @@ func PrintNamespacesList(ctx context.Context, out io.Writer, manifestFile string
 		PropagateProfiles:   opts.PropagateProfiles,
 	})
 	if err != nil {
-		formatter.WriteErr(err)
+		fmtErr := formatter.WriteErr(err)
+		if fmtErr != nil {
+			log.Print(fmtErr)
+		}
 		return err
 	}
 


### PR DESCRIPTION
* Update PrintNamespacesList to break on YAML file separator '---' followed by a new line.

* fix: Update PrintNamespacesList to break on YAML file separator '---' followed by a new line.

* fix: update yaml line break character and add more tests

* fix: use yaml parser to process multiple files

* fix: add test for single manifest w break at end

* fix: remove unnecessary conversion

* fix: update import

* fix: if resourceToInfoMap is empty, return nil

* fix: format

* fix: log fmt write error and update empty manifest (with just ---) handling

* fix: format

* fix: fix imports

* fix: add test case