### PR TITLE
confine GCS downloads to destination root

### DIFF
--- a/pkg/skaffold/gcs/client/native.go
+++ b/pkg/skaffold/gcs/client/native.go
@@ -79,7 +79,10 @@ func (n *Native) DownloadRecursive(ctx context.Context, src, dst string) error {
 	}
 
 	for uri, localPath := range files {
-		fullPath := filepath.Join(dst, localPath)
+		fullPath, err := resolveDestinationPath(dst, localPath)
+		if err != nil {
+			return err
+		}
 		dir := filepath.Dir(fullPath)
 		if _, err := os.Stat(dir); os.IsNotExist(err) {
 			if err := os.MkdirAll(dir, os.ModePerm); err != nil {
@@ -93,6 +96,34 @@ func (n *Native) DownloadRecursive(ctx context.Context, src, dst string) error {
 	}
 
 	return nil
+}
+
+func resolveDestinationPath(dst, localPath string) (string, error) {
+	normalizedLocalPath := filepath.Clean(filepath.FromSlash(localPath))
+	if filepath.IsAbs(normalizedLocalPath) {
+		return "", fmt.Errorf("gcs object path %q escapes destination root %q", localPath, dst)
+	}
+
+	joinedPath := filepath.Clean(filepath.Join(dst, localPath))
+	dstRoot, err := filepath.Abs(dst)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve destination root: %w", err)
+	}
+
+	fullPath, err := filepath.Abs(joinedPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve destination path: %w", err)
+	}
+
+	relPath, err := filepath.Rel(dstRoot, fullPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to compare destination path: %w", err)
+	}
+	if relPath == ".." || strings.HasPrefix(relPath, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("gcs object path %q escapes destination root %q", localPath, dst)
+	}
+
+	return joinedPath, nil
 }
 
 // Uploads a single file to the given dst.

--- a/pkg/skaffold/gcs/client/native_test.go
+++ b/pkg/skaffold/gcs/client/native_test.go
@@ -39,6 +39,12 @@ type repoHandlerMock struct {
 	uploadedFile    string
 }
 
+type listedObjectBucketHandler struct {
+	listedObjects    []string
+	downloadedFiles  map[string]string
+	downloadAttempts int
+}
+
 func (r *repoHandlerMock) filterOnlyFiles(paths []string) ([]string, error) {
 	matches := []string{}
 	for _, m := range paths {
@@ -99,6 +105,25 @@ func (r *repoHandlerMock) UploadObject(ctx context.Context, objName string, cont
 }
 
 func (r *repoHandlerMock) Close() {}
+
+func (l *listedObjectBucketHandler) ListObjects(ctx context.Context, q *storage.Query) ([]string, error) {
+	return l.listedObjects, nil
+}
+
+func (l *listedObjectBucketHandler) DownloadObject(ctx context.Context, localPath, uri string) error {
+	if l.downloadedFiles == nil {
+		l.downloadedFiles = map[string]string{}
+	}
+	l.downloadAttempts++
+	l.downloadedFiles[uri] = localPath
+	return nil
+}
+
+func (l *listedObjectBucketHandler) UploadObject(ctx context.Context, objName string, content *os.File) error {
+	return nil
+}
+
+func (l *listedObjectBucketHandler) Close() {}
 
 func TestDownloadRecursive(t *testing.T) {
 	tests := []struct {
@@ -282,6 +307,83 @@ func TestDownloadRecursive(t *testing.T) {
 			}
 
 			t.CheckMapsMatch(test.expectedDownloadedFiles, rh.downloadedFiles)
+		})
+	}
+}
+
+func TestDownloadRecursiveRejectsEscapingPaths(t *testing.T) {
+	tests := []struct {
+		name        string
+		listedFiles []string
+		dst         string
+	}{
+		{
+			name:        "rejects traversal in object path",
+			listedFiles: []string{"prefix/../../.kube/config"},
+			dst:         "download",
+		},
+		{
+			name:        "rejects absolute object path",
+			listedFiles: []string{"/tmp/owned"},
+			dst:         "download",
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.name, func(t *testutil.T) {
+			bucket := &listedObjectBucketHandler{
+				listedObjects: test.listedFiles,
+			}
+			t.Override(&GetBucketManager, func(ctx context.Context, bucketName string) (bucketHandler, error) {
+				return bucket, nil
+			})
+
+			n := Native{}
+			err := n.DownloadRecursive(context.TODO(), "gs://bucket/prefix", test.dst)
+			t.CheckErrorContains("escapes destination root", err)
+			t.CheckDeepEqual(0, bucket.downloadAttempts)
+		})
+	}
+}
+
+func TestResolveDestinationPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		dst         string
+		localPath   string
+		wantErr     bool
+		expectedEnd string
+	}{
+		{
+			name:        "preserves nested path within root",
+			dst:         "download",
+			localPath:   "dir/manifest.yaml",
+			expectedEnd: filepath.Join("download", "dir", "manifest.yaml"),
+		},
+		{
+			name:      "rejects traversal segment",
+			dst:       "download",
+			localPath: "../manifest.yaml",
+			wantErr:   true,
+		},
+		{
+			name:      "rejects absolute path",
+			dst:       "download",
+			localPath: filepath.Join(string(filepath.Separator), "tmp", "manifest.yaml"),
+			wantErr:   true,
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.name, func(t *testutil.T) {
+			fullPath, err := resolveDestinationPath(test.dst, test.localPath)
+			if test.wantErr {
+				t.CheckErrorContains("escapes destination root", err)
+				return
+			}
+
+			t.CheckNoError(err)
+			t.CheckDeepEqual(filepath.Clean(test.expectedEnd), fullPath)
 		})
 	}
 }


### PR DESCRIPTION
## what changed

- validate each resolved GCS download target before creating parent directories or writing files
- reject cleaned object paths that are absolute or that escape the requested destination root
- add regression coverage for traversal-style object names and absolute-path object names

## why

`Native.DownloadRecursive` derives local download targets from remote object names. before this change, the code joined `dst` with the derived path and wrote the result without checking that the cleaned destination still stayed under `dst`.

that meant a crafted object name could resolve outside the intended download root. this patch keeps the existing relative-path behavior for valid objects, but adds an explicit confinement check before any filesystem write.

## impact

valid downloads keep their current layout. object names that resolve outside the requested destination root now fail fast instead of creating directories or writing files in unexpected locations.

## validation

- `go test ./pkg/skaffold/gcs/client`
- `go test -run 'TestResolveDestinationPath|TestDownloadRecursiveRejectsEscapingPaths' -v ./pkg/skaffold/gcs/client`
