### PR TITLE
feat: process Helm chart versions as templates while skaffold render

### DIFF
--- a/pkg/skaffold/render/renderer/helm/helm.go
+++ b/pkg/skaffold/render/renderer/helm/helm.go
@@ -178,15 +178,17 @@ func (h Helm) generateHelmManifest(ctx context.Context, builds []graph.Artifact,
 		return nil, helm.UserErr(fmt.Sprintf("cannot expand release name %q", release.Name), err)
 	}
 
-	release.ChartPath, err = sUtil.ExpandEnvTemplateOrFail(release.ChartPath, nil)
+	chartPath, err := sUtil.ExpandEnvTemplateOrFail(release.ChartPath, nil)
 	if err != nil {
 		return nil, helm.UserErr(fmt.Sprintf("cannot expand chart path %q", release.ChartPath), err)
 	}
+	release.ChartPath = chartPath
 
-	release.Version, err = sUtil.ExpandEnvTemplateOrFail(release.Version, nil)
+	version, err := sUtil.ExpandEnvTemplateOrFail(release.Version, nil)
 	if err != nil {
 		return nil, helm.UserErr(fmt.Sprintf("cannot expand chart version %q", release.Version), err)
 	}
+	release.Version = version
 
 	namespace, err := helm.ReleaseNamespace(h.namespace, release)
 	if err != nil {


### PR DESCRIPTION
Fixes: #9937 

**Description**

Skaffold render should support extracting Helm chart versions from environment variables to maintain consistency with skaffold deploy.

**Tests**

Tested with the below configuration:

```yaml
apiVersion: skaffold/v4beta12
kind: Config
metadata:
  name: istio-release
deploy:
  helm:
    releases:
    - name: istiod
      namespace: istio-release
      createNamespace: true
      remoteChart: oci://gcr.io/istio-release/charts/istiod
      version: "{{.ISTIO_VERSION}}"
      wait: true
``` 
Now we are able to extract the version of Helm chart from environment variables

```bash
export ISTIO_VERSION=1.28.0
./skaffold render
```
