### PR TITLE
fix: Exit initializer analysis on context cancel

### DIFF
--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -114,7 +114,7 @@ func withFallbackConfig(ctx context.Context, out io.Writer, opts config.Skaffold
 	if errors.As(err, &e) && e.StatusCode() == proto.StatusCode_CONFIG_FILE_NOT_FOUND_ERR {
 		if (opts.AutoCreateConfig || opts.AutoInit) && initializer.ValidCmd(opts) {
 			output.Default.Fprintf(out, "Skaffold config file %s not found - Trying to create one for you...\n", opts.ConfigurationFile)
-			config, err := initializer.Transparent(context.Background(), out, initConfig.Config{Opts: opts, EnableManifestGeneration: opts.AutoInit})
+			config, err := initializer.Transparent(ctx, out, initConfig.Config{Opts: opts, EnableManifestGeneration: opts.AutoInit})
 			if err != nil {
 				return nil, fmt.Errorf("unable to generate skaffold config file automatically - try running `skaffold init`: %w", err)
 			}

--- a/pkg/skaffold/initializer/analyze/analyze_test.go
+++ b/pkg/skaffold/initializer/analyze/analyze_test.go
@@ -388,7 +388,7 @@ deploy:
 			t.Override(&jib.Validate, fakeValidateJibConfig)
 
 			a := NewAnalyzer(test.config)
-			err := a.Analyze(".")
+			err := a.Analyze(t.Context(), ".")
 
 			t.CheckError(test.shouldErr, err)
 			if test.shouldErr {

--- a/pkg/skaffold/initializer/helm_test.go
+++ b/pkg/skaffold/initializer/helm_test.go
@@ -107,7 +107,7 @@ spec:
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.NewTempDir().WriteFiles(test.filesWithContents).Chdir()
 			a := analyze.NewAnalyzer(config)
-			err := a.Analyze(".")
+			err := a.Analyze(t.Context(), ".")
 			t.CheckError(test.shouldErr, err)
 			d := deploy.NewInitializer(a.HelmChartInfo(), config)
 			dc := d.DeployConfig()

--- a/pkg/skaffold/initializer/init.go
+++ b/pkg/skaffold/initializer/init.go
@@ -41,7 +41,7 @@ func DoInit(ctx context.Context, out io.Writer, c config.Config) error {
 		}
 	}
 
-	a, err := AnalyzeProject(c)
+	a, err := AnalyzeProject(ctx, c)
 	if err != nil {
 		return err
 	}
@@ -57,9 +57,9 @@ func DoInit(ctx context.Context, out io.Writer, c config.Config) error {
 }
 
 // AnalyzeProject scans the project directory for files and keeps track of what types of files it finds (builders, k8s manifests, etc.).
-func AnalyzeProject(c config.Config) (*analyze.ProjectAnalysis, error) {
+func AnalyzeProject(ctx context.Context, c config.Config) (*analyze.ProjectAnalysis, error) {
 	a := analyze.NewAnalyzer(c)
-	if err := a.Analyze("."); err != nil {
+	if err := a.Analyze(ctx, "."); err != nil {
 		return nil, err
 	}
 	return a, nil

--- a/pkg/skaffold/initializer/transparent.go
+++ b/pkg/skaffold/initializer/transparent.go
@@ -42,7 +42,7 @@ func Transparent(ctx context.Context, out io.Writer, c initConfig.Config) (*late
 		}
 	}
 
-	a, err := AnalyzeProject(c)
+	a, err := AnalyzeProject(ctx, c)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->

Running skaffold init in a directory with a large number of files can take an extremely long time as it crawls and analyzes all subdirectories. The use of `context.Background()` means that it is not derived from the top-level context, and signals (e.g. the user pressing CTRL-C) cannot cancel the operation.

This has caused issues for me when accidentally running e.g. `skaffold dev` in the wrong directory, which falls back to `init`.

I've added in a `context.Context` param where appropriate in the `initializer` package, and checked `ctx.Err()` when iterating over analyzers in order to exit out early.

This has required some changes to some public parts of the `initializer` package. If that's a problem, separate functions like `AnalyzeWithContext` function could be added instead.

**User facing changes**
<!-- Describe any user facing changes this PR introduces. -->

Before: pressing CTRL-C `skaffold init` does nothing, as the parent context is not connected to the analysis context.  

```
$ time ~/pkg/skaffold/skaffold dev
Skaffold config file skaffold.yaml not found - Trying to create one for you...
^C^C^C^C^C^C^C^C^C^C^C^Cunable to generate skaffold config file automatically - try running `skaffold init`: one or more valid build configuration must be present to build images with Skaffold; please provide at least one build config and try again, or run `skaffold init --skip-build`

real	0m4.638s
user	0m4.690s
sys	0m1.285s
```

After: pressing CTRL-C during `skaffold init` immediately terminates the operation.
```
λ time ~/pkg/skaffold/skaffold dev
Skaffold config file skaffold.yaml not found - Trying to create one for you...
^C
real	0m0.826s
user	0m1.006s
sys	0m0.272s
```


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
