### PR TITLE
fix(kustomize): Updated generator support for both EnvSources and FileSources using [{key}=]{path} syntax

### DIFF
--- a/pkg/skaffold/deploy/kubectl/kustomize_test.go
+++ b/pkg/skaffold/deploy/kubectl/kustomize_test.go
@@ -361,6 +361,16 @@ func TestDependenciesForKustomization(t *testing.T) {
 			expected: []string{"kustomization.yaml", "secret1.env", "secret1.file", "secret2.env", "secret2.file", "secret3.env", "secret3.file"},
 		},
 		{
+			description: "configMapGenerator & secretGenerator listing file sources with alternative keys",
+			kustomizations: map[string]string{"kustomization.yaml": `configMapGenerator:
+- name: config-sample
+  files: [app.properties=app.local.properties]
+secretGenerator:
+- name: secret-sample
+  files: [secrets.json=secrets.local.json]`},
+			expected: []string{"app.local.properties", "kustomization.yaml", "secrets.local.json"},
+		},
+		{
 			description:    "base exists locally",
 			kustomizations: map[string]string{"kustomization.yaml": `bases: [base]`},
 			expected:       []string{"base/app.yaml", "base/kustomization.yaml", "kustomization.yaml"},

--- a/pkg/skaffold/render/renderer/kustomize/fs.go
+++ b/pkg/skaffold/render/renderer/kustomize/fs.go
@@ -62,7 +62,7 @@ func (f TmpFSReal) GetPath(path string) (string, error) {
 }
 
 func (f TmpFSReal) validate(path string) error {
-	if path != f.root && !strings.HasPrefix(path, f.root+"/") {
+	if path != f.root && !strings.HasPrefix(path, f.root+string(filepath.Separator)) {
 		return fmt.Errorf("temporary file system operation is out of boundary, root: %s, trying to access %s", f.root, path)
 	}
 	return nil

--- a/pkg/skaffold/render/renderer/kustomize/kustomize.go
+++ b/pkg/skaffold/render/renderer/kustomize/kustomize.go
@@ -479,6 +479,27 @@ func kustomizeDependencies(workdir string, paths []string) ([]string, error) {
 	return deps.ToList(), nil
 }
 
+// getGeneratorSources collects file paths from the FileSources, EnvSources, and
+// EnvSource fields of a kustomize ConfigMap or Secret generator into a flat list
+// of source paths. Entries in FileSources may use the [{key}=]{path} syntax, in
+// which case only the path portion is extracted.
+func getGeneratorSources(fileSources, envSources []string, envSource string) []string {
+	var sources []string
+	for _, f := range fileSources {
+		// Entries from FileSources can take the form: [{key}=]{path}
+		if _, path, found := strings.Cut(f, "="); found {
+			f = path
+		}
+		sources = append(sources, f)
+	}
+
+	sources = append(sources, envSources...)
+	if envSource != "" {
+		sources = append(sources, envSource)
+	}
+	return sources
+}
+
 // DependenciesForKustomization finds common kustomize artifacts relative to the
 // provided working dir, and collects them into a list of files to be passed
 // to the file watcher.
@@ -553,46 +574,12 @@ func DependenciesForKustomization(dir string) ([]string, error) {
 	}
 
 	for _, generator := range content.ConfigMapGenerator {
-		var sources []string
-
-		if generator.FileSources != nil {
-			for _, f := range generator.FileSources {
-				// Entries from FileSources can take the form: [{key}=]{path}
-				i := strings.IndexRune(f, '=')
-				if i > -1 {
-					f = f[i+1:]
-				}
-				sources = append(sources, f)
-			}
-		}
-
-		sources = append(sources, generator.EnvSources...)
-		if generator.EnvSource != "" {
-			sources = append(sources, generator.EnvSource)
-		}
-
+		sources := getGeneratorSources(generator.FileSources, generator.EnvSources, generator.EnvSource)
 		deps = append(deps, sUtil.AbsolutePaths(dir, sources)...)
 	}
 
 	for _, generator := range content.SecretGenerator {
-		var sources []string
-
-		if generator.FileSources != nil {
-			for _, f := range generator.FileSources {
-				// Entries from FileSources can take the form: [{key}=]{path}
-				i := strings.IndexRune(f, '=')
-				if i > -1 {
-					f = f[i+1:]
-				}
-				sources = append(sources, f)
-			}
-		}
-
-		sources = append(sources, generator.EnvSources...)
-		if generator.EnvSource != "" {
-			sources = append(sources, generator.EnvSource)
-		}
-
+		sources := getGeneratorSources(generator.FileSources, generator.EnvSources, generator.EnvSource)
 		deps = append(deps, sUtil.AbsolutePaths(dir, sources)...)
 	}
 

--- a/pkg/skaffold/render/renderer/kustomize/kustomize_test.go
+++ b/pkg/skaffold/render/renderer/kustomize/kustomize_test.go
@@ -17,8 +17,11 @@ limitations under the License.
 package kustomize
 
 import (
+	"slices"
 	"testing"
 
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/render"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/v2/testutil"
 )
 
@@ -83,6 +86,108 @@ func TestBuildCommandArgs(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			args := kustomizeBuildArgs(test.buildArgs, test.kustomizePath)
 			t.CheckDeepEqual(test.expectedArgs, args)
+		})
+	}
+}
+
+func TestMirror(t *testing.T) {
+	tests := []struct {
+		description string
+		shouldErr   bool
+		createFiles map[string]string
+		touchFiles  []string
+	}{
+		{
+			description: "mirror configmap and secret generators using env files, regular files, and regular files with keys",
+			shouldErr:   false,
+			createFiles: map[string]string{
+				"kustomization.yaml": `configMapGenerator:
+  - name: app-env
+    envs:
+      - configmaps/app-env/app.env
+  - name: app-config
+    files:
+      - credentials.pub=configmaps/app-config/credentials.local.pub
+      - configmaps/app-config/setup.json
+
+secretGenerator:
+  - name: app-env-secrets
+    envs:
+      - secrets/app-env-secrets/secrets.env
+  - name: app-config-secrets
+    files:
+      - credentials.key=secrets/app-config-secrets/credentials.local.key
+      - secrets/app-config-secrets/eyesonly.txt
+`},
+			touchFiles: []string{
+				"configmaps/app-env/app.env",
+				"configmaps/app-config/credentials.local.pub",
+				"configmaps/app-config/setup.json",
+				"secrets/app-env-secrets/secrets.env",
+				"secrets/app-config-secrets/credentials.local.key",
+				"secrets/app-config-secrets/eyesonly.txt",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			// Create the file structure required for the test
+			sourceDir := t.NewTempDir()
+
+			for path, contents := range test.createFiles {
+				sourceDir.Write(path, contents)
+			}
+
+			sourceDir.Touch(test.touchFiles...)
+
+			// Create the instance to test
+			mockCfg := render.MockConfig{
+				WorkingDir: sourceDir.Root(),
+			}
+
+			rc := latest.RenderConfig{
+				Generate: latest.Generate{
+					Kustomize: &latest.Kustomize{
+						Paths: []string{sourceDir.Root()},
+					},
+				},
+			}
+
+			k, err := New(mockCfg, rc, map[string]string{}, "default", "", nil, false)
+			t.CheckNoError(err)
+
+			// Test the mirror function on a temporary workspace
+			targetDir := t.NewTempDir()
+			fs := newTmpFS(targetDir.Root())
+			defer fs.Cleanup()
+
+			t_err := k.mirror(sourceDir.Root(), fs)
+
+			// Gather a list of the expected files
+			expectedFiles, err := sourceDir.List()
+			t.CheckNoError(err)
+
+			slices.Sort(expectedFiles)
+
+			// Gather a list of files that have been created by the mirror function
+			targetFileList, err := targetDir.List()
+			t.CheckNoError(err)
+
+			minPrefixLen := len(targetDir.Root()) + len(sourceDir.Root())
+			prefixLen := len(targetDir.Root())
+
+			var mirroredFiles []string
+			for _, f := range targetFileList {
+				if len(f) >= minPrefixLen {
+					mirroredFiles = append(mirroredFiles, f[prefixLen:])
+				}
+			}
+
+			slices.Sort(mirroredFiles)
+
+			// Validate test results
+			t.CheckErrorAndDeepEqual(test.shouldErr, t_err, expectedFiles, mirroredFiles)
 		})
 	}
 }


### PR DESCRIPTION
**Fixes**: #9338
**Related**: n/a
**Merge before/after**: n/a

**Description**
When using kustomize during the render stage, if files must be mirrored before rendering because they require modifications (when using --set flags, for example), files defined in the `env` section of `configMapGenerator` and `secretGenerator` are omitted, and thus the render ends up failing because it cannot find all the required filed.

The error message in that case is similar to this:
```
running [kustomize build /var/folders/dy/qslwfy7n0jz3wp1gjxs3m32h0000gp/T/4251885249/Users/foobar/src/test/skaffold-set-issue/src/foobar/kustomize/overlays/issue1]
 - stdout: ""
 - stderr: "Error: loading KV pairs: env source files: [local.env]: evalsymlink failure on '/private/var/folders/dy/qslwfy7n0jz3wp1gjxs3m32h0000gp/T/4251885249/Users/foobar/src/test/skaffold-set-issue/src/foobar/kustomize/overlays/issue1/local.env' : lstat /private/var/folders/dy/qslwfy7n0jz3wp1gjxs3m32h0000gp/T/4251885249/Users/foobar/src/test/skaffold-set-issue/src/foobar/kustomize/overlays/issue1/local.env: no such file or directory\n"
 - cause: exit status 1
```

Moreover, both on the previous situation and when using skaffold in dev mode (using the `skaffold dev` command), files defined in the `files` section of the `configMapGenerator` and `secretGenerator` that make use of the `[{key}=]{path}` syntax aren't properly recognized and the files neither won't be copied when mirroring or watched upon for changes in dev mode.

The error message visible during the render stage is similar to this:
```
open /Users/foobar/src/test/skaffold-set-issue/src/foobar/kustomize/overlays/issue2/application.yaml=application-foobar.yaml: no such file or directory
```

An example of the `[{key}=]{path}` syntax can be seen in the second example from [kustomize's reference documentation](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/configmapgenerator/#configmap-from-file)).

This PR adds additional test cases for the situations described above and the required fixes.