### PR TITLE
feat: thread --set/--set-value-file through deploy/dev/run/exec/verify and inject deploy params into action + verify containers

### DIFF
--- a/cmd/skaffold/app/cmd/deploy_params_flags_test.go
+++ b/cmd/skaffold/app/cmd/deploy_params_flags_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2026 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/v2/testutil"
+)
+
+// TestDeployParamsFlagsAvailable verifies that --set and --set-value-file
+// are registered on every command through which deploy parameters can flow:
+// render, delete (pre-existing) + deploy, dev, run, exec, verify (added for
+// Cloud Deploy custom-target / verify parity).
+//
+// Note: the filter command also accepts --set but not --set-value-file, so
+// it is intentionally excluded from this check.
+func TestDeployParamsFlagsAvailable(t *testing.T) {
+	cases := []struct {
+		name string
+		ctor func() *cobra.Command
+	}{
+		{name: "render", ctor: NewCmdRender},
+		{name: "delete", ctor: NewCmdDelete},
+		{name: "deploy", ctor: NewCmdDeploy},
+		{name: "dev", ctor: NewCmdDev},
+		{name: "run", ctor: NewCmdRun},
+		{name: "exec", ctor: NewCmdExec},
+		{name: "verify", ctor: NewCmdVerify},
+	}
+
+	for _, tc := range cases {
+		testutil.Run(t, tc.name, func(t *testutil.T) {
+			t.NewTempDir().Chdir()
+			t.Override(&opts, config.SkaffoldOptions{})
+
+			cmd := tc.ctor()
+			cmd.SilenceUsage = true
+
+			t.CheckTrue(cmd.Flags().Lookup("set") != nil)
+			t.CheckTrue(cmd.Flags().Lookup("set-value-file") != nil)
+		})
+	}
+}
+
+// TestDeployParamsFlagsBindToOpts verifies the flag values bind through to
+// opts.ManifestsOverrides / opts.ManifestsValueFile on the newly added
+// commands, mirroring the existing TestNewCmdDelete coverage.
+func TestDeployParamsFlagsBindToOpts(t *testing.T) {
+	cases := []struct {
+		name string
+		ctor func() *cobra.Command
+	}{
+		{name: "deploy", ctor: NewCmdDeploy},
+		{name: "dev", ctor: NewCmdDev},
+		{name: "run", ctor: NewCmdRun},
+		{name: "exec", ctor: NewCmdExec},
+		{name: "verify", ctor: NewCmdVerify},
+	}
+
+	for _, tc := range cases {
+		testutil.Run(t, tc.name, func(t *testutil.T) {
+			t.NewTempDir().Chdir()
+			t.Override(&opts, config.SkaffoldOptions{})
+
+			cmd := tc.ctor()
+			cmd.SilenceUsage = true
+
+			err := cmd.Flags().Parse([]string{"--set", "key1=val1", "--set", "key2=val2"})
+			t.CheckNoError(err)
+			t.CheckDeepEqual([]string{"key1=val1", "key2=val2"}, opts.ManifestsOverrides)
+
+			err = cmd.Flags().Parse([]string{"--set-value-file", "values.env"})
+			t.CheckNoError(err)
+			t.CheckDeepEqual("values.env", opts.ManifestsValueFile)
+		})
+	}
+}

--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -757,19 +757,19 @@ The build result from a previous 'skaffold build --file-output' run can be used 
 	},
 	{
 		Name:          "set",
-		Usage:         "overrides templated manifest fields by provided key-value pairs",
+		Usage:         "overrides templated manifest fields by provided key-value pairs; on `exec`/`verify`, entries are also injected as environment variables into the custom action / verify containers",
 		Value:         &opts.ManifestsOverrides,
 		DefValue:      []string{},
 		FlagAddMethod: "StringSliceVar",
-		DefinedOn:     []string{"render", "filter", "delete"},
+		DefinedOn:     []string{"render", "filter", "delete", "deploy", "dev", "run", "exec", "verify"},
 	},
 	{
 		Name:          "set-value-file",
-		Usage:         "overrides templated manifest fields by a file containing key-value pairs in .env file format",
+		Usage:         "overrides templated manifest fields by a file containing key-value pairs in .env file format; on `exec`/`verify`, entries are also injected as environment variables into the custom action / verify containers",
 		Value:         &opts.ManifestsValueFile,
 		DefValue:      "",
 		FlagAddMethod: "StringVar",
-		DefinedOn:     []string{"render", "delete"},
+		DefinedOn:     []string{"render", "delete", "deploy", "dev", "run", "exec", "verify"},
 	},
 	{
 		Name: "status-check-selectors",

--- a/docs-v2/content/en/docs/custom-actions.md
+++ b/docs-v2/content/en/docs/custom-actions.md
@@ -28,7 +28,7 @@ $ skaffold exec update-infra
 Starting execution for update-infra
 ...
 [setup-external-proxy] updating proxy version...
-[setup-external-proxy] copying proxy rules...   
+[setup-external-proxy] copying proxy rules...
 [setup-external-proxy] starting proxy...
 [update-db-schema] starting db update...
 [update-db-schema] db schema update completed
@@ -135,7 +135,7 @@ The template can be extended using the [`customActions[].executionMode.kubernete
 
 ## Skaffold build + exec
 
-Custom Actions can be used together with [Skaffold build]({{< relref "docs/builders/" >}}) so the Custom Actions can use images build by Skaffold. 
+Custom Actions can be used together with [Skaffold build]({{< relref "docs/builders/" >}}) so the Custom Actions can use images build by Skaffold.
 
 Using the following `skaffold.yaml` file:
 
@@ -155,3 +155,36 @@ $ skaffold exec update-infra --build-artifacts=build.json
 
 That way, Skaffold will be able to run the `local-db-updater` image in the `update-infra` Custom Action.
 
+## Passing deploy parameters
+
+Custom Actions can receive **deploy parameters** as environment variables in every container of the invoked action. This mirrors [Google Cloud Deploy: pass parameters to your deployments](https://docs.cloud.google.com/deploy/docs/parameters), where deploy parameters are surfaced into Cloud Deploy execution environment (render, verify, actions/tasks).
+
+Provide values on the command line with `--set` (repeatable) or in an `.env`-style file via `--set-value-file`:
+
+```console
+$ skaffold exec terraform-apply \
+    --set TF_VAR_bucket=my-bkt \
+    --set TF_VAR_region=us-central1 \
+    --set-value-file infra.env
+```
+
+Inside every container of the invoked action, the values become environment variables:
+
+```console
+$ echo "$TF_VAR_bucket"
+my-bkt
+```
+
+### Precedence
+
+When the same key is supplied from multiple sources, later entries override earlier ones:
+
+1. The base env map (e.g. `--env-file` contents).
+2. Entries from `--set-value-file`.
+3. Entries from `--set` (highest priority).
+
+On key collision between a deploy parameter and a container-declared `env:` entry in `skaffold.yaml`, the deploy parameter wins, matching Cloud Deploy behaviour.
+
+### Availability across commands
+
+The `--set` and `--set-value-file` flags are available on `render`, `delete`, `deploy`, `dev`, `run`, `exec`, and `verify`. The `--set` flag is also available on `filter`. On the render/deploy commands the values flow into manifest templating; on `exec` they additionally become container environment variables for the invoked action, and on `verify` they become container environment variables for the verify test containers (see [Verify]({{< relref "/docs/verify" >}})).

--- a/docs-v2/content/en/docs/references/cli/_index.md
+++ b/docs-v2/content/en/docs/references/cli/_index.md
@@ -838,10 +838,10 @@ Options:
 	Specify the location of the remote cache (default $HOME/.skaffold/remote-cache)
 
     --set=[]:
-	overrides templated manifest fields by provided key-value pairs
+	overrides templated manifest fields by provided key-value pairs; on `exec`/`verify`, entries are also injected as environment variables into the custom action / verify containers
 
     --set-value-file='':
-	overrides templated manifest fields by a file containing key-value pairs in .env file format
+	overrides templated manifest fields by a file containing key-value pairs in .env file format; on `exec`/`verify`, entries are also injected as environment variables into the custom action / verify containers
 
     --sync-remote-cache='always':
 	Controls how Skaffold manages the remote config cache (see `remote-cache-dir`). One of `always` (default), `missing`, or `never`. `always` syncs remote repositories to latest on access. `missing` only clones remote repositories if they do not exist locally. `never` means the user takes responsibility for updating remote repositories.
@@ -980,6 +980,12 @@ Options:
     --rpc-port=:
 	tcp port to expose the Skaffold API over gRPC
 
+    --set=[]:
+	overrides templated manifest fields by provided key-value pairs; on `exec`/`verify`, entries are also injected as environment variables into the custom action / verify containers
+
+    --set-value-file='':
+	overrides templated manifest fields by a file containing key-value pairs in .env file format; on `exec`/`verify`, entries are also injected as environment variables into the custom action / verify containers
+
     --status-check=:
 	Wait for deployed resources to stabilize
 
@@ -1051,6 +1057,8 @@ Env vars:
 * `SKAFFOLD_RESOURCE_SELECTOR_RULES_FILE` (same as `--resource-selector-rules-file`)
 * `SKAFFOLD_RPC_HTTP_PORT` (same as `--rpc-http-port`)
 * `SKAFFOLD_RPC_PORT` (same as `--rpc-port`)
+* `SKAFFOLD_SET` (same as `--set`)
+* `SKAFFOLD_SET_VALUE_FILE` (same as `--set-value-file`)
 * `SKAFFOLD_STATUS_CHECK` (same as `--status-check`)
 * `SKAFFOLD_STATUS_CHECK_SELECTORS` (same as `--status-check-selectors`)
 * `SKAFFOLD_SYNC_REMOTE_CACHE` (same as `--sync-remote-cache`)
@@ -1197,6 +1205,12 @@ Options:
     --rpc-port=:
 	tcp port to expose the Skaffold API over gRPC
 
+    --set=[]:
+	overrides templated manifest fields by provided key-value pairs; on `exec`/`verify`, entries are also injected as environment variables into the custom action / verify containers
+
+    --set-value-file='':
+	overrides templated manifest fields by a file containing key-value pairs in .env file format; on `exec`/`verify`, entries are also injected as environment variables into the custom action / verify containers
+
     --skip-tests=false:
 	Whether to skip the tests after building
 
@@ -1293,6 +1307,8 @@ Env vars:
 * `SKAFFOLD_RESOURCE_SELECTOR_RULES_FILE` (same as `--resource-selector-rules-file`)
 * `SKAFFOLD_RPC_HTTP_PORT` (same as `--rpc-http-port`)
 * `SKAFFOLD_RPC_PORT` (same as `--rpc-port`)
+* `SKAFFOLD_SET` (same as `--set`)
+* `SKAFFOLD_SET_VALUE_FILE` (same as `--set-value-file`)
 * `SKAFFOLD_SKIP_TESTS` (same as `--skip-tests`)
 * `SKAFFOLD_STATUS_CHECK` (same as `--status-check`)
 * `SKAFFOLD_STATUS_CHECK_SELECTORS` (same as `--status-check-selectors`)
@@ -1445,6 +1461,12 @@ Options:
     --rpc-port=:
 	tcp port to expose the Skaffold API over gRPC
 
+    --set=[]:
+	overrides templated manifest fields by provided key-value pairs; on `exec`/`verify`, entries are also injected as environment variables into the custom action / verify containers
+
+    --set-value-file='':
+	overrides templated manifest fields by a file containing key-value pairs in .env file format; on `exec`/`verify`, entries are also injected as environment variables into the custom action / verify containers
+
     --sync-remote-cache='always':
 	Controls how Skaffold manages the remote config cache (see `remote-cache-dir`). One of `always` (default), `missing`, or `never`. `always` syncs remote repositories to latest on access. `missing` only clones remote repositories if they do not exist locally. `never` means the user takes responsibility for updating remote repositories.
 
@@ -1472,6 +1494,8 @@ Env vars:
 * `SKAFFOLD_REMOTE_CACHE_DIR` (same as `--remote-cache-dir`)
 * `SKAFFOLD_RPC_HTTP_PORT` (same as `--rpc-http-port`)
 * `SKAFFOLD_RPC_PORT` (same as `--rpc-port`)
+* `SKAFFOLD_SET` (same as `--set`)
+* `SKAFFOLD_SET_VALUE_FILE` (same as `--set-value-file`)
 * `SKAFFOLD_SYNC_REMOTE_CACHE` (same as `--sync-remote-cache`)
 
 ### skaffold fix
@@ -1713,10 +1737,10 @@ Options:
 	Path to JSON file specifying the deny list of yaml objects for skaffold to NOT transform with 'image' and 'label' field replacements.  NOTE: this list is additive to skaffold's default denylist and denylist has priority over allowlist
 
     --set=[]:
-	overrides templated manifest fields by provided key-value pairs
+	overrides templated manifest fields by provided key-value pairs; on `exec`/`verify`, entries are also injected as environment variables into the custom action / verify containers
 
     --set-value-file='':
-	overrides templated manifest fields by a file containing key-value pairs in .env file format
+	overrides templated manifest fields by a file containing key-value pairs in .env file format; on `exec`/`verify`, entries are also injected as environment variables into the custom action / verify containers
 
     --sync-remote-cache='always':
 	Controls how Skaffold manages the remote config cache (see `remote-cache-dir`). One of `always` (default), `missing`, or `never`. `always` syncs remote repositories to latest on access. `missing` only clones remote repositories if they do not exist locally. `never` means the user takes responsibility for updating remote repositories.
@@ -1895,6 +1919,12 @@ Options:
     --rpc-port=:
 	tcp port to expose the Skaffold API over gRPC
 
+    --set=[]:
+	overrides templated manifest fields by provided key-value pairs; on `exec`/`verify`, entries are also injected as environment variables into the custom action / verify containers
+
+    --set-value-file='':
+	overrides templated manifest fields by a file containing key-value pairs in .env file format; on `exec`/`verify`, entries are also injected as environment variables into the custom action / verify containers
+
     --skip-tests=false:
 	Whether to skip the tests after building
 
@@ -1979,6 +2009,8 @@ Env vars:
 * `SKAFFOLD_RESOURCE_SELECTOR_RULES_FILE` (same as `--resource-selector-rules-file`)
 * `SKAFFOLD_RPC_HTTP_PORT` (same as `--rpc-http-port`)
 * `SKAFFOLD_RPC_PORT` (same as `--rpc-port`)
+* `SKAFFOLD_SET` (same as `--set`)
+* `SKAFFOLD_SET_VALUE_FILE` (same as `--set-value-file`)
 * `SKAFFOLD_SKIP_TESTS` (same as `--skip-tests`)
 * `SKAFFOLD_STATUS_CHECK` (same as `--status-check`)
 * `SKAFFOLD_STATUS_CHECK_SELECTORS` (same as `--status-check-selectors`)
@@ -2164,6 +2196,12 @@ Options:
     --rpc-port=:
 	tcp port to expose the Skaffold API over gRPC
 
+    --set=[]:
+	overrides templated manifest fields by provided key-value pairs; on `exec`/`verify`, entries are also injected as environment variables into the custom action / verify containers
+
+    --set-value-file='':
+	overrides templated manifest fields by a file containing key-value pairs in .env file format; on `exec`/`verify`, entries are also injected as environment variables into the custom action / verify containers
+
     --status-check=:
 	Wait for deployed resources to stabilize
 
@@ -2194,6 +2232,8 @@ Env vars:
 * `SKAFFOLD_REMOTE_CACHE_DIR` (same as `--remote-cache-dir`)
 * `SKAFFOLD_RPC_HTTP_PORT` (same as `--rpc-http-port`)
 * `SKAFFOLD_RPC_PORT` (same as `--rpc-port`)
+* `SKAFFOLD_SET` (same as `--set`)
+* `SKAFFOLD_SET_VALUE_FILE` (same as `--set-value-file`)
 * `SKAFFOLD_STATUS_CHECK` (same as `--status-check`)
 * `SKAFFOLD_SYNC_REMOTE_CACHE` (same as `--sync-remote-cache`)
 

--- a/docs-v2/content/en/docs/verify.md
+++ b/docs-v2/content/en/docs/verify.md
@@ -106,3 +106,18 @@ $ echo $?
 1
 ```
 and `skaffold verify` will exit with error code `1`
+
+## Passing deploy parameters
+
+Verify containers receive **deploy parameters** as environment variables, mirroring
+[Google Cloud Deploy](https://docs.cloud.google.com/deploy/docs/parameters), which
+surfaces values such as the deployed Cloud Run service URL to verify containers.
+Provide them with `--set` (repeatable) or an `.env`-style `--set-value-file`:
+
+```console
+$ skaffold verify --set SERVICE_URL=https://my-service-abc-uc.a.run.app
+```
+
+Precedence (lowest to highest): `--env-file` base < `--set-value-file` < `--set`.
+These flags are also available on `render`, `delete`, `deploy`, `dev`, `run`, and
+`exec`; see [Custom actions]({{< relref "/docs/custom-actions#passing-deploy-parameters" >}}).

--- a/examples/custom-actions-deploy-params/README.md
+++ b/examples/custom-actions-deploy-params/README.md
@@ -1,0 +1,13 @@
+# Custom actions: deploy parameters
+
+`skaffold exec` forwards deploy parameters — values from `--set` or
+`--set-value-file` — as environment variables into every container of the
+invoked custom action, mirroring [Google Cloud Deploy](https://docs.cloud.google.com/deploy/docs/parameters).
+
+```console
+$ skaffold exec show-params --set TF_VAR_bucket=my-bkt --set REGION=us-central1
+```
+
+The `printer` container echoes `TF_VAR_bucket=my-bkt` and `REGION=us-central1`.
+Precedence (lowest to highest): base env / `--env-file` < `--set-value-file` < `--set`.
+On key collision, deploy parameters override a container's own `env:` entry.

--- a/examples/custom-actions-deploy-params/skaffold.yaml
+++ b/examples/custom-actions-deploy-params/skaffold.yaml
@@ -1,0 +1,12 @@
+apiVersion: skaffold/v4beta14
+kind: Config
+metadata:
+  name: deploy-params-demo
+customActions:
+  - name: show-params
+    containers:
+      - name: printer
+        image: busybox
+        command: ["sh", "-c"]
+        args:
+          - 'echo "TF_VAR_bucket=${TF_VAR_bucket}"; echo "REGION=${REGION}"'

--- a/integration/examples/custom-actions-deploy-params/skaffold.yaml
+++ b/integration/examples/custom-actions-deploy-params/skaffold.yaml
@@ -1,0 +1,12 @@
+apiVersion: skaffold/v4beta14
+kind: Config
+metadata:
+  name: deploy-params-demo
+customActions:
+  - name: show-params
+    containers:
+      - name: printer
+        image: busybox
+        command: ["sh", "-c"]
+        args:
+          - 'echo "TF_VAR_bucket=${TF_VAR_bucket}"; echo "REGION=${REGION}"'

--- a/integration/exec_test.go
+++ b/integration/exec_test.go
@@ -33,6 +33,8 @@ func TestExec_LocalActions(t *testing.T) {
 		action       string
 		shouldErr    bool
 		envFile      string
+		setValues    []string
+		setValueFile string
 		expectedMsgs []string
 	}{
 
@@ -67,6 +69,15 @@ func TestExec_LocalActions(t *testing.T) {
 				"[task7] bye-from-env-file",
 			},
 		},
+		{
+			description: "deploy parameters injected as container env vars",
+			action:      "action-deploy-params",
+			setValues:   []string{"DP_STRING=hello", "DP_REGION=us-central1"},
+			expectedMsgs: []string{
+				"[printer] DP_STRING=hello",
+				"[printer] DP_REGION=us-central1",
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -76,6 +87,12 @@ func TestExec_LocalActions(t *testing.T) {
 
 			if test.envFile != "" {
 				args = append(args, "--env-file", test.envFile)
+			}
+			for _, sv := range test.setValues {
+				args = append(args, "--set", sv)
+			}
+			if test.setValueFile != "" {
+				args = append(args, "--set-value-file", test.setValueFile)
 			}
 
 			out, err := skaffold.Exec(args...).InDir("testdata/custom-actions-local").RunWithCombinedOutput(t.T)

--- a/integration/testdata/custom-actions-local/skaffold.yaml
+++ b/integration/testdata/custom-actions-local/skaffold.yaml
@@ -77,3 +77,12 @@ customActions:
         env:
           - name: FOO
             value: from-local-img
+
+  - name: action-deploy-params
+    containers:
+      - name: printer
+        image: alpine:3.15.4
+        command: ["/bin/sh"]
+        args:
+          - "-c"
+          - 'echo "DP_STRING=$DP_STRING" && echo "DP_REGION=$DP_REGION"'

--- a/integration/verify_test.go
+++ b/integration/verify_test.go
@@ -57,6 +57,26 @@ func TestLocalVerifyPassingTestsWithEnvVar(t *testing.T) {
 	// TODO(aaron-prindle) verify that SUCCEEDED event is found where expected
 }
 
+// TestLocalVerifyWithDeployParams asserts that deploy parameters supplied via
+// --set are injected as environment variables into verify containers, matching
+// the Cloud Deploy behaviour of surfacing deploy parameters to verify tasks.
+// The verify-succeed alpine container runs `echo $FOO`; here FOO is provided
+// on the command line rather than through --env-file.
+func TestLocalVerifyWithDeployParams(t *testing.T) {
+	MarkIntegrationTest(t, CanRunWithoutGcp)
+
+	rpcPort := randomPort()
+	// `--default-repo=` is used to cancel the default repo that is set by default.
+	out, err := skaffold.Verify("--default-repo=", "--rpc-port", rpcPort,
+		"--set", "FOO=from-set").InDir("testdata/verify-succeed").RunWithCombinedOutput(t)
+	logs := string(out)
+
+	testutil.CheckError(t, false, err)
+	testutil.CheckContains(t, "from-set", logs)
+	testutil.CheckContains(t, "alpine-1", logs)
+	testutil.CheckContains(t, "alpine-2", logs)
+}
+
 func TestVerifyWithNotCreatedNetwork(t *testing.T) {
 	MarkIntegrationTest(t, CanRunWithoutGcp)
 	// `--default-repo=` is used to cancel the default repo that is set by default.

--- a/pkg/skaffold/runner/actions_deploy_params_test.go
+++ b/pkg/skaffold/runner/actions_deploy_params_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2026 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/actions/docker"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/deploy/label"
+	dockerutil "github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/docker"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/runner/runcontext"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/v2/testutil"
+)
+
+func TestMergeDeployParams(t *testing.T) {
+	tests := []struct {
+		description string
+		base        map[string]string
+		fileContent string // empty means no value file
+		overrides   []string
+		expected    map[string]string
+	}{
+		{
+			description: "no inputs yields nil",
+			expected:    nil,
+		},
+		{
+			description: "base-only is preserved",
+			base:        map[string]string{"A": "1"},
+			expected:    map[string]string{"A": "1"},
+		},
+		{
+			description: "overrides only",
+			overrides:   []string{"FOO=bar", "BAZ=qux"},
+			expected:    map[string]string{"FOO": "bar", "BAZ": "qux"},
+		},
+		{
+			description: "value-file only",
+			fileContent: "KEY=val\nOTHER=thing\n",
+			expected:    map[string]string{"KEY": "val", "OTHER": "thing"},
+		},
+		{
+			description: "overrides shadow value-file which shadow base",
+			base:        map[string]string{"COMMON": "from-base", "ONLY_BASE": "b"},
+			fileContent: "COMMON=from-file\nONLY_FILE=f\n",
+			overrides:   []string{"COMMON=from-override", "ONLY_OVERRIDE=o"},
+			expected: map[string]string{
+				"COMMON":        "from-override",
+				"ONLY_BASE":     "b",
+				"ONLY_FILE":     "f",
+				"ONLY_OVERRIDE": "o",
+			},
+		},
+		{
+			description: "override without = sign is skipped",
+			overrides:   []string{"FOO=bar", "MALFORMED"},
+			expected:    map[string]string{"FOO": "bar"},
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			valueFile := ""
+			if test.fileContent != "" {
+				dir := t.NewTempDir().Root()
+				valueFile = filepath.Join(dir, "values.env")
+				if err := os.WriteFile(valueFile, []byte(test.fileContent), 0o600); err != nil {
+					t.Fatalf("writing temp value file: %v", err)
+				}
+			}
+
+			got, err := mergeDeployParams(test.base, valueFile, test.overrides)
+			t.CheckNoError(err)
+			t.CheckDeepEqual(test.expected, got)
+		})
+	}
+}
+
+func TestMergeDeployParams_ValueFileNotFound(t *testing.T) {
+	testutil.Run(t, "", func(t *testutil.T) {
+		_, err := mergeDeployParams(nil, "/does/not/exist.env", nil)
+		t.CheckError(true, err)
+	})
+}
+
+// TestGetActionsRunner_InjectsDeployParamsIntoExecEnv exercises the end-to-end
+// wiring: --set and --set-value-file values from SkaffoldOptions must reach
+// the docker exec-env constructor as part of its envMap argument, so that
+// downstream container tasks receive them as environment variables.
+func TestGetActionsRunner_InjectsDeployParamsIntoExecEnv(t *testing.T) {
+	testutil.Run(t, "", func(t *testutil.T) {
+		dir := t.NewTempDir().Root()
+		valueFile := filepath.Join(dir, "values.env")
+		if err := os.WriteFile(valueFile, []byte("FROM_FILE=file\nCOMMON=file\n"), 0o600); err != nil {
+			t.Fatalf("writing temp value file: %v", err)
+		}
+
+		runCtx := runcontext.RunContext{
+			Opts: config.SkaffoldOptions{
+				ManifestsOverrides: []string{"FROM_SET=cli", "COMMON=cli"},
+				ManifestsValueFile: valueFile,
+			},
+			Pipelines: runcontext.NewPipelines(map[string]latest.Pipeline{
+				"default": {
+					CustomActions: []latest.Action{{
+						Name: "act",
+						ExecutionModeConfig: latest.ActionExecutionModeConfig{
+							VerifyExecutionModeType: latest.VerifyExecutionModeType{
+								LocalExecutionMode: &latest.LocalVerifier{},
+							},
+						},
+					}},
+				},
+			}, []string{"default"}),
+		}
+
+		var capturedEnv map[string]string
+		t.Override(&docker.NewExecEnv, func(_ context.Context, _ dockerutil.Config, _ *label.DefaultLabeller, _ []*latest.PortForwardResource, _ string, envMap map[string]string, _ []latest.Action) (*docker.ExecEnv, error) {
+			capturedEnv = envMap
+			return &docker.ExecEnv{}, nil
+		})
+
+		_, err := GetActionsRunner(context.TODO(), &runCtx, &label.DefaultLabeller{}, "", "")
+		t.CheckNoError(err)
+
+		t.CheckDeepEqual("file", capturedEnv["FROM_FILE"])
+		t.CheckDeepEqual("cli", capturedEnv["FROM_SET"])
+		// --set overrides --set-value-file on key collision.
+		t.CheckDeepEqual("cli", capturedEnv["COMMON"])
+	})
+}

--- a/pkg/skaffold/runner/actions_runner.go
+++ b/pkg/skaffold/runner/actions_runner.go
@@ -51,6 +51,17 @@ func GetActionsRunner(ctx context.Context, runCtx *runcontext.RunContext, l *lab
 		return nil, err
 	}
 
+	// Merge deploy parameters (--set / --set-value-file) into the env map so
+	// they are injected as environment variables into every container of any
+	// invoked custom action. This mirrors the Cloud Deploy custom-target
+	// behaviour where deploy parameters are surfaced to render and deploy
+	// containers. CLI --set overrides --set-value-file which overrides the
+	// --verify-env-file base.
+	envMap, err = mergeDeployParams(envMap, runCtx.Opts.ManifestsValueFile, runCtx.Opts.ManifestsOverrides)
+	if err != nil {
+		return nil, err
+	}
+
 	return createActionsRunner(ctx, runCtx, l, dockerNetwork, envMap, aCfgs)
 }
 
@@ -119,4 +130,37 @@ func loadEnvMap(envFile string) (map[string]string, error) {
 		return nil, nil
 	}
 	return util.ParseEnvVariablesFromFile(envFile)
+}
+
+// mergeDeployParams overlays deploy parameters coming from --set-value-file
+// and --set onto the provided base env map. Precedence, from lowest to
+// highest: base map (e.g. values from --verify-env-file) < --set-value-file
+// entries < --set entries. A nil base map is treated as empty.
+func mergeDeployParams(base map[string]string, valueFile string, overrides []string) (map[string]string, error) {
+	if valueFile == "" && len(overrides) == 0 {
+		if len(base) == 0 {
+			return nil, nil
+		}
+		return base, nil
+	}
+	out := make(map[string]string, len(base))
+	for k, v := range base {
+		out[k] = v
+	}
+	if valueFile != "" {
+		fileVals, err := util.ParseEnvVariablesFromFile(valueFile)
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range fileVals {
+			out[k] = v
+		}
+	}
+	for k, v := range util.EnvSliceToMap(overrides, "=") {
+		out[k] = v
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
 }

--- a/pkg/skaffold/runner/verifier.go
+++ b/pkg/skaffold/runner/verifier.go
@@ -57,6 +57,16 @@ func GetVerifier(ctx context.Context, runCtx *runcontext.RunContext, labeller *l
 		}
 	}
 
+	// Merge deploy parameters (--set / --set-value-file) into the env map so
+	// they are injected as environment variables into every verify container.
+	// This mirrors the Cloud Deploy behaviour where deploy parameters (e.g. the
+	// Cloud Run service URL) are surfaced to verify containers. CLI --set
+	// overrides --set-value-file which overrides the --env-file base.
+	envMap, err = mergeDeployParams(envMap, runCtx.Opts.ManifestsValueFile, runCtx.Opts.ManifestsOverrides)
+	if err != nil {
+		return nil, err
+	}
+
 	if len(kubernetesTestCases) != 0 {
 		nv, err := k8sjob.NewVerifier(ctx, runCtx, labeller, kubernetesTestCases, runCtx.Artifacts(), envMap, runCtx.GetNamespace())
 		if err != nil {


### PR DESCRIPTION
Fixes #10128

Threads `--set` / `--set-value-file` through `deploy`, `dev`, `run`, `exec`, and `verify`, and injects those key/value pairs as environment variables into every custom-action container (`exec`) and verify container (`verify`). This matches [Google Cloud Deploy](https://docs.cloud.google.com/deploy/docs/parameters), which surfaces deploy parameters — e.g. a Cloud SQL URL or the deployed Cloud Run service URL — to those containers.

## Changes

- **`cmd/skaffold/app/cmd/flags.go`** — expose `--set` / `--set-value-file` on `deploy`/`dev`/`run`/`exec`/`verify`.
- **`pkg/skaffold/runner/actions_runner.go`** — `mergeDeployParams` merges the params into the custom-action exec-env.
- **`pkg/skaffold/runner/verifier.go`** — `GetVerifier` reuses the same helper so verify containers receive them too.
- **Docs** + a runnable `custom-actions-deploy-params` example.

## Precedence

`--env-file` base < `--set-value-file` < `--set` (highest). On key collision with a container's own `env:`, the deploy parameter wins — matching Cloud Deploy.

## Tests

- **Unit**: `mergeDeployParams` precedence/malformed/missing-file, the actions exec-env wiring, and flag presence/binding across all commands.
- **Integration**: `skaffold exec --set` and `skaffold verify --set` reach the container env.
