### PR TITLE
fix(verify): preserve job manifest command and args

### DIFF
--- a/integration/testdata/verify-fail-k8s/failing-job.yaml
+++ b/integration/testdata/verify-fail-k8s/failing-job.yaml
@@ -1,0 +1,14 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: failing-job-manifest
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      containers:
+        - name: failing-job-manifest
+          image: alpine:3.15.4
+          command: ["/bin/sh"]
+          args: ["-c", "echo failure from job manifest; exit 1"]
+      restartPolicy: Never

--- a/integration/testdata/verify-fail-k8s/skaffold.yaml
+++ b/integration/testdata/verify-fail-k8s/skaffold.yaml
@@ -17,6 +17,16 @@ verify:
       kubernetesCluster: {}
 
 profiles:
+  - name: with-failing-job-manifest
+    verify:
+      - name: failing-job-manifest
+        executionMode:
+          kubernetesCluster:
+            jobManifestPath: failing-job.yaml
+        container:
+          name: failing-job-manifest
+          image: alpine:3.15.4
+
   - name: no-duplicated-logs
     verify:
       - name: alpine-1

--- a/integration/verify_test.go
+++ b/integration/verify_test.go
@@ -147,6 +147,15 @@ func TestKubernetesJobVerifyEnvVarFromJobManifest(t *testing.T) {
 	testutil.CheckContains(t, "ZZZ with-job-manifest", logs)
 }
 
+func TestKubernetesJobVerifyFailureFromJobManifest(t *testing.T) {
+	MarkIntegrationTest(t, CanRunWithoutGcp)
+
+	out, err := skaffold.Verify("--default-repo=", "-p", "with-failing-job-manifest").InDir("testdata/verify-fail-k8s").RunWithCombinedOutput(t)
+
+	testutil.CheckError(t, true, err)
+	testutil.CheckContains(t, "failure from job manifest", string(out))
+}
+
 func TestKubernetesJobVerifyOneTestFailsWithEnvVar(t *testing.T) {
 	MarkIntegrationTest(t, CanRunWithoutGcp)
 	tmp := t.TempDir()

--- a/pkg/skaffold/verify/k8sjob/verify.go
+++ b/pkg/skaffold/verify/k8sjob/verify.go
@@ -411,8 +411,12 @@ func (v *Verifier) createJobFromManifestPath(jobName string, container latest.Ve
 
 func patchToK8sContainer(container latest.VerifyContainer, dst *corev1.Container) {
 	dst.Image = container.Image
-	dst.Command = container.Command
-	dst.Args = container.Args
+	if container.Command != nil {
+		dst.Command = container.Command
+	}
+	if container.Args != nil {
+		dst.Args = container.Args
+	}
 	dst.Name = container.Name
 
 	for _, e := range container.Env {

--- a/pkg/skaffold/verify/k8sjob/verify_test.go
+++ b/pkg/skaffold/verify/k8sjob/verify_test.go
@@ -91,6 +91,46 @@ func TestPatchToK8sContainer(t *testing.T) {
 			},
 		},
 		{
+			description: "preserve command and args when not configured",
+			verifyContainer: latest.VerifyContainer{
+				Name:  "my-container",
+				Image: "my-new-image:latest",
+			},
+			k8sContainer: corev1.Container{
+				Name:    "my-container",
+				Image:   "my-image:latest",
+				Command: []string{"/bin/sh"},
+				Args:    []string{"-c", "exit 1"},
+			},
+			expected: corev1.Container{
+				Name:    "my-container",
+				Image:   "my-new-image:latest",
+				Command: []string{"/bin/sh"},
+				Args:    []string{"-c", "exit 1"},
+			},
+		},
+		{
+			description: "clear command and args when explicitly configured empty",
+			verifyContainer: latest.VerifyContainer{
+				Name:    "my-container",
+				Image:   "my-image:latest",
+				Command: []string{},
+				Args:    []string{},
+			},
+			k8sContainer: corev1.Container{
+				Name:    "my-container",
+				Image:   "my-image:latest",
+				Command: []string{"/bin/sh"},
+				Args:    []string{"-c", "exit 1"},
+			},
+			expected: corev1.Container{
+				Name:    "my-container",
+				Image:   "my-image:latest",
+				Command: []string{},
+				Args:    []string{},
+			},
+		},
+		{
 			description: "update name",
 			verifyContainer: latest.VerifyContainer{
 				Name: "my-new-container",


### PR DESCRIPTION
Fixes: #10073

**Description**

When `jobManifestPath` is set, Skaffold uses the manifest container as a base and patches it with the `verify.container` configuration. The patch currently overwrites `command` and `args` even when those optional fields are omitted, so a failing command defined in the Job manifest is cleared before the Job runs.

Preserve the manifest values when the corresponding Skaffold fields are omitted. Explicitly configured values, including empty arrays, continue to override the manifest.

**User facing changes**

A verify test can define its command and arguments in the referenced Kubernetes Job manifest. Skaffold now runs that command and reports its non-zero exit as a verification failure.

**Tests**

- Added table-driven unit coverage for omitted and explicitly empty command/args.
- Added a Kubernetes integration regression test with a failing command defined only in the Job manifest.
- `go test -race ./pkg/skaffold/verify/k8sjob`
- `make quicktest`
- `make checks`
- `make linters`
- Integration test passed against a disposable Kind v1.36.1 cluster.