### PR TITLE
feat: local runArgs whitelist for custom actions and verify (skaffold/v4beta15)

### DIFF
--- a/docs-v2/content/en/docs/custom-actions.md
+++ b/docs-v2/content/en/docs/custom-actions.md
@@ -109,6 +109,45 @@ A Custom Action has an execution mode associated with it that indicates Skaffold
 
 This is the default configuration when no [`customActions[].executionMode`]({{< relref "/docs/references/yaml/#customActions-executionMode" >}}) is specified. With this execution mode, Skaffold will run every container associated to a given Custom Action with a Docker daemon.
 
+##### Passing Docker run flags with `runArgs`
+
+When an action needs to reach host resources (for example your local
+`~/.config/gcloud` credentials, or the host network for GCE/GKE metadata),
+use [`customActions[].executionMode.local.runArgs`]({{< relref
+"/docs/references/yaml/#customActions-executionMode-local-runArgs" >}}).
+Skaffold parses each entry against a conservative whitelist and overlays
+the result on the Docker `HostConfig` used to start the container:
+
+| Flag | Effect |
+| --- | --- |
+| `--network=<mode>` | Sets `HostConfig.NetworkMode`. Accepts `host`, `bridge`, `none`, or a named network. |
+| `-v=<src>:<dst>[:opts]`, `--volume=<src>:<dst>[:opts]` | Appends to `HostConfig.Binds`. |
+| `--add-host=<host>:<ip>` | Appends to `HostConfig.ExtraHosts`. |
+| `--tmpfs=<path>[:opts]` | Merges into `HostConfig.Tmpfs`. |
+
+Only the `--flag=value` form is accepted — space-separated values and
+unknown flags are rejected at load time so typos fail loudly rather
+than silently dropping settings.
+
+```yaml
+customActions:
+  - name: reuse-local-adc
+    executionMode:
+      local:
+        runArgs:
+          - "-v=/root/.config/gcloud:/root/.config/gcloud:ro"
+          - "--network=host"
+    containers:
+      - name: gcloud
+        image: google/cloud-sdk:slim
+        command: ["gcloud"]
+        args: ["auth", "list"]
+```
+
+> **Security note:** `runArgs` hands raw flags to the host Docker daemon.
+> Avoid committing broad bind mounts (`-v=/:/host`) or host-network access
+> to source control unless the action genuinely needs them.
+
 #### Remote (K8s job)
 
 With this execution mode, Skaffold will create a K8s job for each container associated with the given action. For the following configuration:

--- a/docs-v2/content/en/docs/verify.md
+++ b/docs-v2/content/en/docs/verify.md
@@ -21,6 +21,8 @@ You can run post-deployment verification tests in the following execution enviro
 
 When Skaffold runs a post-deployment verifications test in the local execution mode, it uses the `docker` CLI to run the test container on the host machine. This is the default execution mode.
 
+Local verify containers accept the same conservative `runArgs` whitelist as custom actions via [`verify[].executionMode.local.runArgs`]({{< relref "/docs/references/yaml/#verify-executionMode-local-runArgs" >}}) (`--network`, `-v`/`--volume`, `--add-host`, `--tmpfs`). See [Passing Docker run flags with `runArgs`]({{< relref "/docs/custom-actions#passing-docker-run-flags-with-runargs" >}}) for details and the security note.
+
 ### Kubernetes cluster
 
 When Skaffold runs a post-deployment verification test in the Kubernetes cluster execution mode, it uses the `kubectl` CLI to run the test container as a Kubernetes Job.

--- a/integration/examples/custom-actions-runargs/skaffold.yaml
+++ b/integration/examples/custom-actions-runargs/skaffold.yaml
@@ -1,0 +1,29 @@
+apiVersion: skaffold/v4beta15
+kind: Config
+metadata:
+  name: custom-actions-runargs
+
+customActions:
+  - name: extra-host
+    executionMode:
+      local:
+        runArgs:
+          - "--add-host=metadata-server:169.254.169.254"
+          - "--tmpfs=/scratch:size=16m"
+    containers:
+      - name: probe
+        image: alpine:3.20
+        command: ["/bin/sh"]
+        args: ["-c", "grep metadata-server /etc/hosts && touch /scratch/ok && echo scratch-writable"]
+
+  - name: gcloud-auth-list
+    executionMode:
+      local:
+        runArgs:
+          - "-v=/root/.config/gcloud:/root/.config/gcloud:ro"
+          - "--network=host"
+    containers:
+      - name: gcloud
+        image: google/cloud-sdk:slim
+        command: ["gcloud"]
+        args: ["auth", "list"]

--- a/integration/exec_test.go
+++ b/integration/exec_test.go
@@ -67,6 +67,15 @@ func TestExec_LocalActions(t *testing.T) {
 				"[task7] bye-from-env-file",
 			},
 		},
+		{
+			description: "action with runArgs overlay",
+			action:      "action-runargs",
+			expectedMsgs: []string{
+				// --add-host writes "<ip>\t<host>" into the container's /etc/hosts.
+				"[runargs-task] 10.11.12.13",
+				"runargs-host",
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/integration/testdata/custom-actions-local/skaffold.yaml
+++ b/integration/testdata/custom-actions-local/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v4beta14
+apiVersion: skaffold/v4beta15
 kind: Config
 
 build:
@@ -77,3 +77,14 @@ customActions:
         env:
           - name: FOO
             value: from-local-img
+
+  - name: action-runargs
+    executionMode:
+      local:
+        runArgs:
+          - "--add-host=runargs-host:10.11.12.13"
+    containers:
+      - name: runargs-task
+        image: alpine:3.15.4
+        command: ["/bin/sh"]
+        args: ["-c", "grep runargs-host /etc/hosts"]

--- a/pkg/skaffold/actions/docker/exec_env.go
+++ b/pkg/skaffold/actions/docker/exec_env.go
@@ -169,13 +169,20 @@ func (e ExecEnv) createTasks(ctx context.Context, out io.Writer, aCfgs latest.Ac
 	timeout := *aCfgs.Config.Timeout
 	useLocalImages := aCfgs.ExecutionModeConfig.LocalExecutionMode.UseLocalImages
 
+	runArgs, err := dockerutil.ParseRunArgs(aCfgs.ExecutionModeConfig.LocalExecutionMode.RunArgs)
+	if err != nil {
+		return nil, nil, fmt.Errorf("action %q: %w", aCfgs.Name, err)
+	}
+
 	for _, cCfg := range containerCfgs {
 		art, err := e.pullArtifact(ctx, out, builts, useLocalImages, cCfg)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		ts = append(ts, NewTask(cCfg, e.client, e.portManager, e.pResources, *art, timeout, &e))
+		task := NewTask(cCfg, e.client, e.portManager, e.pResources, *art, timeout, &e)
+		task.runArgs = runArgs
+		ts = append(ts, task)
 
 		tracked = append(tracked, graph.Artifact{
 			ImageName: cCfg.Image,

--- a/pkg/skaffold/actions/docker/task.go
+++ b/pkg/skaffold/actions/docker/task.go
@@ -64,6 +64,11 @@ type Task struct {
 
 	// Reference to the associated execution environment.
 	execEnv *ExecEnv
+
+	// Optional whitelisted docker-run-style flags parsed from the owning
+	// action's executionMode.local.runArgs. Nil when the user didn't
+	// provide any.
+	runArgs *dockerutil.RunArgs
 }
 
 var NewTask = newTask
@@ -153,6 +158,7 @@ func (t Task) containerCreateOpts(ctx context.Context, containerName string) (*d
 		ContainerConfig: containerCfg,
 		Bindings:        bindings,
 		Wait:            true,
+		HostConfigApply: t.runArgs.ApplyToHostConfig,
 	}, nil
 }
 

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -74,6 +74,10 @@ type ContainerCreateOpts struct {
 	ContainerConfig *container.Config
 	VerifyTestName  string
 	Labels          map[string]string
+	// HostConfigApply, if non-nil, is invoked after the default HostConfig
+	// has been constructed in Run and lets callers overlay additional
+	// fields (e.g. Binds, ExtraHosts, NetworkMode overrides).
+	HostConfigApply func(*container.HostConfig)
 }
 
 // LocalDaemon talks to a local Docker API.
@@ -230,15 +234,19 @@ func (l *localDaemon) Run(ctx context.Context, out io.Writer, opts ContainerCrea
 	if opts.ContainerConfig == nil {
 		return nil, nil, "", fmt.Errorf("cannot call Run with empty container config")
 	}
+	hostCfg := &container.HostConfig{
+		NetworkMode:  container.NetworkMode(opts.Network),
+		VolumesFrom:  opts.VolumesFrom,
+		PortBindings: opts.Bindings,
+		Mounts:       opts.Mounts,
+	}
+	if opts.HostConfigApply != nil {
+		opts.HostConfigApply(hostCfg)
+	}
 	c, err := l.apiClient.ContainerCreate(ctx, client.ContainerCreateOptions{
-		Config: opts.ContainerConfig,
-		HostConfig: &container.HostConfig{
-			NetworkMode:  container.NetworkMode(opts.Network),
-			VolumesFrom:  opts.VolumesFrom,
-			PortBindings: opts.Bindings,
-			Mounts:       opts.Mounts,
-		},
-		Name: opts.Name,
+		Config:     opts.ContainerConfig,
+		HostConfig: hostCfg,
+		Name:       opts.Name,
 	})
 	if err != nil {
 		return nil, nil, "", err

--- a/pkg/skaffold/docker/runargs.go
+++ b/pkg/skaffold/docker/runargs.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2026 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package docker
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/moby/moby/api/types/container"
+)
+
+// allowedRunArgs is the conservative whitelist of `docker run` flags that may
+// be forwarded to a local container via `runArgs`. Every accepted flag maps to
+// a field on the Docker HostConfig.
+const allowedRunArgs = "--network, -v/--volume, --add-host, --tmpfs"
+
+// RunArgs is the parsed, whitelisted projection of a user-supplied
+// executionMode.local.runArgs list (shared by custom actions and verify).
+//
+// Only a small, deliberately conservative subset of `docker run` flags is
+// recognised; unknown flags are rejected so users fail fast instead of being
+// silently ignored. See ParseRunArgs for the full list.
+type RunArgs struct {
+	NetworkMode string
+	Binds       []string
+	ExtraHosts  []string
+	Tmpfs       map[string]string
+}
+
+// ParseRunArgs parses a docker-run-style argument list and returns a
+// whitelisted RunArgs projection. Supported flags:
+//
+//	--network=VALUE
+//	-v=SRC:DST[:MODE]   (also --volume=...)
+//	--add-host=HOST:IP
+//	--tmpfs=PATH[:OPTIONS]
+//
+// Each flag must be in the `--flag=value` (or `-f=value`) form; the
+// space-separated variant is not supported to keep the parser unambiguous.
+// A nil / empty input returns a nil *RunArgs.
+func ParseRunArgs(args []string) (*RunArgs, error) {
+	if len(args) == 0 {
+		return nil, nil
+	}
+	out := &RunArgs{}
+	for i, raw := range args {
+		arg := strings.TrimSpace(raw)
+		if arg == "" {
+			continue
+		}
+		key, val, ok := strings.Cut(arg, "=")
+		if !ok {
+			// No '=' means either an unknown bare flag or the space-separated form.
+			if strings.HasPrefix(arg, "-") {
+				return nil, fmt.Errorf("runArgs[%d] %q: unsupported flag %q (only --flag=value form is supported; allowed: %s)", i, raw, arg, allowedRunArgs)
+			}
+			return nil, fmt.Errorf("runArgs[%d] %q: only --flag=value form is supported (no space-separated values)", i, raw)
+		}
+		switch key {
+		case "--network":
+			out.NetworkMode = val
+		case "-v", "--volume":
+			out.Binds = append(out.Binds, val)
+		case "--add-host":
+			out.ExtraHosts = append(out.ExtraHosts, val)
+		case "--tmpfs":
+			if out.Tmpfs == nil {
+				out.Tmpfs = map[string]string{}
+			}
+			mountPath, opts, _ := strings.Cut(val, ":")
+			out.Tmpfs[mountPath] = opts
+		default:
+			return nil, fmt.Errorf("runArgs[%d] %q: unsupported flag %q (allowed: %s)", i, raw, key, allowedRunArgs)
+		}
+	}
+	return out, nil
+}
+
+// ApplyToHostConfig overlays parsed runArgs onto hc in place. NetworkMode is
+// only overridden when the user provided one. A nil receiver is a no-op.
+func (r *RunArgs) ApplyToHostConfig(hc *container.HostConfig) {
+	if r == nil || hc == nil {
+		return
+	}
+	if r.NetworkMode != "" {
+		hc.NetworkMode = container.NetworkMode(r.NetworkMode)
+	}
+	if len(r.Binds) > 0 {
+		hc.Binds = append(hc.Binds, r.Binds...)
+	}
+	if len(r.ExtraHosts) > 0 {
+		hc.ExtraHosts = append(hc.ExtraHosts, r.ExtraHosts...)
+	}
+	if len(r.Tmpfs) > 0 {
+		if hc.Tmpfs == nil {
+			hc.Tmpfs = map[string]string{}
+		}
+		for k, v := range r.Tmpfs {
+			hc.Tmpfs[k] = v
+		}
+	}
+}

--- a/pkg/skaffold/docker/runargs_test.go
+++ b/pkg/skaffold/docker/runargs_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2026 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package docker
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/moby/moby/api/types/container"
+
+	"github.com/GoogleContainerTools/skaffold/v2/testutil"
+)
+
+func TestParseRunArgs_Empty(t *testing.T) {
+	got, err := ParseRunArgs(nil)
+	testutil.CheckError(t, false, err)
+	if got != nil {
+		t.Fatalf("expected nil, got %+v", got)
+	}
+
+	got, err = ParseRunArgs([]string{})
+	testutil.CheckError(t, false, err)
+	if got != nil {
+		t.Fatalf("expected nil, got %+v", got)
+	}
+}
+
+func TestParseRunArgs_Supported(t *testing.T) {
+	got, err := ParseRunArgs([]string{
+		"--network=host",
+		"-v=/host:/container:ro",
+		"--volume=/data:/data",
+		"--add-host=db:127.0.0.1",
+		"--tmpfs=/tmp:size=64m",
+	})
+	testutil.CheckError(t, false, err)
+	testutil.CheckDeepEqual(t, "host", got.NetworkMode)
+	testutil.CheckDeepEqual(t, []string{"/host:/container:ro", "/data:/data"}, got.Binds)
+	testutil.CheckDeepEqual(t, []string{"db:127.0.0.1"}, got.ExtraHosts)
+	testutil.CheckDeepEqual(t, map[string]string{"/tmp": "size=64m"}, got.Tmpfs)
+}
+
+func TestParseRunArgs_UnsupportedFlag(t *testing.T) {
+	// Flags that used to be on the whitelist must now be rejected.
+	for _, flag := range []string{"--rm", "-e=FOO=bar", "--user=1000", "--privileged", "--cap-add=NET_ADMIN"} {
+		_, err := ParseRunArgs([]string{flag})
+		if err == nil || !strings.Contains(err.Error(), "unsupported flag") {
+			t.Fatalf("%q: expected unsupported flag error, got %v", flag, err)
+		}
+	}
+}
+
+func TestParseRunArgs_SpaceSeparated(t *testing.T) {
+	_, err := ParseRunArgs([]string{"plain value"})
+	if err == nil || !strings.Contains(err.Error(), "only --flag=value form") {
+		t.Fatalf("expected only --flag=value error, got %v", err)
+	}
+}
+
+func TestParseRunArgs_SkipsEmptyEntries(t *testing.T) {
+	got, err := ParseRunArgs([]string{"", "   ", "--network=host"})
+	testutil.CheckError(t, false, err)
+	testutil.CheckDeepEqual(t, "host", got.NetworkMode)
+}
+
+func TestApplyToHostConfig_NilSafe(t *testing.T) {
+	var r *RunArgs
+	r.ApplyToHostConfig(nil)
+	r.ApplyToHostConfig(&container.HostConfig{})
+	(&RunArgs{}).ApplyToHostConfig(nil)
+}
+
+func TestApplyToHostConfig_OverridesAndAppends(t *testing.T) {
+	r := &RunArgs{
+		NetworkMode: "host",
+		Binds:       []string{"/a:/a"},
+		ExtraHosts:  []string{"h:1.2.3.4"},
+		Tmpfs:       map[string]string{"/tmp": "size=16m"},
+	}
+	hc := &container.HostConfig{
+		NetworkMode: container.NetworkMode("bridge"),
+		Binds:       []string{"/pre:/pre"},
+		ExtraHosts:  []string{"pre:0.0.0.0"},
+		Tmpfs:       map[string]string{"/run": "size=8m"},
+	}
+	r.ApplyToHostConfig(hc)
+	testutil.CheckDeepEqual(t, "host", string(hc.NetworkMode))
+	testutil.CheckDeepEqual(t, []string{"/pre:/pre", "/a:/a"}, hc.Binds)
+	testutil.CheckDeepEqual(t, []string{"pre:0.0.0.0", "h:1.2.3.4"}, hc.ExtraHosts)
+	testutil.CheckDeepEqual(t, map[string]string{"/run": "size=8m", "/tmp": "size=16m"}, hc.Tmpfs)
+}
+
+func TestApplyToHostConfig_EmptyRunArgsDoesNotOverrideNetwork(t *testing.T) {
+	r := &RunArgs{}
+	hc := &container.HostConfig{NetworkMode: container.NetworkMode("bridge")}
+	r.ApplyToHostConfig(hc)
+	testutil.CheckDeepEqual(t, "bridge", string(hc.NetworkMode))
+}

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -25,8 +25,8 @@ import (
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/util"
 )
 
-// !!! WARNING !!! This config version is already released, please DO NOT MODIFY the structs in this file.
-const Version string = "skaffold/v4beta14"
+// This config version is not yet released, it is SAFE TO MODIFY the structs in this file.
+const Version string = "skaffold/v4beta15"
 
 // NewSkaffoldConfig creates a SkaffoldConfig
 func NewSkaffoldConfig() util.VersionedConfig {
@@ -684,6 +684,13 @@ type LocalVerifier struct {
 	// UseLocalImages if true, will first check if the containers images exist locally before triggering a pull.
 	// Defaults to false.
 	UseLocalImages bool `yaml:"useLocalImages,omitempty"`
+
+	// RunArgs is an optional list of `docker run`-style flags applied to the
+	// verify test container. The same conservative whitelist is supported on
+	// `customActions.*.executionMode.local.runArgs`: `--network`, `-v` /
+	// `--volume`, `--add-host`, `--tmpfs`. Unknown flags are rejected, and each
+	// flag must be in `--flag=value` form.
+	RunArgs []string `yaml:"runArgs,omitempty"`
 }
 
 // KubernetesClusterVerifier uses the `kubectl` CLI to create veriy test case

--- a/pkg/skaffold/verify/docker/verify.go
+++ b/pkg/skaffold/verify/docker/verify.go
@@ -225,6 +225,16 @@ func (v *Verifier) createAndRunContainer(ctx context.Context, out io.Writer, art
 		containerCfg.Cmd = tc.Container.Args
 	}
 
+	// Parse the optional per-test-case runArgs whitelist. Unknown flags are
+	// surfaced as a test-case failure instead of being silently dropped.
+	var runArgs *dockerutil.RunArgs
+	if local := tc.ExecutionMode.LocalExecutionMode; local != nil {
+		runArgs, err = dockerutil.ParseRunArgs(local.RunArgs)
+		if err != nil {
+			return fmt.Errorf("verify test %q: %w", tc.Name, err)
+		}
+	}
+
 	// Use container name from test case if available, otherwise derive from image
 	containerName := v.getContainerName(ctx, artifact.ImageName, tc.Container.Name)
 
@@ -233,6 +243,7 @@ func (v *Verifier) createAndRunContainer(ctx context.Context, out io.Writer, art
 		Network:         v.network,
 		ContainerConfig: containerCfg,
 		VerifyTestName:  tc.Name,
+		HostConfigApply: runArgs.ApplyToHostConfig,
 	}
 
 	bindings, err := v.portManager.AllocatePorts(artifact.ImageName, v.resources, containerCfg, network.PortMap{})

--- a/pkg/skaffold/verify/docker/verify_test.go
+++ b/pkg/skaffold/verify/docker/verify_test.go
@@ -39,6 +39,7 @@ type fakeDockerDaemon struct {
 
 	PulledImages []string
 	ImgsInDaemon map[string]string
+	RunOpts      []docker.ContainerCreateOpts
 }
 
 func (fd *fakeDockerDaemon) NetworkCreate(ctx context.Context, name string, labels map[string]string) error {
@@ -56,6 +57,7 @@ func (fd *fakeDockerDaemon) ImageID(ctx context.Context, ref string) (string, er
 }
 
 func (fd *fakeDockerDaemon) Run(ctx context.Context, out io.Writer, opts docker.ContainerCreateOpts) (<-chan container.WaitResponse, <-chan error, string, error) {
+	fd.RunOpts = append(fd.RunOpts, opts)
 	statusCh := make(chan container.WaitResponse)
 	go func() {
 		statusCh <- container.WaitResponse{Error: nil, StatusCode: 0}
@@ -195,5 +197,89 @@ func TestGetContainerName(t *testing.T) {
 				t.CheckDeepEqual(test.expected, actual)
 			},
 		)
+	}
+}
+
+func Test_RunArgs(t *testing.T) {
+	tests := []struct {
+		description string
+		runArgs     []string
+		shouldErr   bool
+		verify      func(t *testutil.T, opts docker.ContainerCreateOpts)
+	}{
+		{
+			description: "nil runArgs leaves HostConfigApply a no-op on nil receiver",
+			runArgs:     nil,
+			verify: func(t *testutil.T, opts docker.ContainerCreateOpts) {
+				hc := &container.HostConfig{}
+				opts.HostConfigApply(hc)
+				t.CheckDeepEqual(&container.HostConfig{}, hc)
+			},
+		},
+		{
+			description: "parsed runArgs overlay host config",
+			runArgs: []string{
+				"--network=host",
+				"-v=/src:/dst",
+				"--add-host=h:1.2.3.4",
+				"--tmpfs=/tmp:size=16m",
+			},
+			verify: func(t *testutil.T, opts docker.ContainerCreateOpts) {
+				hc := &container.HostConfig{}
+				opts.HostConfigApply(hc)
+				t.CheckDeepEqual(container.NetworkMode("host"), hc.NetworkMode)
+				t.CheckDeepEqual([]string{"/src:/dst"}, hc.Binds)
+				t.CheckDeepEqual([]string{"h:1.2.3.4"}, hc.ExtraHosts)
+				t.CheckDeepEqual(map[string]string{"/tmp": "size=16m"}, hc.Tmpfs)
+			},
+		},
+		{
+			// A flag dropped from the whitelist must now fail the test case.
+			description: "unknown flag fails the test case",
+			runArgs:     []string{"--privileged"},
+			shouldErr:   true,
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			testEvent.InitializeState([]latest.Pipeline{{}})
+			ctx := context.TODO()
+			runCtx := &runcontext.RunContext{}
+
+			fd := &fakeDockerDaemon{
+				LocalDaemon:  docker.NewLocalDaemon(&testutil.FakeAPIClient{}, nil, false, nil),
+				ImgsInDaemon: map[string]string{"gcr.io/img:latest": "id"},
+			}
+			t.Override(&docker.NewAPIClient, func(context.Context, docker.Config) (docker.LocalDaemon, error) {
+				return fd, nil
+			})
+
+			cases := []*latest.VerifyTestCase{{
+				Name:   "t1",
+				Config: latest.VerifyConfig{},
+				ExecutionMode: latest.VerifyExecutionModeConfig{
+					VerifyExecutionModeType: latest.VerifyExecutionModeType{
+						LocalExecutionMode: &latest.LocalVerifier{
+							UseLocalImages: true,
+							RunArgs:        test.runArgs,
+						},
+					},
+				},
+				Container: latest.VerifyContainer{Name: "c1", Image: "gcr.io/img:latest"},
+			}}
+
+			verifier, err := NewVerifier(ctx, runCtx, &label.DefaultLabeller{}, cases, nil, "", nil)
+			t.CheckError(false, err)
+
+			err = verifier.Verify(ctx, nil, nil)
+			if test.shouldErr {
+				t.CheckError(true, err)
+				return
+			}
+			t.CheckError(false, err)
+			t.CheckTrue(len(fd.RunOpts) == 1)
+			test.verify(t, fd.RunOpts[0])
+		})
 	}
 }


### PR DESCRIPTION
## Local `runArgs` for custom actions **and** verify

Closes #10130.

Lets local (Docker) custom-action and `verify` containers forward a small, conservative whitelist of `docker run` flags via `executionMode.local.runArgs`. The primary motivation is **local/Cloud Deploy parity**: Cloud Deploy's execution environment already runs as a service account (ADC works out of the box), but local `skaffold exec` / `skaffold verify` containers have no access to the host's Google credentials. A bind-mount via `runArgs` closes the gap.

```yaml
customActions:
  - name: reuse-local-adc
    executionMode:
      local:
        runArgs:
          - "-v=/root/.config/gcloud:/root/.config/gcloud:ro"
          - "--network=host"
    containers:
      - name: gcloud
        image: google/cloud-sdk:slim
        command: ["gcloud"]
        args: ["auth", "list"]
```

### Whitelist (all map to the Docker `HostConfig`)

| Flag | Effect |
| --- | --- |
| `--network=<mode>` | `HostConfig.NetworkMode` |
| `-v`/`--volume=<src>:<dst>[:opts]` | `HostConfig.Binds` |
| `--add-host=<host>:<ip>` | `HostConfig.ExtraHosts` |
| `--tmpfs=<path>[:opts]` | `HostConfig.Tmpfs` |

Only the `--flag=value` form is accepted; unknown flags are rejected at load time. (Reduced from an earlier, broader set — `-e`/`--user`/`--privileged`/`--cap-add`/`--cap-drop` were dropped for a tighter security posture, which also let `ApplyToContainerConfig` go away entirely.)

### DRY

The parser + `HostConfig` overlay live once in the neutral `pkg/skaffold/docker` package (next to `ContainerCreateOpts`); `actions/docker` and `verify/docker` both consume it through the existing `ContainerCreateOpts.HostConfigApply` hook. The two container-creation runtimes stay separate — no rewrite.

### New schema version `skaffold/v4beta15`

`skaffold/v4beta14` is released ("DO NOT MODIFY"), so adding `LocalVerifier.runArgs` required cutting a new version via `hack/new-version.sh`.

**Note to reviewer**: I only committed the new `config.go` schema v4beta15 as @Darien-Lin mentioned this is usually done by the maintainers. If you would like me to push all changes generated by cutting the schema version, let me know. Feel free to push to this branch yourself as well and merge.

### Tests

- Unit: parser + host-config overlay (`pkg/skaffold/docker`), verify wiring (`verify/docker`).
- Integration: `exec action-runargs` forwards `--add-host` into the container's `/etc/hosts`.

```
$ go build ./...                       # ok (was failing on the docker/docker import)
$ go test ./pkg/skaffold/docker/... ./pkg/skaffold/actions/... ./pkg/skaffold/verify/... ./pkg/skaffold/schema/...   # ok
$ ./hack/check-samples.sh              # ok
```