### PR TITLE
Draft: Use a pipeline to load images into kind

### DIFF
--- a/pkg/skaffold/deploy/component/kubernetes/component.go
+++ b/pkg/skaffold/deploy/component/kubernetes/component.go
@@ -84,7 +84,7 @@ func newDebugger(mode config.RunMode, podSelector kubernetes.PodSelector, namesp
 
 func newImageLoader(cfg k8sloader.Config, cli *kubectl.CLI) loader.ImageLoader {
 	if cfg.LoadImages() {
-		return k8sloader.NewImageLoader(cfg.GetKubeContext(), cli)
+		return k8sloader.NewImageLoader(cfg, cli)
 	}
 	return &loader.NoopImageLoader{}
 }

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -92,6 +92,7 @@ type LocalDaemon interface {
 	Push(ctx context.Context, out io.Writer, ref string) (string, error)
 	Pull(ctx context.Context, out io.Writer, ref string, platform v1.Platform) error
 	Load(ctx context.Context, out io.Writer, input io.Reader, ref string) (string, error)
+	Save(ctx context.Context, out io.Writer, ref string) (io.ReadCloser, error)
 	Run(ctx context.Context, out io.Writer, opts ContainerCreateOpts) (<-chan container.WaitResponse, <-chan error, string, error)
 	Delete(ctx context.Context, out io.Writer, id string) error
 	Tag(ctx context.Context, image, ref string) error
@@ -541,6 +542,11 @@ func (l *localDaemon) Load(ctx context.Context, out io.Writer, input io.Reader, 
 	}
 
 	return l.ImageID(ctx, ref)
+}
+
+// Save saves an image to a tar file. Returns a ReadCloser for the tar file.
+func (l *localDaemon) Save(ctx context.Context, out io.Writer, ref string) (io.ReadCloser, error) {
+	return l.apiClient.ImageSave(ctx, []string{ref})
 }
 
 // Tag adds a tag to an image.


### PR DESCRIPTION
This fixes the issue when kind runs in podman instead of docker

See: https://github.com/kubernetes-sigs/kind/issues/2038
Fixes: #9901

**Description**
Because `kind load docker-image`  doesn't work if kind is running with podman and the image to load is created with podman as well, the concept to load the image has to be changed. This problem is described in https://github.com/kubernetes-sigs/kind/issues/2038. An "easy fix" for this is to save the image with the corresponding container engine as a docker-image to stdout and pass it to `kind image-load /dev/stdin`. By using `localDocker` like the builder does, podman can be selected by setting `DOCKER_HOST` to a podman-socket.

This implementation is more like a proof of concept than anything else. As everyone easily can see, I'm not a go-developer ;-)

This was tested as in "works on my machine". My machine at the moment:
* Fedora 34
* podman 5.6.2
* `systemctl`s `--user podman.socket` is enabled and started
* `DOCKER_HOST=unix:///var/run/user/$(id -u)/podman/podman.sock`
* kind 0.30.0
* kubectl v1.28.15
* cluster version v1.34.0
* application used for testing: https://gitlab.com/biletado/backend/go/-/tree/feature/skaffold

**User facing changes (remove if N/A)**
If implemented correctly, nothing changes for docker users

**Follow-up Work (remove if N/A)**
Do a real implementation ;-)


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
