### PR TITLE
feat: identify Rancher Desktop context as local cluster type

### DIFF
--- a/docs-v2/content/en/docs/design/global-config.md
+++ b/docs-v2/content/en/docs/design/global-config.md
@@ -18,7 +18,7 @@ The options are:
 | `insecure-registries` | list of strings | A list of image registries that may be accessed without TLS. |
 | `k3d-disable-load` | boolean | If true, do not use `k3d import image` to load images locally. |
 | `kind-disable-load` | boolean | If true, do not use `kind load` to load images locally. |
-| `local-cluster` | boolean | If true, do not try to push images after building. By default, contexts with names `docker-for-desktop`, `docker-desktop`, or `minikube` are treated as local. |
+| `local-cluster` | boolean | If true, do not try to push images after building. By default, contexts with names `docker-for-desktop`, `docker-desktop`, `minikube`, or `rancher-desktop` are treated as local. |
 | `update-check` | boolean | Check for a more recent version of Skaffold. |
 | `collect-metrics` | boolean | Collect anonymized usage data. |
 

--- a/docs-v2/content/en/docs/environment/local-cluster.md
+++ b/docs-v2/content/en/docs/environment/local-cluster.md
@@ -22,14 +22,15 @@ kubectl config current-context
 
 Skaffold checks for the following context names:
 
-| Kubernetes context | Local cluster type | Notes |
-| ------------------ | ------------------ | ----- |
-| docker-desktop     | [`Docker Desktop`] | |
-| docker-for-desktop | [`Docker Desktop`] | This context name is deprecated |
-| minikube <sup>1</sup> | [`minikube`]    | See <sup>1</sup> | |
-| kind-(.*)          | [`kind`]           | This pattern is used by kind >= v0.6.0 |
-| (.*)@kind          | [`kind`]           | This pattern was used by kind < v0.6.0 |
-| k3d-(.*)           | [`k3d`]            | This pattern is used by k3d >= v3.0.0 |
+| Kubernetes context    | Local cluster type  | Notes                                  |
+|-----------------------|---------------------|----------------------------------------|
+| docker-desktop        | [`Docker Desktop`]  |                                        |
+| docker-for-desktop    | [`Docker Desktop`]  | This context name is deprecated        |
+| minikube <sup>1</sup> | [`minikube`]        | See <sup>1</sup>                       |
+| kind-(.*)             | [`kind`]            | This pattern is used by kind >= v0.6.0 |
+| (.*)@kind             | [`kind`]            | This pattern was used by kind < v0.6.0 |
+| k3d-(.*)              | [`k3d`]             | This pattern is used by k3d >= v3.0.0  |
+| rancher-desktop       | [`Rancher Desktop`] |                                        |
 
 For any other name, Skaffold assumes that the cluster is remote and that images
 have to be pushed.
@@ -43,6 +44,7 @@ context name.
  [`Docker Desktop`]: https://www.docker.com/products/docker-desktop
  [`kind`]: https://github.com/kubernetes-sigs/kind
  [`k3d`]: https://github.com/rancher/k3d
+ [`Rancher Desktop`]: https://rancherdesktop.io
 
 ### Manual override
 

--- a/pkg/skaffold/config/util.go
+++ b/pkg/skaffold/config/util.go
@@ -246,6 +246,7 @@ func GetCluster(ctx context.Context, opts GetClusterOpts) (Cluster, error) {
 	case kubeContext == constants.DefaultMinikubeContext ||
 		kubeContext == constants.DefaultDockerForDesktopContext ||
 		kubeContext == constants.DefaultDockerDesktopContext ||
+		kubeContext == constants.DefaultRancherDesktopContext ||
 		isKindCluster || isK3dCluster:
 		local = true
 

--- a/pkg/skaffold/config/util_test.go
+++ b/pkg/skaffold/config/util_test.go
@@ -352,6 +352,11 @@ func TestGetCluster(t *testing.T) {
 			expected:    Cluster{Local: true, LoadImages: false, PushImages: false},
 		},
 		{
+			description: "rancher-desktop",
+			cfg:         &ContextConfig{Kubecontext: "rancher-desktop"},
+			expected:    Cluster{Local: true, LoadImages: false, PushImages: false},
+		},
+		{
 			description: "minikube",
 			cfg:         &ContextConfig{Kubecontext: "minikube"},
 			expected:    Cluster{Local: true, LoadImages: false, PushImages: false},
@@ -436,6 +441,7 @@ func TestIsKindCluster(t *testing.T) {
 		{context: "kind@kind", expectedIsKind: true},
 		{context: "other@kind", expectedIsKind: true},
 		{context: "docker-for-desktop", expectedIsKind: false},
+		{context: "rancher-desktop", expectedIsKind: false},
 		{context: "not-kind", expectedIsKind: false},
 	}
 	for _, test := range tests {
@@ -526,6 +532,7 @@ func TestIsK3dCluster(t *testing.T) {
 		{context: "k3d-other", expectedIsK3d: true},
 		{context: "kind-kind", expectedIsK3d: false},
 		{context: "docker-for-desktop", expectedIsK3d: false},
+		{context: "rancher-desktop", expectedIsK3d: false},
 		{context: "not-k3d", expectedIsK3d: false},
 	}
 	for _, test := range tests {

--- a/pkg/skaffold/constants/constants.go
+++ b/pkg/skaffold/constants/constants.go
@@ -43,6 +43,7 @@ const (
 	DefaultMinikubeContext         = "minikube"
 	DefaultDockerForDesktopContext = "docker-for-desktop"
 	DefaultDockerDesktopContext    = "docker-desktop"
+	DefaultRancherDesktopContext   = "rancher-desktop"
 	GCSBucketSuffix                = "_cloudbuild"
 
 	HelmOverridesFilename = "skaffold-overrides.yaml"


### PR DESCRIPTION
**Description**

Before this PR, when deploying to Rancher Desktop, Skaffold will push images to remote registry because it does not understand that Rancher Desktop is a local cluster.

This PR adds `rancher-desktop` context to list of known local cluster names.

**User facing changes (remove if N/A)**

Before: user needs to explicitly disable `build.local.push` when using Rancher Desktop to avoid pushing images to remote registry.

After: Skaffold automatically detects that Rancher Desktop is local and does not push images to remote registry by default.
