### PR TITLE
Implement remote chart

### DIFF
--- a/docs-v2/content/en/docs/deployers/helm.md
+++ b/docs-v2/content/en/docs/deployers/helm.md
@@ -298,3 +298,48 @@ The `helm` type offers the following options:
 Each `release` includes the following fields:
 
 {{< schema root="HelmRelease" >}}
+
+## Using values files from remote Helm charts (NEW)
+
+Skaffold now supports using values files that are co-located inside remote Helm charts (e.g., charts from OCI registries or remote repositories).
+
+### How to use
+
+In your `skaffold.yaml`, specify a values file from inside the remote chart using the special `:chart:` prefix:
+
+```yaml
+deploy:
+  helm:
+    releases:
+      - name: my-remote-release
+        remoteChart: oci://harbor.example.com/myrepo/mychart
+        version: 1.2.3
+        valuesFiles:
+          - ":chart:values-prod.yaml"   # This will extract values-prod.yaml from the remote chart
+```
+
+- The `:chart:` prefix tells Skaffold to pull the remote chart, extract the specified file, and use it as a values file override.
+- You can use this for any file that exists in the root of the chart archive (e.g., `values-prod.yaml`, `values-staging.yaml`, etc).
+- You can mix local and remote values files in the list.
+
+### Example
+
+Suppose your remote chart contains both `values.yaml` and `values-prod.yaml`. To use the production values:
+
+```yaml
+deploy:
+  helm:
+    releases:
+      - name: my-remote-release
+        remoteChart: oci://harbor.example.com/myrepo/mychart
+        version: 1.2.3
+        valuesFiles:
+          - ":chart:values-prod.yaml"
+```
+
+### Limitations
+- The `:chart:` syntax only works for remote charts (using `remoteChart`).
+- The file must exist in the root of the chart archive.
+- Skaffold will pull the chart and extract the file to a temporary location for each deploy.
+
+---

--- a/pkg/skaffold/helm/util.go
+++ b/pkg/skaffold/helm/util.go
@@ -188,7 +188,8 @@ func PullAndExtractChartFile(chartRef, version, fileInChart string) (string, fun
 			return "", nil, err
 		}
 		// Chart files are inside a top-level dir, e.g. united/values-prod.yaml
-		if filepath.Base(hdr.Name) == fileInChart {
+pathParts := strings.Split(filepath.ToSlash(hdr.Name), "/")
+if hdr.Typeflag == tar.TypeReg && len(pathParts) == 2 && pathParts[1] == fileInChart {
 			extractedPath = filepath.Join(tmpDir, fileInChart)
 			outFile, err := os.Create(extractedPath)
 			if err != nil {

--- a/pkg/skaffold/helm/util.go
+++ b/pkg/skaffold/helm/util.go
@@ -17,9 +17,14 @@ limitations under the License.
 package helm
 
 import (
+	"archive/tar"
+	"compress/gzip"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
+	"os/exec"
+	"path/filepath"
 
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/latest"
@@ -118,4 +123,87 @@ func ReleaseNamespace(namespace string, release latest.HelmRelease) (string, err
 		return namespace, nil
 	}
 	return "", nil
+}
+
+// PullAndExtractChartFile pulls a remote Helm chart and extracts a file from it (e.g., values-prod.yaml).
+// chartRef: the remote chart reference (e.g., oci://...)
+// version: the chart version
+// fileInChart: the file to extract (e.g., values-prod.yaml)
+// Returns the path to the extracted file, and a cleanup function.
+func PullAndExtractChartFile(chartRef, version, fileInChart string) (string, func(), error) {
+	tmpDir, err := os.MkdirTemp("", "skaffold-helm-pull-*")
+	if err != nil {
+		return "", nil, err
+	}
+	success := false
+	cleanup := func() { os.RemoveAll(tmpDir) }
+	defer func() {
+		if !success {
+			cleanup()
+		}
+	}()
+
+	// Pull the chart
+	pullArgs := []string{"pull", chartRef, "--version", version, "--destination", tmpDir}
+	cmd := exec.Command("helm", pullArgs...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return "", nil, fmt.Errorf("failed to pull chart: %v\n%s", err, string(out))
+	}
+
+	// Find the .tgz file
+	var tgzPath string
+	dirEntries, err := os.ReadDir(tmpDir)
+	if err != nil {
+		return "", nil, err
+	}
+	for _, entry := range dirEntries {
+		if filepath.Ext(entry.Name()) == ".tgz" {
+			tgzPath = filepath.Join(tmpDir, entry.Name())
+			break
+		}
+	}
+	if tgzPath == "" {
+		return "", nil, fmt.Errorf("no chart archive found after helm pull")
+	}
+
+	// Extract the requested file
+	tgzFile, err := os.Open(tgzPath)
+	if err != nil {
+		return "", nil, err
+	}
+	defer tgzFile.Close()
+	gzReader, err := gzip.NewReader(tgzFile)
+	if err != nil {
+		return "", nil, err
+	}
+	tarReader := tar.NewReader(gzReader)
+
+	var extractedPath string
+	for {
+		hdr, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return "", nil, err
+		}
+		// Chart files are inside a top-level dir, e.g. united/values-prod.yaml
+		if filepath.Base(hdr.Name) == fileInChart {
+			extractedPath = filepath.Join(tmpDir, fileInChart)
+			outFile, err := os.Create(extractedPath)
+			if err != nil {
+				return "", nil, err
+			}
+			defer outFile.Close()
+			if _, err := io.Copy(outFile, tarReader); err != nil {
+				return "", nil, err
+			}
+			break
+		}
+	}
+	if extractedPath == "" {
+		return "", nil, fmt.Errorf("file %s not found in chart", fileInChart)
+	}
+	success = true
+	return extractedPath, cleanup, nil
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #nnn <!-- tracking issues that this PR will close -->
**Related**: _N/A_
**Merge before/after**: _N/A_

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
This PR adds support for using values files that are co-located inside remote Helm charts (such as those from OCI registries or remote repositories) in Skaffold.  
- Users can now specify a values file from a remote chart using the special `:chart:` prefix in the `valuesFiles` list.
- Skaffold will pull the remote chart, extract the specified file, and use it as a values file override during deployment.
- Documentation has been updated to describe the new feature, usage, and limitations.

**User facing changes**
<!-- Describe any user facing changes this PR introduces. -->
**Before:**
- Users could only use local values files with remote Helm charts.
- It was not possible to reference additional values files (e.g., `values-prod.yaml`) that exist only inside the remote chart.

**After:**
- Users can specify `:chart:values-prod.yaml` in `valuesFiles` to use a values file from inside the remote chart.
- Example:
  ```yaml
  deploy:
    helm:
      releases:
        - name: my-remote-release
          remoteChart: oci://harbor.example.com/myrepo/mychart
          version: 1.2.3
          valuesFiles:
            - ":chart:values-prod.yaml"
  ```
- Skaffold will automatically pull the chart, extract the file, and use it for deployment.

**Documentation**
- The Helm deployer documentation (`docs-v2/content/en/docs/deployers/helm.md`) has been updated with usage instructions, an example, and limitations for the new feature.

**Follow-up Work**
<!-- Mention any related follow up work to this PR. -->
- Add integration tests for this feature (if not already present).
- Consider supporting subdirectories or more advanced file selection in the future.

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->