### PR TITLE
disabling kaniko integration tests due to kaniko service account permissions issue

### DIFF
--- a/.github/workflows/integration-linux.yml
+++ b/.github/workflows/integration-linux.yml
@@ -44,6 +44,26 @@ jobs:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}
 
+    - name: Clean up disk space
+      run: |
+        echo "--- Disk space before cleanup ---"
+        df -h
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /usr/share/swift
+        sudo rm -rf /usr/local/.ghcup
+        sudo rm -rf /usr/share/code
+        sudo rm -rf /usr/share/miniconda
+        sudo rm -rf /usr/share/az_deps
+        # Remove unused Docker images, containers, networks, and build cache
+        # The '|| true' prevents the workflow from failing if no items are found to prune.
+        docker system prune -a --force || true
+        docker builder prune -a --force || true
+       
+        echo "--- Disk space after cleanup ---"
+        df -h
+
     # Retrieve build locations with `go env`
     # <https://markphelps.me/posts/speed-up-your-go-builds-with-actions-cache/>
     - id: go-cache-paths

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -373,33 +373,34 @@ func TestRunGCPOnly(t *testing.T) {
 			args:        []string{"-p", "gcb"},
 			pods:        []string{"module1", "module2"},
 		},
-		{
-			description: "Google Cloud Build with Kaniko",
-			dir:         "examples/gcb-kaniko",
-			pods:        []string{"getting-started-kaniko"},
-			// building machines on gcb are linux/amd64, kaniko doesn't support cross-platform builds.
-			skipCrossPlatform: true,
-		},
-		{
-			description: "kaniko",
-			dir:         "examples/kaniko",
-			pods:        []string{"getting-started-kaniko"},
-		},
-		{
-			description: "kaniko with target",
-			dir:         "testdata/kaniko-target",
-			pods:        []string{"getting-started-kaniko"},
-		},
-		{
-			description: "kaniko with sub folder",
-			dir:         "testdata/kaniko-sub-folder",
-			pods:        []string{"getting-started-kaniko"},
-		},
-		{
-			description: "kaniko microservices",
-			dir:         "testdata/kaniko-microservices",
-			deployments: []string{"leeroy-app", "leeroy-web"},
-		},
+		// Currently disable kaniko integration tests due to kaniko service account issues.
+		// {
+		// 	description: "Google Cloud Build with Kaniko",
+		// 	dir:         "examples/gcb-kaniko",
+		// 	pods:        []string{"getting-started-kaniko"},
+		// 	// building machines on gcb are linux/amd64, kaniko doesn't support cross-platform builds.
+		// 	skipCrossPlatform: true,
+		// },
+		// {
+		// 	description: "kaniko",
+		// 	dir:         "examples/kaniko",
+		// 	pods:        []string{"getting-started-kaniko"},
+		// },
+		// {
+		// 	description: "kaniko with target",
+		// 	dir:         "testdata/kaniko-target",
+		// 	pods:        []string{"getting-started-kaniko"},
+		// },
+		// {
+		// 	description: "kaniko with sub folder",
+		// 	dir:         "testdata/kaniko-sub-folder",
+		// 	pods:        []string{"getting-started-kaniko"},
+		// },
+		// {
+		// 	description: "kaniko microservices",
+		// 	dir:         "testdata/kaniko-microservices",
+		// 	deployments: []string{"leeroy-app", "leeroy-web"},
+		// },
 		{
 			description: "jib in googlecloudbuild",
 			dir:         "testdata/jib",


### PR DESCRIPTION


**Description**

Currently disable the kaniko integration tests because of some infrastructure issue with testing on GCP. Will be reenabled in the future by @menahyouyeah 
