### PR TITLE
fix(helm): Make Helm 4 plugin version a semver string

### DIFF
--- a/pkg/skaffold/helm/bin.go
+++ b/pkg/skaffold/helm/bin.go
@@ -58,7 +58,7 @@ var Helm4PostRendererVersion = semver.MustParse("4.0.0-beta.1")
 
 const PostRendererTemplate = `
 name: "%s"
-version: "0.1"
+version: "0.1.0"
 type: postrenderer/v1
 apiVersion: v1
 runtime: subprocess


### PR DESCRIPTION
Fixes: https://github.com/GoogleContainerTools/skaffold/issues/10046

**Description**

The value must now be semver (breaking change). The value is still required, so I couldn't just remove it. This change works for an older Helm v4.x and for the latest v4.1.4.