### PR TITLE
Upgrade Go version to 1.26.3

### DIFF
--- a/.github/workflows/integration-linux.yml
+++ b/.github/workflows/integration-linux.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: 1.26.2
+        go-version: 1.26.3
       id: go
 
     - name: Set up Java

--- a/.github/workflows/linters-checks.yml
+++ b/.github/workflows/linters-checks.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.26.2
+          go-version: 1.26.3
         id: go
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/unit-tests-darwin.yml
+++ b/.github/workflows/unit-tests-darwin.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: 1.26.2
+        go-version: 1.26.3
       id: go
 
     # Retrieve build locations with `go env`

--- a/.github/workflows/unit-tests-linux.yml
+++ b/.github/workflows/unit-tests-linux.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: 1.26.2
+        go-version: 1.26.3
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/unit-tests-windows.yml
+++ b/.github/workflows/unit-tests-windows.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: 1.26.2
+        go-version: 1.26.3
       id: go
 
     # Retrieve build locations with `go env`

--- a/.github/workflows/verify-examples.yml
+++ b/.github/workflows/verify-examples.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: 1.26.2
+        go-version: 1.26.3
       id: go
 
     # Skip changes not affecting examples or integration/examples

--- a/deploy/skaffold/Dockerfile.deps
+++ b/deploy/skaffold/Dockerfile.deps
@@ -17,7 +17,7 @@ ARG ARCH=amd64
 
 FROM ${BASE_PREFIX}docker:28.1.1 as docker-source
 FROM docker/buildx-bin:0.23.0 as buildx-source
-FROM ${BASE_PREFIX}golang:1.26.2 as golang-source
+FROM ${BASE_PREFIX}golang:1.26.3 as golang-source
 
 # Download kubectl
 FROM ${BASE_PREFIX}alpine:3.21.2 as download-kubectl
@@ -169,7 +169,6 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
     jq \
     apt-transport-https && \
     rm -rf /var/lib/apt/lists/*
-
 # Use the alias created at the top
 COPY --from=golang-source /usr/local/go /usr/local/go
 ENV PATH /usr/local/go/bin:/root/go/bin:$PATH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleContainerTools/skaffold/v2
 
-go 1.26.2
+go 1.26.3
 
 // broken on Windows, see https://github.com/karrick/godirwalk/issues/70
 exclude github.com/karrick/godirwalk v1.17.0


### PR DESCRIPTION
Upgrade Go version to 1.26.3 to address security vulnerabilities in the Go standard library. This upgrades the go.mod directive and the GitHub Actions workflows to use Go 1.26.3.