### PR TITLE
fix: streamline repo cloning logic in gitutil.go

### DIFF
--- a/pkg/skaffold/git/gitutil.go
+++ b/pkg/skaffold/git/gitutil.go
@@ -125,6 +125,10 @@ func syncRepo(ctx context.Context, g Config, opts config.SkaffoldOptions) (strin
 			return "", SyncDisabledErr(g, repoCacheDir)
 		}
 		if _, err := r.Run(ctx, "clone", g.RepoCloneURI, fmt.Sprintf("./%s", hash), "--branch", ref, "--depth", "1"); err != nil {
+			// Remove partially created directory before attempting full clone
+			if rmErr := os.RemoveAll(repoCacheDir); rmErr != nil {
+				return "", fmt.Errorf("failed to remove partially created repo directory: %w", rmErr)
+			}
 			if _, err := r.Run(ctx, "clone", g.RepoCloneURI, fmt.Sprintf("./%s", hash)); err != nil {
 				return "", fmt.Errorf("failed to clone repo: %w", err)
 			}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: https://github.com/GoogleContainerTools/skaffold/issues/9878

**Description**
Fixed error handling to properly fall back from branch-based cloning to commit SHA fetching when needed.
Previously, the code parsed error messages to determine fallback behavior, which is fragile and can break if git changes its error messages
