### PR TITLE
fix: add --set and --set-value-file flag support to delete command and unit tests

### DIFF
--- a/cmd/skaffold/app/cmd/delete_test.go
+++ b/cmd/skaffold/app/cmd/delete_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/v2/testutil"
+)
+
+func TestNewCmdDelete(t *testing.T) {
+	testutil.Run(t, "", func(t *testutil.T) {
+		t.NewTempDir().Chdir()
+		t.Override(&opts, config.SkaffoldOptions{})
+		t.Override(&dryRun, false)
+
+		cmd := NewCmdDelete()
+		cmd.SilenceUsage = true
+
+		// Check that the command accepts the --set flag and it's correctly bound
+		err := cmd.Flags().Parse([]string{"--set", "key1=val1", "--set", "key2=val2"})
+		t.CheckNoError(err)
+		t.CheckDeepEqual([]string{"key1=val1", "key2=val2"}, opts.ManifestsOverrides)
+
+		// Check that the command accepts the --set-value-file flag and it's correctly bound
+		err = cmd.Flags().Parse([]string{"--set-value-file", "values.env"})
+		t.CheckNoError(err)
+		t.CheckDeepEqual("values.env", opts.ManifestsValueFile)
+
+		// Check that the command accepts the --dry-run flag and it's correctly bound
+		err = cmd.Flags().Parse([]string{"--dry-run"})
+		t.CheckNoError(err)
+		t.CheckTrue(dryRun)
+	})
+}

--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -761,7 +761,7 @@ The build result from a previous 'skaffold build --file-output' run can be used 
 		Value:         &opts.ManifestsOverrides,
 		DefValue:      []string{},
 		FlagAddMethod: "StringSliceVar",
-		DefinedOn:     []string{"render", "filter"},
+		DefinedOn:     []string{"render", "filter", "delete"},
 	},
 	{
 		Name:          "set-value-file",
@@ -769,7 +769,7 @@ The build result from a previous 'skaffold build --file-output' run can be used 
 		Value:         &opts.ManifestsValueFile,
 		DefValue:      "",
 		FlagAddMethod: "StringVar",
-		DefinedOn:     []string{"render"},
+		DefinedOn:     []string{"render", "delete"},
 	},
 	{
 		Name: "status-check-selectors",

--- a/docs-v2/content/en/docs/references/cli/_index.md
+++ b/docs-v2/content/en/docs/references/cli/_index.md
@@ -838,6 +838,12 @@ Options:
     --remote-cache-dir='':
 	Specify the location of the remote cache (default $HOME/.skaffold/remote-cache)
 
+    --set=[]:
+	overrides templated manifest fields by provided key-value pairs
+
+    --set-value-file='':
+	overrides templated manifest fields by a file containing key-value pairs in .env file format
+
     --sync-remote-cache='always':
 	Controls how Skaffold manages the remote config cache (see `remote-cache-dir`). One of `always` (default), `missing`, or `never`. `always` syncs remote repositories to latest on access. `missing` only clones remote repositories if they do not exist locally. `never` means the user takes responsibility for updating remote repositories.
 
@@ -866,6 +872,8 @@ Env vars:
 * `SKAFFOLD_PROFILE_AUTO_ACTIVATION` (same as `--profile-auto-activation`)
 * `SKAFFOLD_PROPAGATE_PROFILES` (same as `--propagate-profiles`)
 * `SKAFFOLD_REMOTE_CACHE_DIR` (same as `--remote-cache-dir`)
+* `SKAFFOLD_SET` (same as `--set`)
+* `SKAFFOLD_SET_VALUE_FILE` (same as `--set-value-file`)
 * `SKAFFOLD_SYNC_REMOTE_CACHE` (same as `--sync-remote-cache`)
 
 ### skaffold deploy


### PR DESCRIPTION
**Description**
This PR adds support for the `--set` and `--set-value-file` flag to the `skaffold delete` command, allowing users to override templated manifest fields with key-value pairs during deletion operations.

Fixes #10053 

**Changes made:**
1. Updated `cmd/skaffold/app/cmd/flags.go` line 764 to include "delete" in the `DefinedOn` list for the "set" and "set-value-file" flags
2. Created `cmd/skaffold/app/cmd/delete_test.go` with unit tests to verify that the delete command accepts `--set`, `--set-value-file` and `--dry-run` flags
3. Verified the built skaffold binary correctly accepts the `--set` and `--set-value-file` flag for the delete command

**User facing changes**
Users can now use the `--set` and `--set-value-file` flags with `skaffold delete` to override templated manifest fields:

**Before:** `skaffold delete` did not accept `--set` or `--set-value-file` flags
**After:** `skaffold delete --set key=value --set set-value-file=file` is now supported

This allows for more flexible deletion operations when working with templated manifests.

**Testing**
- Added unit test `TestNewCmdDelete` in `delete_test.go` that verifies both `--set`, `--set-value-file` and `--dry-run` flags are available
- All existing tests pass
- All linters pass