### PR TITLE
perf(helm): reuse the v4 post-renderer plugin and helm version across a run

### DIFF
--- a/cmd/skaffold/skaffold.go
+++ b/cmd/skaffold/skaffold.go
@@ -24,6 +24,7 @@ import (
 	"cloud.google.com/go/profiler"
 
 	"github.com/GoogleContainerTools/skaffold/v2/cmd/skaffold/app"
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/helm"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/instrumentation"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/output/log"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/version"
@@ -50,6 +51,9 @@ func main() {
 		// ignore cancelled errors
 		code = app.ExitCode(err)
 	}
+	// The Helm v4 post-renderer plugin is installed once and shared for the whole
+	// run rather than per release, so it is removed here instead of by each caller.
+	helm.CleanupSharedPostRenderer(context.Background())
 	instrumentation.ShutdownAndFlush(context.Background(), code)
 	os.Exit(code)
 }

--- a/pkg/skaffold/deploy/helm/helm_test.go
+++ b/pkg/skaffold/deploy/helm/helm_test.go
@@ -471,6 +471,8 @@ func TestNewDeployer(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunWithOutput("helm version", test.helmVersion))
+			helm.ResetBinVerCacheForTest()
+			t.Cleanup(helm.ResetBinVerCacheForTest)
 
 			_, err := NewDeployer(context.Background(), &helmConfig{}, &label.DefaultLabeller{}, &testDeployConfig, nil, "default", nil)
 			t.CheckError(test.shouldErr, err)
@@ -1108,6 +1110,8 @@ func TestHelmDeploy(t *testing.T) {
 			t.Override(&warnings.Printf, fakeWarner.Warnf)
 			t.Override(&util.OSEnviron, func() []string { return env })
 			t.Override(&util.DefaultExecCommand, test.commands)
+			helm.ResetBinVerCacheForTest()
+			t.Cleanup(helm.ResetBinVerCacheForTest)
 			t.Override(&helm.OSExecutable, func() (string, error) { return "SKAFFOLD-BINARY", nil })
 			t.Override(&helm.PluginInstallDir, "TEMPORARY-TEST-DIR/PLUGIN-NAME")
 			helm.ResetSharedPostRendererForTest()
@@ -1215,6 +1219,8 @@ func TestHelmDeployConcurrently(t *testing.T) {
 			t.Override(&warnings.Printf, fakeWarner.Warnf)
 			t.Override(&util.OSEnviron, func() []string { return env })
 			t.Override(&util.DefaultExecCommand, test.commands)
+			helm.ResetBinVerCacheForTest()
+			t.Cleanup(helm.ResetBinVerCacheForTest)
 			t.Override(&helm.OSExecutable, func() (string, error) { return "SKAFFOLD-BINARY", nil })
 			t.Override(&helm.PluginInstallDir, "TEMPORARY-TEST-DIR/PLUGIN-NAME")
 			helm.ResetSharedPostRendererForTest()
@@ -1311,6 +1317,8 @@ func TestHelmCleanup(t *testing.T) {
 			t.Override(&warnings.Printf, fakeWarner.Warnf)
 			t.Override(&util.OSEnviron, func() []string { return []string{"FOO=FOOBAR"} })
 			t.Override(&util.DefaultExecCommand, test.commands)
+			helm.ResetBinVerCacheForTest()
+			t.Cleanup(helm.ResetBinVerCacheForTest)
 
 			deployer, err := NewDeployer(context.Background(), &helmConfig{
 				namespace: test.namespace,
@@ -1409,6 +1417,8 @@ func TestHelmDependencies(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunWithOutput("helm version", version31))
+			helm.ResetBinVerCacheForTest()
+			t.Cleanup(helm.ResetBinVerCacheForTest)
 			tmpDir := t.NewTempDir().Touch(test.files...)
 			var local, remote string
 			if test.remote {
@@ -1688,6 +1698,8 @@ func TestHelmRender(t *testing.T) {
 			t.Override(&helm.PluginInstallDir, "TEMPORARY-TEST-DIR/PLUGIN-NAME")
 			helm.ResetSharedPostRendererForTest()
 			t.Override(&util.DefaultExecCommand, test.commands)
+			helm.ResetBinVerCacheForTest()
+			t.Cleanup(helm.ResetBinVerCacheForTest)
 			helmRenderer, err := rhelm.New(context.TODO(), &helmConfig{
 				namespace: test.namespace,
 			}, latest.RenderConfig{
@@ -1733,6 +1745,8 @@ func TestHelmHooks(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunWithOutput("helm version", version31))
+			helm.ResetBinVerCacheForTest()
+			t.Cleanup(helm.ResetBinVerCacheForTest)
 			t.Override(&hooks.NewDeployRunner, func(*ctl.CLI, latest.DeployHooks, *[]string, logger.Formatter, hooks.DeployEnvOpts, *[]string) hooks.Runner {
 				return test.runner
 			})
@@ -1790,6 +1804,8 @@ func TestHasRunnableHooks(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunWithOutput("helm version", version31))
+			helm.ResetBinVerCacheForTest()
+			t.Cleanup(helm.ResetBinVerCacheForTest)
 			k, err := NewDeployer(context.Background(), &helmConfig{}, &label.DefaultLabeller{}, &test.cfg, nil, "default", nil)
 			t.RequireNoError(err)
 			actual := k.HasRunnableHooks()

--- a/pkg/skaffold/deploy/helm/helm_test.go
+++ b/pkg/skaffold/deploy/helm/helm_test.go
@@ -1110,6 +1110,7 @@ func TestHelmDeploy(t *testing.T) {
 			t.Override(&util.DefaultExecCommand, test.commands)
 			t.Override(&helm.OSExecutable, func() (string, error) { return "SKAFFOLD-BINARY", nil })
 			t.Override(&helm.PluginInstallDir, "TEMPORARY-TEST-DIR/PLUGIN-NAME")
+			helm.ResetSharedPostRendererForTest()
 			t.Override(&kubectx.CurrentConfig, func() (api.Config, error) {
 				return api.Config{CurrentContext: ""}, nil
 			})
@@ -1216,6 +1217,7 @@ func TestHelmDeployConcurrently(t *testing.T) {
 			t.Override(&util.DefaultExecCommand, test.commands)
 			t.Override(&helm.OSExecutable, func() (string, error) { return "SKAFFOLD-BINARY", nil })
 			t.Override(&helm.PluginInstallDir, "TEMPORARY-TEST-DIR/PLUGIN-NAME")
+			helm.ResetSharedPostRendererForTest()
 			t.Override(&kubectx.CurrentConfig, func() (api.Config, error) {
 				return api.Config{CurrentContext: ""}, nil
 			})
@@ -1684,6 +1686,7 @@ func TestHelmRender(t *testing.T) {
 			t.Override(&util.OSEnviron, func() []string { return append([]string{"FOO=FOOBAR"}, test.env...) })
 			t.Override(&helm.OSExecutable, func() (string, error) { return "SKAFFOLD-BINARY", nil })
 			t.Override(&helm.PluginInstallDir, "TEMPORARY-TEST-DIR/PLUGIN-NAME")
+			helm.ResetSharedPostRendererForTest()
 			t.Override(&util.DefaultExecCommand, test.commands)
 			helmRenderer, err := rhelm.New(context.TODO(), &helmConfig{
 				namespace: test.namespace,

--- a/pkg/skaffold/helm/bin.go
+++ b/pkg/skaffold/helm/bin.go
@@ -27,6 +27,7 @@ import (
 	"path"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/blang/semver"
@@ -95,6 +96,62 @@ func BinVer(ctx context.Context) (semver.Version, error) {
 	return semver.ParseTolerant(matches[1])
 }
 
+// sharedPostRenderer memoizes the Helm v4 post-renderer plugin for the lifetime
+// of the process.
+//
+// The plugin manifest depends only on the Skaffold binary path: everything that
+// varies per release or per config (labels, image replacements, debug settings,
+// kubeconfig) travels in SKAFFOLD_CMDLINE at `helm template` / `helm install`
+// invocation time, not in the manifest. So the plugin installed for one release
+// is byte-identical to the next, apart from its randomly generated name, and one
+// installed plugin serves the whole run.
+//
+// Installing it per call is paid once per RELEASE on the deploy path and once
+// per CONFIG on the render path.
+var sharedPostRenderer struct {
+	mu     sync.Mutex
+	binary string // Skaffold binary the installed plugin points at
+	name   string // installed plugin name, empty when nothing is installed
+	dir    string
+	client Client // client used to install it; reused to uninstall
+}
+
+// ResetSharedPostRendererForTest drops the memoized plugin without shelling out
+// to Helm. The cache is process-wide, so tests that assert on the
+// `helm plugin install` command sequence must reset it or they observe each
+// other's installs.
+func ResetSharedPostRendererForTest() {
+	sharedPostRenderer.mu.Lock()
+	defer sharedPostRenderer.mu.Unlock()
+	sharedPostRenderer.name = ""
+	sharedPostRenderer.dir = ""
+	sharedPostRenderer.binary = ""
+	sharedPostRenderer.client = nil
+}
+
+// CleanupSharedPostRenderer uninstalls the process-wide post-renderer plugin, if
+// one was installed. Safe to call when none was. Intended for a single call at
+// process shutdown, since the plugin is deliberately kept installed across
+// renders and deploys.
+//
+// It reuses the Client captured at install time: generateHelmCommand
+// dereferences the Client for GlobalFlags() regardless of subcommand, so a nil
+// one would panic here.
+func CleanupSharedPostRenderer(ctx context.Context) {
+	sharedPostRenderer.mu.Lock()
+	defer sharedPostRenderer.mu.Unlock()
+	if sharedPostRenderer.name == "" {
+		return
+	}
+	Exec(ctx, sharedPostRenderer.client, new(bytes.Buffer), false, nil,
+		"plugin", "uninstall", sharedPostRenderer.name)
+	os.RemoveAll(sharedPostRenderer.dir)
+	sharedPostRenderer.name = ""
+	sharedPostRenderer.dir = ""
+	sharedPostRenderer.binary = ""
+	sharedPostRenderer.client = nil
+}
+
 // PreparePostRenderer conditionally installs a post renderer plugin (starting from Helm v4) and returns
 // an optional cleanup function in that case, plus in any case the needed command line arguments
 func PreparePostRenderer(ctx context.Context, h Client, skaffoldBinary string, helmVersion semver.Version) (func(), []string, error) {
@@ -103,6 +160,12 @@ func PreparePostRenderer(ctx context.Context, h Client, skaffoldBinary string, h
 	}
 
 	// Helm v4 logic
+
+	sharedPostRenderer.mu.Lock()
+	defer sharedPostRenderer.mu.Unlock()
+	if sharedPostRenderer.name != "" && sharedPostRenderer.binary == skaffoldBinary {
+		return nil, []string{"--post-renderer", sharedPostRenderer.name}, nil
+	}
 
 	skaffoldBinaryAsYaml, err := yaml.Marshal(skaffoldBinary)
 	if err != nil {
@@ -137,11 +200,14 @@ func PreparePostRenderer(ctx context.Context, h Client, skaffoldBinary string, h
 		return nil, nil, PluginErr("Failed to install Helm plugin", errors.New(strings.TrimSpace(out.String())))
 	}
 
-	cleanUp := func() {
-		Exec(ctx, h, out, false, nil, "plugin", "uninstall", helmPluginName)
-		os.RemoveAll(helmPluginDir)
-	}
-	return cleanUp, []string{"--post-renderer", helmPluginName}, nil
+	// Keep it installed for the rest of the run; CleanupSharedPostRenderer removes
+	// it at shutdown. Returning a nil cleanup is what stops each caller's `defer`
+	// from uninstalling it again immediately.
+	sharedPostRenderer.binary = skaffoldBinary
+	sharedPostRenderer.name = helmPluginName
+	sharedPostRenderer.dir = helmPluginDir
+	sharedPostRenderer.client = h
+	return nil, []string{"--post-renderer", helmPluginName}, nil
 }
 
 func PrepareSkaffoldFilter(h Client, builds []graph.Artifact, flags []string) (skaffoldBinary string, env []string, cleanup func(), err error) {

--- a/pkg/skaffold/helm/bin.go
+++ b/pkg/skaffold/helm/bin.go
@@ -79,8 +79,39 @@ type Client interface {
 	ManifestOverrides() map[string]string
 }
 
+// binVerCache memoizes `helm version` for the process. The helm binary on PATH
+// cannot change mid-run, and this is called once per deployer and once per
+// renderer — 23 times on a 21-config monorepo, at ~0.45s a call.
+var binVerCache struct {
+	mu     sync.Mutex
+	ver    semver.Version
+	err    error
+	cached bool
+}
+
+// ResetBinVerCacheForTest clears the memoized `helm version`. Tests that assert
+// on the executed command sequence need this, since the cache is process-wide.
+func ResetBinVerCacheForTest() {
+	binVerCache.mu.Lock()
+	defer binVerCache.mu.Unlock()
+	binVerCache.cached = false
+	binVerCache.err = nil
+	binVerCache.ver = semver.Version{}
+}
+
 // BinVer returns the version of the helm binary found in PATH.
 func BinVer(ctx context.Context) (semver.Version, error) {
+	binVerCache.mu.Lock()
+	defer binVerCache.mu.Unlock()
+	if binVerCache.cached {
+		return binVerCache.ver, binVerCache.err
+	}
+	ver, err := binVer(ctx)
+	binVerCache.ver, binVerCache.err, binVerCache.cached = ver, err, true
+	return ver, err
+}
+
+func binVer(ctx context.Context) (semver.Version, error) {
 	// Helm v2 needed the `--client` to avoid connecting to Kubernetes.
 	// Support for Helm v2 was dropped here.
 	cmd := exec.CommandContext(ctx, "helm", "version")

--- a/pkg/skaffold/helm/bin_test.go
+++ b/pkg/skaffold/helm/bin_test.go
@@ -77,6 +77,8 @@ func TestBinVer(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
+			ResetBinVerCacheForTest()
+			t.Cleanup(ResetBinVerCacheForTest)
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunWithOutput("helm version", test.helmVersion))
 			ver, err := BinVer(context.Background())
 

--- a/pkg/skaffold/helm/postrenderer_shared_test.go
+++ b/pkg/skaffold/helm/postrenderer_shared_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2026 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helm
+
+import (
+	"context"
+	"testing"
+
+	"github.com/blang/semver"
+
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/util"
+	"github.com/GoogleContainerTools/skaffold/v2/testutil"
+)
+
+const testPluginDir = "TEMPORARY-TEST-DIR/PLUGIN-NAME"
+
+// The plugin manifest depends only on the Skaffold binary path — everything that
+// varies per release travels in SKAFFOLD_CMDLINE — so it is installed once and
+// reused for the whole run. Installing per call cost ~0.54s per cycle, paid once
+// per release on the deploy path and once per config on the render path: 21
+// installs + 21 uninstalls on a 21-release monorepo.
+//
+// CmdRun asserts the EXACT command sequence, so a single expected
+// `helm plugin install` across five calls is the assertion.
+func TestPreparePostRendererInstallsOncePerProcess(t *testing.T) {
+	testutil.Run(t, "installs once across many calls", func(t *testutil.T) {
+		ResetSharedPostRendererForTest()
+		t.Cleanup(ResetSharedPostRendererForTest)
+		t.Override(&PluginInstallDir, testPluginDir)
+		t.Override(&util.DefaultExecCommand,
+			testutil.CmdRun("helm plugin install "+testPluginDir))
+
+		helm4 := semver.MustParse("4.2.3")
+		var first []string
+		for i := 0; i < 5; i++ {
+			cleanup, args, err := PreparePostRenderer(
+				context.Background(), mockClient{}, "/path/to/skaffold", helm4)
+			t.CheckNoError(err)
+			// A non-nil cleanup would uninstall the shared plugin the moment the
+			// caller's defer ran, reinstating the per-call install.
+			t.CheckDeepEqual(true, cleanup == nil)
+			if i == 0 {
+				first = args
+				continue
+			}
+			t.CheckDeepEqual(first, args)
+		}
+		t.CheckDeepEqual("--post-renderer", first[0])
+	})
+}
+
+// A different Skaffold binary means a different plugin manifest, so the cache
+// must not hand back the old plugin.
+func TestPreparePostRendererReinstallsForDifferentBinary(t *testing.T) {
+	testutil.Run(t, "reinstalls when the binary changes", func(t *testutil.T) {
+		ResetSharedPostRendererForTest()
+		t.Cleanup(ResetSharedPostRendererForTest)
+		t.Override(&PluginInstallDir, testPluginDir)
+		t.Override(&util.DefaultExecCommand, testutil.
+			CmdRun("helm plugin install "+testPluginDir).
+			AndRun("helm plugin install "+testPluginDir))
+
+		helm4 := semver.MustParse("4.2.3")
+		_, _, err := PreparePostRenderer(context.Background(), mockClient{}, "/bin/one", helm4)
+		t.CheckNoError(err)
+		_, _, err = PreparePostRenderer(context.Background(), mockClient{}, "/bin/two", helm4)
+		t.CheckNoError(err)
+		t.CheckDeepEqual("/bin/two", sharedPostRenderer.binary)
+	})
+}
+
+// Helm v3 takes the executable directly and must never install a plugin.
+func TestPreparePostRendererHelm3NeedsNoPlugin(t *testing.T) {
+	ResetSharedPostRendererForTest()
+	t.Cleanup(ResetSharedPostRendererForTest)
+
+	cleanup, args, err := PreparePostRenderer(
+		context.Background(), mockClient{}, "/path/to/skaffold", semver.MustParse("3.19.0"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cleanup != nil {
+		t.Error("helm v3 must not return a plugin cleanup")
+	}
+	if len(args) != 2 || args[0] != "--post-renderer" || args[1] != "/path/to/skaffold" {
+		t.Errorf("helm v3 should pass the binary directly, got %v", args)
+	}
+	if sharedPostRenderer.name != "" {
+		t.Error("helm v3 must not install a shared plugin")
+	}
+}
+
+func TestCleanupSharedPostRendererIsSafeWhenNothingInstalled(t *testing.T) {
+	ResetSharedPostRendererForTest()
+	// Must not panic and must not shell out to helm.
+	CleanupSharedPostRenderer(context.Background())
+}


### PR DESCRIPTION
**Draft** — opening early for direction before I invest further. Happy to split,
reshape, or drop either commit.

### Summary

Two pieces of per-call work in the Helm renderer/deployer that are invariant for
the lifetime of the process, but are paid **once per release** on the deploy path
and **once per config** on the render path.

Two independent commits, reviewable separately:

1. **`perf(helm): install the v4 post-renderer plugin once per run, not per release`**

   Since `4.0.0-beta.1`, `PreparePostRenderer` installs Skaffold's post-renderer
   as a Helm plugin, and does so on every call: create a temp dir, write a
   manifest, `helm plugin install`, then the caller's `defer` runs
   `helm plugin uninstall`.

   The manifest depends only on the Skaffold binary path. Everything that varies
   per release — labels, image replacements, debug settings, kubeconfig —
   travels in `SKAFFOLD_CMDLINE` at `helm template` / `helm install` invocation
   time, not in the manifest. So the plugin installed for release N is
   byte-identical to the one for release N+1 apart from its randomly generated
   name.

   Now installed once, keyed on the Skaffold binary, and removed at process
   shutdown via `CleanupSharedPostRenderer`. A different binary still forces a
   reinstall.

   **Helm v3 is unaffected** — that path passes `--post-renderer <executable>`
   and installs no plugin at all, which is why this is invisible to most users
   today.

2. **`perf(helm): memoize `helm version``**

   `BinVer` shells out per deployer and per renderer. The helm binary on PATH
   cannot change mid-run.

### Impact

Measured on a repository with 21 Helm releases across 21 configs (`skaffold
render`, warm caches, alternating A/B against the same commit, 6 runs each):

| | before | after |
|---|---|---|
| helm subprocesses | 107 | **45** |
| — `plugin install`/`uninstall` | 42 | 2 |
| — `helm version` | 23 | 1 |
| wall clock (mean) | 33.63s | **19.61s** |

The distributions do not overlap (before 32.01–35.21s, after 19.03–20.70s), and
**rendered output is byte-identical** before and after (179,484 bytes).

The saving scales with release count, so it is negligible for a handful of
releases and material for a large monorepo. It also compounds with
[#8363](https://github.com/GoogleContainerTools/skaffold/issues/8363) /
[#5417](https://github.com/GoogleContainerTools/skaffold/issues/5417) (serial
render/deploy of Helm releases) — this doesn't address that, it just stops each
serialized release from paying avoidable subprocess overhead.

### Risks / things worth reviewer attention

- **Both caches are process-wide.** That is the point, but it means tests that
  assert on the executed command sequence observe each other. I added
  `ResetSharedPostRendererForTest` and `ResetBinVerCacheForTest` and wired them
  into the affected tests. If you'd prefer a different mechanism (a `TestMain`
  reset, or threading state through a struct rather than package-level), say so —
  package-level state was chosen to keep the diff small, not because it's the
  nicest shape.
- **`CleanupSharedPostRenderer` is called from `main()`**, after `app.Run`. That
  is a new shutdown responsibility; if there's a more idiomatic teardown hook I
  missed, point me at it.
- It captures the `Client` used at install time to uninstall with, because
  `generateHelmCommand` dereferences the `Client` for `GlobalFlags()` regardless
  of subcommand, so passing `nil` there would panic.
- Behaviour change on the error path: `BinVer` now memoizes failures too, so a
  broken `helm` reports the same error per call instead of re-executing. That
  seemed right, but it is a change.

### Testing

- New tests: plugin installed once across repeated calls, reinstall on a changed
  binary, Helm v3 installs no plugin, cleanup safe when nothing installed.
- `go test ./pkg/skaffold/helm/... ./pkg/skaffold/deploy/helm/... ./pkg/skaffold/render/renderer/helm/...` passes.
- `go build ./...` and `go vet` clean.

I have not run the integration suite — happy to if that's expected before this
leaves draft.

### CLA

Not yet signed. I'll get that sorted before this is ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
