### PR TITLE
fix: stop binding SIGPIPE to the root context so registry resets don't cancel builds

### DIFF
--- a/cmd/skaffold/app/skaffold.go
+++ b/cmd/skaffold/app/skaffold.go
@@ -33,7 +33,7 @@ import (
 )
 
 func Run(out, stderr io.Writer) error {
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM, syscall.SIGINT, syscall.SIGPIPE)
+	ctx, cancel := rootContext()
 	defer cancel()
 
 	catchStackdumpRequests()
@@ -62,4 +62,18 @@ func Run(out, stderr io.Writer) error {
 		}
 	}
 	return err
+}
+
+// rootContext returns the root context, cancelled on interrupt and termination
+// signals. SIGPIPE is deliberately ignored rather than wired to cancellation:
+// registering it with signal.Notify makes Go deliver it for every file
+// descriptor, so a registry resetting an idle connection mid-build would
+// otherwise cancel long-running builds. Ignoring it still lets a closed output
+// pipe shut skaffold down gracefully without killing the process mid-cleanup.
+//
+// https://github.com/GoogleContainerTools/skaffold/issues/10106
+// https://github.com/GoogleContainerTools/skaffold/issues/510
+func rootContext() (context.Context, context.CancelFunc) {
+	signal.Ignore(syscall.SIGPIPE)
+	return signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
 }

--- a/cmd/skaffold/app/skaffold_signal_test.go
+++ b/cmd/skaffold/app/skaffold_signal_test.go
@@ -1,0 +1,51 @@
+//go:build !windows
+// +build !windows
+
+/*
+Copyright 2025 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"context"
+	"os/signal"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestRootContextIgnoresSIGPIPE checks that SIGPIPE does not cancel the root
+// context. Before the fix it was passed to signal.NotifyContext, which
+// cancelled the run when a registry reset an idle connection during a build.
+//
+// https://github.com/GoogleContainerTools/skaffold/issues/10106
+func TestRootContextIgnoresSIGPIPE(t *testing.T) {
+	defer signal.Reset(syscall.SIGPIPE)
+
+	ctx, cancel := rootContext()
+	defer cancel()
+
+	if err := syscall.Kill(syscall.Getpid(), syscall.SIGPIPE); err != nil {
+		t.Fatalf("sending SIGPIPE: %v", err)
+	}
+
+	select {
+	case <-ctx.Done():
+		t.Fatalf("SIGPIPE cancelled the root context: %v", context.Cause(ctx))
+	case <-time.After(200 * time.Millisecond):
+		// expected: SIGPIPE is ignored and the context stays alive.
+	}
+}


### PR DESCRIPTION
Fixes: #10106

**Description**

`Run()` in `cmd/skaffold/app/skaffold.go` bound `syscall.SIGPIPE` to the root cancellation context:

```go
ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM, syscall.SIGINT, syscall.SIGPIPE)
```

Per the Go [`os/signal`](https://pkg.go.dev/os/signal#hdr-SIGPIPE) docs, once a program registers SIGPIPE via `Notify`/`NotifyContext` the runtime delivers it for **every** file descriptor (not just stdout/stderr). So a SIGPIPE raised when a registry such as `mcr.microsoft.com` resets an idle connection mid-build gets delivered to the root context and is treated as a request to cancel the whole run. Multi-stage builds whose first stage runs longer than the registry's ~60s idle timeout are cancelled with reason `broken pipe signal received` (the strace in #10106 shows the `ECONNRESET` → `EPIPE` → `SIGPIPE` sequence). `docker build` of the same Dockerfile succeeds because only skaffold turns that SIGPIPE into a cancellation.

This change stops treating SIGPIPE as a cancellation signal: it removes SIGPIPE from `NotifyContext` and `signal.Ignore`s it instead (extracted into a small `rootContext()` helper so it can be unit-tested).

`Ignore` is deliberate rather than simply dropping SIGPIPE from the list. SIGPIPE was originally caught on purpose (#510 / #515) so that a closed output pipe (e.g. `skaffold ... | head`) would not abruptly kill skaffold before graceful cleanup finished. Ignoring it preserves that intent — broken-pipe writes return `EPIPE` to the caller instead of either cancelling the run (this bug) or terminating the process via the default disposition (what #515 set out to avoid).

**Testing**

- Added a regression test (`TestRootContextIgnoresSIGPIPE`, `cmd/skaffold/app/skaffold_signal_test.go`, gated `!windows`) asserting a SIGPIPE delivered to the process does not cancel `rootContext()`. It fails against the previous code (SIGPIPE in `NotifyContext`) and passes with this change. `make quicktest` / package tests pass; `gofmt` and `go vet` clean.
- End-to-end with the exact Dockerfile from this issue (`mcr.microsoft.com/dotnet/sdk:10.0` + `RUN … sleep 90`, then `aspnet:10.0`) via the cluster (Kaniko) builder on Linux, plain `skaffold build`:
  - **Before (v2.18.0):** canceled ≈68s in — during `sleep 90`, just after the registry's ~60s idle reset — `Build [test] was canceled`, exactly as reported.
  - **After:** rides through the sleep and both stages to `Build [test] succeeded` (~2 min). No cancellation.

**User facing changes**

- *Before:* long-running multi-stage builds against registries that reset idle connections (e.g. `mcr.microsoft.com`) are cancelled mid-build with `broken pipe signal received`.
- *After:* such a SIGPIPE is ignored; the build runs to completion. Closing skaffold's output pipe (e.g. `skaffold ... | head`) still shuts down gracefully — writes return `EPIPE` rather than cancelling the run or killing the process.
