### PR TITLE
feat: report why an artifact is being rebuilt on a cache miss

### DIFF
--- a/docs-v2/content/en/docs/tutorials/artifact-dependencies.md
+++ b/docs-v2/content/en/docs/tutorials/artifact-dependencies.md
@@ -40,8 +40,8 @@ If this is the first time you're running this, then it should build the artifact
 
 ```text
 Checking cache...
- - base: Not found. Building
- - app: Not found. Building
+ - base: Not found. Building (no cached build for the current inputs)
+ - app: Not found. Building (no cached build for the current inputs)
 
 Building [base]...
 <docker build logs here>

--- a/pkg/skaffold/build/cache/details.go
+++ b/pkg/skaffold/build/cache/details.go
@@ -39,9 +39,40 @@ func (d failed) Hash() string {
 	return ""
 }
 
+// rebuildReason describes why a cache lookup concluded that an artifact has to be rebuilt.
+// It is derived only from what the lookup already knows, so that the two very different
+// causes -- the artifact's inputs changed, and the previously built image disappeared --
+// can be told apart in the output.
+type rebuildReason int
+
+const (
+	// rebuildUnknown is the zero value, used when no reason was determined.
+	rebuildUnknown rebuildReason = iota
+	// rebuildNoCacheEntry means the artifact's current hash has no entry in the artifact
+	// cache: either one of its inputs changed, or it was never built before.
+	rebuildNoCacheEntry
+	// rebuildImageMissing means the current hash does have a cache entry, but the image it
+	// refers to can no longer be found locally or remotely, typically because it was pruned.
+	rebuildImageMissing
+)
+
+// description returns the explanation appended to "Not found. Building", or "" for
+// rebuildUnknown so that the line is printed unchanged.
+func (r rebuildReason) description() string {
+	switch r {
+	case rebuildNoCacheEntry:
+		return "no cached build for the current inputs"
+	case rebuildImageMissing:
+		return "cached image is no longer available"
+	default:
+		return ""
+	}
+}
+
 // Not found, needs building
 type needsBuilding struct {
-	hash string
+	hash   string
+	reason rebuildReason
 }
 
 func (d needsBuilding) Hash() string {

--- a/pkg/skaffold/build/cache/lookup.go
+++ b/pkg/skaffold/build/cache/lookup.go
@@ -83,7 +83,7 @@ func (c *cache) lookup(ctx context.Context, out io.Writer, a *latest.Artifact, t
 		}
 		if entry, err = c.tryImport(ctx, a, tag, hash, pl); err != nil {
 			log.Entry(ctx).Debugf("Could not import artifact from Docker, building instead (%s)", err)
-			return needsBuilding{hash: hash}
+			return needsBuilding{hash: hash, reason: rebuildReasonFor(entry)}
 		}
 	}
 
@@ -95,9 +95,20 @@ func (c *cache) lookup(ctx context.Context, out io.Writer, a *latest.Artifact, t
 	return c.lookupRemote(ctx, hash, tag, pls.Platforms, entry)
 }
 
+// rebuildReasonFor derives why an artifact is being rebuilt from the cache entry, if any,
+// that was found for its current hash. A zero entry means this hash was never recorded, so
+// one of the artifact's inputs must have changed; a populated one means the build was
+// recorded but its image can no longer be found.
+func rebuildReasonFor(entry ImageDetails) rebuildReason {
+	if entry.ID == "" && entry.Digest == "" {
+		return rebuildNoCacheEntry
+	}
+	return rebuildImageMissing
+}
+
 func (c *cache) lookupLocal(ctx context.Context, hash, tag string, entry ImageDetails) cacheDetails {
 	if entry.ID == "" {
-		return needsBuilding{hash: hash}
+		return needsBuilding{hash: hash, reason: rebuildReasonFor(entry)}
 	}
 
 	// Check the imageID for the tag
@@ -117,7 +128,7 @@ func (c *cache) lookupLocal(ctx context.Context, hash, tag string, entry ImageDe
 		return needsLocalTagging{hash: hash, tag: tag, imageID: entry.ID}
 	}
 
-	return needsBuilding{hash: hash}
+	return needsBuilding{hash: hash, reason: rebuildReasonFor(entry)}
 }
 
 func (c *cache) lookupRemote(ctx context.Context, hash, tag string, platforms []specs.Platform, entry ImageDetails) cacheDetails {
@@ -141,7 +152,7 @@ func (c *cache) lookupRemote(ctx context.Context, hash, tag string, platforms []
 		return needsPushing{hash: hash, tag: tag, imageID: entry.ID}
 	}
 
-	return needsBuilding{hash: hash}
+	return needsBuilding{hash: hash, reason: rebuildReasonFor(entry)}
 }
 
 func (c *cache) tryImport(ctx context.Context, a *latest.Artifact, tag string, hash string, pl v1.Platform) (ImageDetails, error) {

--- a/pkg/skaffold/build/cache/lookup_test.go
+++ b/pkg/skaffold/build/cache/lookup_test.go
@@ -37,6 +37,64 @@ import (
 	"github.com/GoogleContainerTools/skaffold/v2/testutil"
 )
 
+func TestRebuildReasonDescription(t *testing.T) {
+	tests := []struct {
+		description string
+		reason      rebuildReason
+		expected    string
+	}{
+		{
+			description: "unknown reason is not described",
+			reason:      rebuildUnknown,
+			expected:    "",
+		},
+		{
+			description: "no cache entry",
+			reason:      rebuildNoCacheEntry,
+			expected:    "no cached build for the current inputs",
+		},
+		{
+			description: "image missing",
+			reason:      rebuildImageMissing,
+			expected:    "cached image is no longer available",
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.CheckDeepEqual(test.expected, test.reason.description())
+		})
+	}
+}
+
+func TestRebuildReasonFor(t *testing.T) {
+	tests := []struct {
+		description string
+		entry       ImageDetails
+		expected    rebuildReason
+	}{
+		{
+			description: "no entry recorded for this hash",
+			entry:       ImageDetails{},
+			expected:    rebuildNoCacheEntry,
+		},
+		{
+			description: "entry recorded with an image ID",
+			entry:       ImageDetails{ID: "imageID"},
+			expected:    rebuildImageMissing,
+		},
+		{
+			description: "entry recorded with only a digest",
+			entry:       ImageDetails{Digest: "digest"},
+			expected:    rebuildImageMissing,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.CheckDeepEqual(test.expected, rebuildReasonFor(test.entry))
+		})
+	}
+}
+
 func TestLookupLocal(t *testing.T) {
 	tests := []struct {
 		description string
@@ -50,7 +108,7 @@ func TestLookupLocal(t *testing.T) {
 			hasher:      mockHasher{"thehash"},
 			api:         &testutil.FakeAPIClient{},
 			cache:       map[string]ImageDetails{},
-			expected:    needsBuilding{hash: "thehash"},
+			expected:    needsBuilding{hash: "thehash", reason: rebuildNoCacheEntry},
 		},
 		{
 			description: "hash failure",
@@ -63,7 +121,7 @@ func TestLookupLocal(t *testing.T) {
 			cache: map[string]ImageDetails{
 				"hash": {Digest: "ignored"},
 			},
-			expected: needsBuilding{hash: "hash"},
+			expected: needsBuilding{hash: "hash", reason: rebuildImageMissing},
 		},
 		{
 			description: "hit but not found",
@@ -72,7 +130,7 @@ func TestLookupLocal(t *testing.T) {
 				"hash": {ID: "imageID"},
 			},
 			api:      &testutil.FakeAPIClient{},
-			expected: needsBuilding{hash: "hash"},
+			expected: needsBuilding{hash: "hash", reason: rebuildImageMissing},
 		},
 		{
 			description: "hit but not found with error",
@@ -115,7 +173,7 @@ func TestLookupLocal(t *testing.T) {
 				"hash": {ID: "imageID"},
 			},
 			api:      (&testutil.FakeAPIClient{}).Add("tag", "otherImageID"),
-			expected: needsBuilding{hash: "hash"},
+			expected: needsBuilding{hash: "hash", reason: rebuildImageMissing},
 		},
 	}
 	for _, test := range tests {
@@ -154,7 +212,7 @@ func TestLookupRemote(t *testing.T) {
 			hasher:      mockHasher{"hash"},
 			api:         &testutil.FakeAPIClient{ErrImagePull: true},
 			cache:       map[string]ImageDetails{},
-			expected:    needsBuilding{hash: "hash"},
+			expected:    needsBuilding{hash: "hash", reason: rebuildNoCacheEntry},
 		},
 		{
 			description: "hash failure",
@@ -193,7 +251,7 @@ func TestLookupRemote(t *testing.T) {
 				"hash": {ID: "imageID"},
 			},
 			api:      &testutil.FakeAPIClient{},
-			expected: needsBuilding{hash: "hash"},
+			expected: needsBuilding{hash: "hash", reason: rebuildImageMissing},
 		},
 	}
 	for _, test := range tests {

--- a/pkg/skaffold/build/cache/retrieve.go
+++ b/pkg/skaffold/build/cache/retrieve.go
@@ -76,7 +76,11 @@ func (c *cache) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, ar
 
 		case needsBuilding:
 			eventV2.CacheCheckMiss(artifact.ImageName, platforms.GetPlatforms(artifact.ImageName).String())
-			output.Yellow.Fprintln(out, "Not found. Building")
+			if reason := result.reason.description(); reason != "" {
+				output.Yellow.Fprintf(out, "Not found. Building (%s)\n", reason)
+			} else {
+				output.Yellow.Fprintln(out, "Not found. Building")
+			}
 			c.hashByName[artifact.ImageName] = result.Hash()
 			needToBuild = append(needToBuild, artifact)
 			continue

--- a/pkg/skaffold/build/cache/retrieve_test.go
+++ b/pkg/skaffold/build/cache/retrieve_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package cache
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/moby/moby/api/types/registry"
@@ -193,6 +195,66 @@ func TestCacheBuildLocal(t *testing.T) {
 		t.CheckDeepEqual(2, len(bRes))
 		t.CheckDeepEqual("artifact1", bRes[0].ImageName)
 		t.CheckDeepEqual("artifact2", bRes[1].ImageName)
+	})
+}
+
+func TestCacheBuildLocalReportsRebuildReason(t *testing.T) {
+	testutil.Run(t, "", func(t *testutil.T) {
+		tmpDir := t.NewTempDir().
+			Write("dep1", "content1").
+			Chdir()
+
+		tags := map[string]string{"artifact1": "artifact1:tag1"}
+		artifacts := []*latest.Artifact{
+			{ImageName: "artifact1", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{}}},
+		}
+		deps := depLister(map[string][]string{"artifact1": {"dep1"}})
+
+		// Mock Docker
+		t.Override(&docker.DefaultAuthHelper, stubAuth{})
+		dockerDaemon := fakeLocalDaemon(&testutil.FakeAPIClient{})
+		t.Override(&docker.NewAPIClient, func(context.Context, docker.Config) (docker.LocalDaemon, error) {
+			return dockerDaemon, nil
+		})
+		t.Override(&docker.EvalBuildArgsWithEnv, func(_ config.RunMode, _ string, _ string, args map[string]*string, _ map[string]*string, _ map[string]string) (map[string]*string, error) {
+			return args, nil
+		})
+
+		cfg := &mockConfig{
+			pipeline:  latest.Pipeline{Build: latest.BuildConfig{BuildType: latest.BuildType{LocalBuild: &latest.LocalBuild{TryImportMissing: false}}}},
+			cacheFile: tmpDir.Path("cache"),
+		}
+		store := make(mockArtifactStore)
+		artifactCache, err := NewCache(context.Background(), cfg, func(imageName string) (bool, error) { return true, nil }, deps, graph.ToArtifactGraph(artifacts), store)
+		t.CheckNoError(err)
+
+		// First build: nothing has ever been built, so there is no cache entry for this hash.
+		var out bytes.Buffer
+		builder := &mockBuilder{dockerDaemon: dockerDaemon, push: false, store: store, cache: artifactCache}
+		_, err = artifactCache.Build(context.Background(), &out, tags, artifacts, platform.Resolver{}, builder.Build)
+		t.CheckNoError(err)
+		if got := out.String(); !strings.Contains(got, "Not found. Building (no cached build for the current inputs)") {
+			t.Errorf("expected the rebuild reason to be reported, got:\n%s", got)
+		}
+
+		// Second build: the artifact is cached, so no reason is reported at all.
+		out.Reset()
+		builder = &mockBuilder{dockerDaemon: dockerDaemon, push: false, store: store, cache: artifactCache}
+		_, err = artifactCache.Build(context.Background(), &out, tags, artifacts, platform.Resolver{}, builder.Build)
+		t.CheckNoError(err)
+		if got := out.String(); strings.Contains(got, "Not found. Building") {
+			t.Errorf("expected a cache hit, got:\n%s", got)
+		}
+
+		// Third build: a dependency changed, so the new hash has no cache entry either.
+		out.Reset()
+		tmpDir.Write("dep1", "new content")
+		builder = &mockBuilder{dockerDaemon: dockerDaemon, push: false, store: store, cache: artifactCache}
+		_, err = artifactCache.Build(context.Background(), &out, tags, artifacts, platform.Resolver{}, builder.Build)
+		t.CheckNoError(err)
+		if got := out.String(); !strings.Contains(got, "Not found. Building (no cached build for the current inputs)") {
+			t.Errorf("expected the rebuild reason to be reported, got:\n%s", got)
+		}
 	})
 }
 


### PR DESCRIPTION
# PR 1 — branch `cache-miss-reason`

Title: feat: report why an artifact is being rebuilt on a cache miss

Fixes #10174

## What

`Not found. Building` says an artifact is being rebuilt but not why, so a
rebuild caused by a pruned image looks exactly like one caused by a source
change.

The cache lookup already distinguishes the two: it knows whether the artifact's
current hash had an entry in the artifact cache. This carries that into
`needsBuilding` as a typed reason and appends it to the existing line:

```
 - app: Not found. Building (no cached build for the current inputs)
 - api: Not found. Building (cached image is no longer available)
```

## Notes for review

- No new files, flags, lookups or I/O. The reason is derived from the cache
  entry the lookup already had in hand, so there is no behavioural change
  beyond the message.
- The reason is a typed value, formatted at the point of printing, so tests
  assert on the enum rather than on prose.
- The existing line is only ever suffixed, so anything matching on
  `Not found. Building` (including `integration/build_test.go` and
  `integration/build_dependencies_test.go`) keeps working.
- The sample output in `docs-v2/.../tutorials/artifact-dependencies.md` is
  updated to match what the command now prints.

## Testing

- `go test ./pkg/skaffold/build/cache/...` — new coverage for the reason
  derivation and for the printed output end to end.
- Full unit suite (`./pkg/skaffold/... ./cmd/... ./hack/... ./pkg/webhook/...`,
  `-race -short`) passes.
- `hack/boilerplate.sh`, `hack/check-schema-changes.sh`, `hack/check-samples.sh`,
  `hack/check-licenses.sh`, `hack/test-generated-proto.sh` and the docs site
  build all pass.
