### PR TITLE
Revert "chore: bump puma from 5.6.9 to 7.2.1 in /integration/examples/ruby/backend"

### DIFF
--- a/integration/examples/ruby/backend/Gemfile.lock
+++ b/integration/examples/ruby/backend/Gemfile.lock
@@ -1,8 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    nio4r (2.7.5)
-    puma (7.2.1)
+    nio4r (2.7.3)
+    puma (5.6.9)
       nio4r (~> 2.0)
     rack (2.2.23)
     rack-unreloader (1.7.0)


### PR DESCRIPTION
Reverts GoogleContainerTools/skaffold#10104