### PR TITLE
fix(helm): implement ordered cleanup for Helm releases based on dependency levels

### DIFF
--- a/pkg/skaffold/deploy/helm/helm_test.go
+++ b/pkg/skaffold/deploy/helm/helm_test.go
@@ -98,6 +98,11 @@ var testDeployPreservingOrderWithDependsOnConfig = latest.LegacyHelmDeploy{
 	 * level 1: B, D
 	 * level 2: A, E
 	 */
+	/** Expected order of deletion:
+	 * level 2: A, E
+	 * level 1: B, D
+	 * level 0: C, F
+	 */
 	Releases: []latest.HelmRelease{{
 		Name:      "A",
 		ChartPath: "examples/test",
@@ -1299,6 +1304,20 @@ func TestHelmCleanup(t *testing.T) {
 				CmdRunWithOutput("helm version", version31).
 				AndRun("helm --kube-context kubecontext delete skaffold-helm --namespace testNamespace --kubeconfig kubeconfig"),
 			helm:      testDeployNamespacedConfig,
+			namespace: kubectl.TestNamespace,
+			builds:    testBuilds,
+		},
+		{
+			description: "helm3 ordered cleanup success",
+			commands: testutil.
+				CmdRunWithOutput("helm version", version31).
+				AndRun("helm --kube-context kubecontext delete A --namespace testNamespace --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext delete E --namespace testNamespace --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext delete B --namespace testNamespace --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext delete D --namespace testNamespace --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext delete C --namespace testNamespace --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext delete F --namespace testNamespace --kubeconfig kubeconfig"),
+			helm:      testDeployPreservingOrderWithDependsOnConfig,
 			namespace: kubectl.TestNamespace,
 			builds:    testBuilds,
 		},


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #9837 <!-- tracking issues that this PR will close -->
**Related**: #7284 
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Respect the dependency graph between helm releases during clean up. Levels of the graph are cleaned on reverse order compared to installation. Releases in the same level are cleaned up in reverse order too.

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->
*Before*
Releases are undeployed in the order they are mentioned in Config.
```
^CCleaning up...
release "postgres-operator" uninstalled
release "postgres" uninstalled
```
*After*
Releases are undeployed in the reverse order they were deployed, respecting the `dependsOn` values.
```
^CCleaning up...
release "postgres" uninstalled
release "postgres-operator" uninstalled
```