### PR TITLE
chore: fix the scorecard-action

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@v2.4.2
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
The `v2` tag doesn't exist, so use a specific version (and rely on dependabot to upgrade it).
-->
