### PR TITLE
feat: show kubectl context by default on startup

### DIFF
--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -28,6 +28,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/constants"
 	kubectx "github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/kubernetes/context"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/output"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/output/log"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/latest"
 	schemaUtil "github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/schema/util"
@@ -403,7 +404,7 @@ func GetRunContext(ctx context.Context, opts config.SkaffoldOptions, configs []s
 		return nil, fmt.Errorf("getting current cluster context: %w", err)
 	}
 	kubeContext := kubeConfig.CurrentContext
-	log.Entry(context.TODO()).Infof("Using kubectl context: %s", kubeContext)
+	output.Default.Fprintf(os.Stdout, "Using kubectl context: %s\n", kubeContext)
 
 	// TODO(dgageot): this should be the folder containing skaffold.yaml. Should also be moved elsewhere.
 	cwd, err := os.Getwd()

--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -404,7 +404,7 @@ func GetRunContext(ctx context.Context, opts config.SkaffoldOptions, configs []s
 		return nil, fmt.Errorf("getting current cluster context: %w", err)
 	}
 	kubeContext := kubeConfig.CurrentContext
-	output.Default.Fprintf(os.Stdout, "Using kubectl context: %s\n", kubeContext)
+output.Default.Fprintf(os.Stderr, "Using kubectl context: %s\n", kubeContext)
 
 	// TODO(dgageot): this should be the folder containing skaffold.yaml. Should also be moved elsewhere.
 	cwd, err := os.Getwd()


### PR DESCRIPTION
Fixes: #6861

Related: N/A
Merge before/after: N/A

Description
This PR addresses issue #6861 by making the kubectl context and cluster information visible by default during startup. Previously, this information was only logged at the INFO level, requiring users to use -v info to see it.

The change ensures that users immediately know which context they are working with when running commands like skaffold dev or skaffold run, improving the overall developer experience.

User facing changes (remove if N/A)
The startup output now includes the current Kubernetes context:

Before: No context information was printed at the default log level.

After: Prints Using kubectl context: <context-name> using the standard Skaffold output package.

Follow-up Work (remove if N/A)
N/A
