### PR TITLE
chore: tell dependabot to ignore the examples directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
     # Security updates have their own PR limit, so setting this to 0 will only
     # allow security updates through.
     open-pull-requests-limit: 0
+    exclude-paths:
+      - examples
+      - integration/examples
 
   # check for updates to github actions
   - directory: "/"


### PR DESCRIPTION
[Finally!](https://github.blog/changelog/2025-08-26-dependabot-can-now-exclude-automatic-pull-requests-for-manifests-in-selected-subdirectories/)
