### PR TITLE
fix(cloudrun): tail logs from all services concurrently

### DIFF
--- a/pkg/skaffold/deploy/cloudrun/log.go
+++ b/pkg/skaffold/deploy/cloudrun/log.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -149,6 +150,7 @@ func (r *runLogTailer) Start(ctx context.Context, out io.Writer) error {
 	if r.resources.resources == nil {
 		return nil
 	}
+	syncOut := &syncWriter{w: out}
 	go func() {
 		for _, resource := range r.resources.resources {
 			if !resource.isTailing {
@@ -157,23 +159,28 @@ func (r *runLogTailer) Start(ctx context.Context, out io.Writer) error {
 				cmd.Env = os.Environ()
 				// gcloud uses buffered stream by default
 				cmd.Env = append(cmd.Env, "PYTHONUNBUFFERED=1") // gcloud defaults streaming output as buffered
-				r, w := io.Pipe()
-				cmd.Stderr = w
-				cmd.Stdout = w
+				pr, pw := io.Pipe()
+				cmd.Stderr = pw
+				cmd.Stdout = pw
 				resource.cancel = cancel
 				if err := cmd.Start(); err != nil {
-					output.Red.Fprintf(out, "failed to start log streaming on service %s\n", resource.name.Service)
+					output.Red.Fprintf(syncOut, "failed to start log streaming on service %s\n", resource.name.Service)
+					pw.Close()
+					continue
 				}
-				if err := streamLog(ctx, out, r, resource.formatter); err != nil {
-					output.Red.Fprintf(out, "log streaming failed: %s\n", err)
-				}
-				go func() {
-					if err := cmd.Wait(); err != nil {
-						output.Red.Fprintf(out, "terminated\n")
-					}
-				}()
 				resource.isTailing = true
 				resource.cmd = cmd
+				go func(res *logTailerResource) {
+					if err := streamLog(ctx, syncOut, pr, res.formatter); err != nil {
+						output.Red.Fprintf(syncOut, "log streaming failed: %s\n", err)
+					}
+				}(resource)
+				go func() {
+					defer pw.Close()
+					if err := cmd.Wait(); err != nil {
+						output.Red.Fprintf(syncOut, "terminated\n")
+					}
+				}()
 			}
 		}
 	}()
@@ -216,6 +223,19 @@ func (r *runLogTailer) Stop() {
 			resource.cmd = nil
 		}
 	}
+}
+
+// syncWriter wraps an io.Writer with a mutex to prevent interleaved output
+// from concurrent log streaming goroutines.
+type syncWriter struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+func (sw *syncWriter) Write(p []byte) (n int, err error) {
+	sw.mu.Lock()
+	defer sw.mu.Unlock()
+	return sw.w.Write(p)
 }
 
 func getGcloudTailArgs(resource RunResourceName) []string {

--- a/pkg/skaffold/deploy/cloudrun/log_test.go
+++ b/pkg/skaffold/deploy/cloudrun/log_test.go
@@ -20,6 +20,9 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"io"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/config"
@@ -245,5 +248,59 @@ func TestGcloudFoundLogTailing(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestStreamLogMultipleServicesConcurrently(t *testing.T) {
+	// Verifies that streamLog can process multiple pipes concurrently.
+	// This is a regression test for the bug where streamLog was called
+	// inline (blocking) inside the for-loop, causing only one service
+	// to be tailed.
+	var buf bytes.Buffer
+	safeOut := &syncWriter{w: &buf}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pr1, pw1 := io.Pipe()
+	pr2, pw2 := io.Pipe()
+
+	formatter1 := LogFormatter{prefix: "svc-a", outputColor: output.DefaultColorCodes[0]}
+	formatter2 := LogFormatter{prefix: "svc-b", outputColor: output.DefaultColorCodes[1]}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		streamLog(ctx, safeOut, pr1, formatter1)
+	}()
+	go func() {
+		defer wg.Done()
+		streamLog(ctx, safeOut, pr2, formatter2)
+	}()
+
+	// Write log lines to both pipes
+	io.WriteString(pw1, "hello from a\n")
+	io.WriteString(pw2, "hello from b\n")
+
+	// Close pipes to signal EOF so streamLog returns
+	pw1.Close()
+	pw2.Close()
+	wg.Wait()
+
+	result := buf.String()
+
+	if !strings.Contains(result, "svc-a") {
+		t.Errorf("expected output to contain svc-a prefix, got: %s", result)
+	}
+	if !strings.Contains(result, "svc-b") {
+		t.Errorf("expected output to contain svc-b prefix, got: %s", result)
+	}
+	if !strings.Contains(result, "hello from a") {
+		t.Errorf("expected output to contain 'hello from a', got: %s", result)
+	}
+	if !strings.Contains(result, "hello from b") {
+		t.Errorf("expected output to contain 'hello from b', got: %s", result)
 	}
 }


### PR DESCRIPTION
## Summary

Fix Cloud Run `--tail` log streaming to show logs from **all** deployed services concurrently, instead of only one randomly selected service.

Fixes https://github.com/GoogleContainerTools/skaffold/issues/10057

## Problem

When running `skaffold run --tail` with multiple Cloud Run services, only one service's logs were displayed. The service appeared to be chosen randomly on each run.

**Root cause:** `streamLog()` was called inline (blocking) inside the for-loop that iterates over resources. Since `streamLog()` runs an infinite read loop, the loop never advanced past the first resource. Go's randomized map iteration order made it appear random.

**Kubernetes deployments are not affected** — the K8s `LogAggregator` already uses `go a.streamContainerLogs(...)` per container.

## Changes

- **`pkg/skaffold/deploy/cloudrun/log.go`**: Move `streamLog()` into its own goroutine per resource so the for-loop continues immediately to start all services. Also renamed `r, w := io.Pipe()` to `pr, pw` to fix variable shadowing of the method receiver.
- **`pkg/skaffold/deploy/cloudrun/log_test.go`**: Added `TestStreamLogMultipleServicesConcurrently` regression test that verifies multiple concurrent `streamLog` calls both produce output.

## Testing

- All existing `cloudrun` package tests pass
- Manually tested with two cloud run services

```
Starting deploy...
Deploying Cloud Run service:
         goodbye-func-main
Deploying Cloud Run service:
         hello-func-main
goodbye-func-main: Service starting: Provisioning revision instances to receive traffic.
hello-func-main: Service starting: Provisioning revision instances to receive traffic.
Cloud Run Service goodbye-func-main finished: Service started. 1/2 deployment(s) still pending
Cloud Run Service hello-func-main finished: Service started. 0/2 deployment(s) still pending
Forwarding service projects/REDACTED/locations/us-east1/services/goodbye-func-main to local port 8080
Forwarding service projects/REDACTED/locations/us-east1/services/hello-func-main to local port 8081
Press Ctrl+C to exit
Proxying to Cloud Run service [hello-func-main] in project [REDACTED] region [us-east1]
http://127.0.0.1:8081/ proxies to https://hello-func-main-REDACTED-ue.a.run.app/
Proxying to Cloud Run service [goodbye-func-main] in project [REDACTED] region [us-east1]
http://127.0.0.1:8080/ proxies to https://goodbye-func-main-REDACTED-ue.a.run.app/
[hello-func-main] streaming logs from REDACTED
[goodbye-func-main] streaming logs from REDACTED
[hello-func-main] 2026-04-21 22:39:59 GET 200 https://hello-func-main-REDACTED-ue.a.run.app/
[goodbye-func-main] 2026-04-21 22:40:08 GET 200 https://goodbye-func-main-REDACTED-ue.a.run.app/
```
