### PR TITLE
fix(deploy): skip kubectl flag validation for configs with no deploy section

### DIFF
--- a/pkg/skaffold/runner/deployer.go
+++ b/pkg/skaffold/runner/deployer.go
@@ -266,11 +266,10 @@ func getDefaultDeployer(runCtx *runcontext.RunContext, labeller *label.DefaultLa
 			logPrefix = d.Logs.Prefix
 		}
 		if d.KubectlDeploy != nil {
-			currentKubectlFlags := d.KubectlDeploy.Flags
 			if kFlags == nil {
-				kFlags = &currentKubectlFlags
+				kFlags = &d.KubectlDeploy.Flags
 			}
-			if err := validateKubectlFlags(kFlags, currentKubectlFlags); err != nil {
+			if err := validateKubectlFlags(kFlags, d.KubectlDeploy.Flags); err != nil {
 				return nil, err
 			}
 			if d.KubectlDeploy.DefaultNamespace != nil {

--- a/pkg/skaffold/runner/deployer.go
+++ b/pkg/skaffold/runner/deployer.go
@@ -265,23 +265,20 @@ func getDefaultDeployer(runCtx *runcontext.RunContext, labeller *label.DefaultLa
 			}
 			logPrefix = d.Logs.Prefix
 		}
-		var currentDefaultNamespace *string
-		var currentKubectlFlags latest.KubectlFlags
 		if d.KubectlDeploy != nil {
-			currentDefaultNamespace = d.KubectlDeploy.DefaultNamespace
-			currentKubectlFlags = d.KubectlDeploy.Flags
-		}
-		if kFlags == nil {
-			kFlags = &currentKubectlFlags
-		}
-		if err := validateKubectlFlags(kFlags, currentKubectlFlags); err != nil {
-			return nil, err
-		}
-		if currentDefaultNamespace != nil {
-			if defaultNamespace != nil && *defaultNamespace != *currentDefaultNamespace {
-				return nil, fmt.Errorf("found multiple namespaces in skaffold.yaml (not supported in `skaffold apply`): %s, %s", *defaultNamespace, *currentDefaultNamespace)
+			currentKubectlFlags := d.KubectlDeploy.Flags
+			if kFlags == nil {
+				kFlags = &currentKubectlFlags
 			}
-			defaultNamespace = currentDefaultNamespace
+			if err := validateKubectlFlags(kFlags, currentKubectlFlags); err != nil {
+				return nil, err
+			}
+			if d.KubectlDeploy.DefaultNamespace != nil {
+				if defaultNamespace != nil && *defaultNamespace != *d.KubectlDeploy.DefaultNamespace {
+					return nil, fmt.Errorf("found multiple namespaces in skaffold.yaml (not supported in `skaffold apply`): %s, %s", *defaultNamespace, *d.KubectlDeploy.DefaultNamespace)
+				}
+				defaultNamespace = d.KubectlDeploy.DefaultNamespace
+			}
 		}
 	}
 	if kFlags == nil {

--- a/pkg/skaffold/runner/deployer_test.go
+++ b/pkg/skaffold/runner/deployer_test.go
@@ -525,6 +525,33 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 					Flags: latest.KubectlFlags{},
 				}, nil, configNameForDefaultDeployer, nil)).(*kubectl.Deployer),
 			},
+			{
+				// Regression test for https://github.com/GoogleContainerTools/skaffold/issues/10071
+				// A dependency config with no deploy section (e.g. only resourceSelector) must not
+				// be treated as a conflicting set of kubectl deploy flags.
+				name: "parent config with kubectl flags and dependency config with no deploy section should not conflict",
+				cfgs: map[string]latest.DeployType{
+					"parent": {
+						KubectlDeploy: &latest.KubectlDeploy{
+							Flags: latest.KubectlFlags{
+								Apply: []string{"--server-side"},
+							},
+						},
+					},
+					"dependency": {},
+				},
+				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
+					Pipelines: runcontext.NewPipelines(
+						map[string]latest.Pipeline{
+							"parent": {},
+						},
+						[]string{"default"}),
+				}, &label.DefaultLabeller{}, &latest.KubectlDeploy{
+					Flags: latest.KubectlFlags{
+						Apply: []string{"--server-side"},
+					},
+				}, nil, configNameForDefaultDeployer, nil)).(*kubectl.Deployer),
+			},
 		}
 
 		for _, test := range tests {


### PR DESCRIPTION
## What changed

When using `skaffold apply` with a multi-config project where a dependency config has no deploy section (e.g. it only provides `resourceSelector`), the default deployer would incorrectly treat the zero-value `KubectlFlags{}` as conflicting with the parent config's kubectl flags (e.g. `--server-side`).

## Root Cause

In `getDefaultDeployer`, `validateKubectlFlags` was called for every pipeline config regardless of whether `d.KubectlDeploy` was `nil`. A `nil` `KubectlDeploy` produced a zero-value `KubectlFlags{}` that did not contain the parent's flags, causing a false conflict error.

## Fix

Moved the `validateKubectlFlags` call and the `DefaultNamespace` conflict check inside the existing `if d.KubectlDeploy != nil` block. Configs without a kubectl deploy section are now skipped entirely.

## Testing

- Added regression test: `TestGetDefaultDeployer/parent_config_with_kubectl_flags_and_dependency_config_with_no_deploy_section_should_not_conflict` in `pkg/skaffold/runner/deployer_test.go`
- All existing `TestGetDefaultDeployer` subtests pass

Fixes #10071
