### PR TITLE
chore: pin the Windows unit tests to Windows 2022.

### DIFF
--- a/.github/workflows/unit-tests-windows.yml
+++ b/.github/workflows/unit-tests-windows.yml
@@ -13,7 +13,7 @@ jobs:
 
   build:
     name: PR unit tests (windows)
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
 
     - name: Check out code into the Go module directory


### PR DESCRIPTION
At some point `windows-latest` changed to be Windows Server 2025. This broke one of our tests: `TestNewEnvClient/ssh`. Certainly we need to figure out why it doesn't work on Windows Server 2025, but for now let's punt that down the road by pinning to Windows Server 2022.
