### PR TITLE
Fix target in digest tagger generation #9826

### DIFF
--- a/pkg/skaffold/tag/input_digest.go
+++ b/pkg/skaffold/tag/input_digest.go
@@ -59,10 +59,16 @@ func (t *inputDigestTagger) GenerateTag(ctx context.Context, image latest.Artifa
 
 	if image.DockerArtifact != nil {
 		srcFiles = append(srcFiles, image.DockerArtifact.DockerfilePath)
+		if image.DockerArtifact.Target != "" {
+			inputs = append(inputs, image.DockerArtifact.Target)
+		}
 	}
 
 	if image.KanikoArtifact != nil {
 		srcFiles = append(srcFiles, image.KanikoArtifact.DockerfilePath)
+		if image.KanikoArtifact.Target != "" {
+			inputs = append(inputs, image.KanikoArtifact.Target)
+		}
 	}
 
 	if image.CustomArtifact != nil && image.CustomArtifact.Dependencies != nil && image.CustomArtifact.Dependencies.Dockerfile != nil {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #9826 <!-- tracking issues that this PR will close -->

**Description**

Honor target in input digest tagger: add the target to the input list so it affects the final hash.

Unit test were included (different targets and no target)

**User facing changes**

Tags will change if using input digest and target (if empty, same tag will be generated)


