### PR TITLE
fix: handle stat errors in file helpers

### DIFF
--- a/pkg/skaffold/util/util.go
+++ b/pkg/skaffold/util/util.go
@@ -267,14 +267,18 @@ func AbsolutePaths(workspace string, paths []string) []string {
 
 func IsFile(path string) bool {
 	info, err := os.Stat(path)
-	// err could be permission-related
-	return (err == nil || !os.IsNotExist(err)) && info.Mode().IsRegular()
+	if err != nil {
+		return false
+	}
+	return info.Mode().IsRegular()
 }
 
 func IsDir(path string) bool {
 	info, err := os.Stat(path)
-	// err could be permission-related
-	return (err == nil || !os.IsNotExist(err)) && info.IsDir()
+	if err != nil {
+		return false
+	}
+	return info.IsDir()
 }
 
 // IsEmptyDir returns true for empty directories otherwise false

--- a/pkg/skaffold/util/util_test.go
+++ b/pkg/skaffold/util/util_test.go
@@ -437,6 +437,14 @@ func TestIsFileIsDir(t *testing.T) {
 	testutil.CheckDeepEqual(t, false, IsDir(filepath.Join(tmpDir.Root(), "nonexistent")))
 }
 
+func TestIsFileIsDirStatError(t *testing.T) {
+	tmpDir := testutil.NewTempDir(t).Touch("file")
+	pathWithFileAsDir := tmpDir.Path("file/child")
+
+	testutil.CheckDeepEqual(t, false, IsFile(pathWithFileAsDir))
+	testutil.CheckDeepEqual(t, false, IsDir(pathWithFileAsDir))
+}
+
 func TestIsURL(t *testing.T) {
 	testutil.CheckDeepEqual(t, false, IsURL("foo"))
 	testutil.CheckDeepEqual(t, false, IsURL("http:bar"))


### PR DESCRIPTION
**Description**
`IsFile` and `IsDir` assumed `os.Stat` always returns `FileInfo` unless the path is missing. But `file/child`, where `file` is a regular file, returns a stat error and nil info, so the old code panics.

This returns `false` on any stat error, same vibe as "not a file/dir". tiny fix, low-key useful.

Repro:
1. create a regular file
2. call `IsFile("<tmp>/file/child")` or `IsDir("<tmp>/file/child")`
3. before: nil pointer panic in `IsFile`/`IsDir`
4. after: returns `false`

**User facing changes**
No CLI output changes, just avoids a crash for bad local paths.

**Testing**
- `go test ./pkg/skaffold/util -run 'TestIsFileIsDir|TestIsFileIsDirStatError'`\n- `go test ./pkg/skaffold/util`\n- `make quicktest`