### PR TITLE
feat(diagnose): default --enable-templating to true

### DIFF
--- a/cmd/skaffold/app/cmd/diagnose.go
+++ b/cmd/skaffold/app/cmd/diagnose.go
@@ -57,7 +57,7 @@ func NewCmdDiagnose() *cobra.Command {
 		WithCommonFlags().
 		WithFlags([]*Flag{
 			{Value: &yamlOnly, Name: "yaml-only", DefValue: false, Usage: "Only prints the effective skaffold.yaml configuration"},
-			{Value: &enableTemplating, Name: "enable-templating", DefValue: false, Usage: "Render supported templated fields with golang template engine"},
+			{Value: &enableTemplating, Name: "enable-templating", DefValue: true, Usage: "Render supported templated fields with golang template engine"},
 			{Value: &outputFile, Name: "output", Shorthand: "o", DefValue: "", Usage: "File to write diagnose result"},
 		}).
 		NoArgs(doDiagnose)

--- a/docs-v2/content/en/docs/references/cli/_index.md
+++ b/docs-v2/content/en/docs/references/cli/_index.md
@@ -1330,7 +1330,7 @@ Options:
     -c, --config='':
 	File for global configurations (defaults to $HOME/.skaffold/config)
 
-    --enable-templating=false:
+    --enable-templating=true:
 	Render supported templated fields with golang template engine
 
     -f, --filename='skaffold.yaml':


### PR DESCRIPTION
## Summary

- Fixes #10126
- `skaffold diagnose` generates the effective Skaffold config used by Google Cloud Deploy's render phase, but the `--enable-templating` flag defaulted to `false`. Cloud Deploy never passes this flag explicitly, so deploy parameters (injected as environment variables) were never interpolated into templated fields such as `deploy.kubectl.defaultNamespace`, which then cascaded into downstream steps (e.g. the `verify` job) relying on the resolved namespace.
- Flips the default to `true` so templating happens out of the box; users can still opt out with `--enable-templating=false`. `expandTemplate` already preserves the original template string when expansion yields `<no value>` (e.g. env var unset), so configs that don't rely on templated fields are unaffected.
- Regenerated the CLI reference docs (`docs-v2/content/en/docs/references/cli/_index.md`) via `./hack/generate-man.sh` to reflect the new default.

## Test plan

- [x] `make` builds successfully
- [x] `skaffold diagnose --help` shows `--enable-templating=true`
- [x] Manual repro: with a config templating `deploy.kubectl.defaultNamespace: "myapp-{{.environment}}"`, running `environment=pr-88 skaffold diagnose --yaml-only` (no flag) now resolves to `defaultNamespace: myapp-pr-88` instead of leaving the literal template
- [x] `go test ./cmd/skaffold/app/cmd/ -run TestDoDiagnose` passes
- [x] Existing `integration/diagnose_test.go` cases that assert on non-templated testdata are unaffected (no `{{ }}` syntax in those fixtures)