### PR TITLE
feat: add --debug-cache to report which inputs caused a rebuild

### DIFF
--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -134,6 +134,15 @@ var flagRegistry = []Flag{
 		IsEnum:        true,
 	},
 	{
+		Name:          "debug-cache",
+		Usage:         "Record the inputs to each artifact's build cache hash, and report which of them changed when an artifact has to be rebuilt",
+		Value:         &opts.DebugCache,
+		DefValue:      false,
+		FlagAddMethod: "BoolVar",
+		DefinedOn:     []string{"dev", "build", "run", "debug"},
+		IsEnum:        true,
+	},
+	{
 		Name:          "cache-file",
 		Usage:         "Specify the location of the cache file (default $HOME/.skaffold/cache)",
 		Value:         &opts.CacheFile,

--- a/docs-v2/content/en/docs/builders/_index.md
+++ b/docs-v2/content/en/docs/builders/_index.md
@@ -27,3 +27,54 @@ to the `build` section.
 
 For detailed per-builder [Skaffold Configuration]({{< relref "/docs/design/config.md" >}}) options,
 see [skaffold.yaml References]({{< relref "/docs/references/yaml" >}}).
+
+## Build caching
+
+Skaffold caches built artifacts, and on each build it hashes everything that
+feeds an artifact — its configuration, its dependency files, its build args and
+its target platforms — to decide whether the artifact can be reused. When the
+hash matches a previous build whose image can still be found, the artifact is
+reused; otherwise it is rebuilt.
+
+Cache misses are reported with the reason they happened:
+
+```text
+Checking cache...
+ - app: Not found. Building (no cached build for the current inputs)
+ - api: Not found. Building (cached image is no longer available)
+```
+
+`no cached build for the current inputs` means something the artifact is built
+from has changed since the last build, or that it has never been built.
+`cached image is no longer available` means the inputs still match a previous
+build, but the image it produced can no longer be found locally or in the
+registry — it was pruned or evicted, and the rebuild simply recreates it.
+
+### Finding out which input changed
+
+To see *which* inputs changed rather than just that they did, run with
+`--debug-cache`:
+
+```bash
+skaffold build --debug-cache
+```
+
+Skaffold then records the inputs to each artifact's hash next to the cache file
+and compares them against the previous run, listing what differs:
+
+```text
+Checking cache...
+ - app: Not found. Building (inputs changed)
+     ~ src/handler.go
+     + src/middleware.go
+     - src/old_handler.go
+```
+
+`~` marks a changed input, `+` an added one and `-` a removed one. Alongside
+dependency files, the artifact's `config`, `build args` and `platforms` can
+appear in this list. The first run with `--debug-cache` has nothing to compare
+against, so it reports the ordinary reason instead.
+
+Only digests of the inputs are recorded, never their values, so build args
+holding credentials are not written to disk. The recorded snapshots live beside
+the cache file, so `--cache-file` also moves them.

--- a/docs-v2/content/en/docs/builders/_index.md
+++ b/docs-v2/content/en/docs/builders/_index.md
@@ -70,8 +70,10 @@ Checking cache...
      - src/old_handler.go
 ```
 
-`~` marks a changed input, `+` an added one and `-` a removed one. Alongside
-dependency files, the artifact's `config`, `build args` and `platforms` can
+`~` marks a changed input, `+` an added one and `-` a removed one. Dependency
+files are listed relative to the artifact's context, so the same project built
+from two different checkouts compares equal instead of reporting every file as
+moved. Alongside them, the artifact's `config`, `build args` and `platforms` can
 appear in this list. The first run with `--debug-cache` has nothing to compare
 against, so it reports the ordinary reason instead.
 

--- a/docs-v2/content/en/docs/references/cli/_index.md
+++ b/docs-v2/content/en/docs/references/cli/_index.md
@@ -267,6 +267,9 @@ Options:
     -c, --config='':
 	File for global configurations (defaults to $HOME/.skaffold/config)
 
+    --debug-cache=false:
+	Record the inputs to each artifact's build cache hash, and report which of them changed when an artifact has to be rebuilt
+
     -d, --default-repo='':
 	Default repository value (overrides global config)
 
@@ -364,6 +367,7 @@ Env vars:
 * `SKAFFOLD_CACHE_FILE` (same as `--cache-file`)
 * `SKAFFOLD_CHECK_CLUSTER_NODE_PLATFORMS` (same as `--check-cluster-node-platforms`)
 * `SKAFFOLD_CONFIG` (same as `--config`)
+* `SKAFFOLD_DEBUG_CACHE` (same as `--debug-cache`)
 * `SKAFFOLD_DEFAULT_REPO` (same as `--default-repo`)
 * `SKAFFOLD_DETECT_MINIKUBE` (same as `--detect-minikube`)
 * `SKAFFOLD_DISABLE_MULTI_PLATFORM_BUILD` (same as `--disable-multi-platform-build`)
@@ -581,6 +585,9 @@ Options:
     -c, --config='':
 	File for global configurations (defaults to $HOME/.skaffold/config)
 
+    --debug-cache=false:
+	Record the inputs to each artifact's build cache hash, and report which of them changed when an artifact has to be rebuilt
+
     -d, --default-repo='':
 	Default repository value (overrides global config)
 
@@ -733,6 +740,7 @@ Env vars:
 * `SKAFFOLD_CLOUD_RUN_LOCATION` (same as `--cloud-run-location`)
 * `SKAFFOLD_CLOUD_RUN_PROJECT` (same as `--cloud-run-project`)
 * `SKAFFOLD_CONFIG` (same as `--config`)
+* `SKAFFOLD_DEBUG_CACHE` (same as `--debug-cache`)
 * `SKAFFOLD_DEFAULT_REPO` (same as `--default-repo`)
 * `SKAFFOLD_DETECT_MINIKUBE` (same as `--detect-minikube`)
 * `SKAFFOLD_DISABLE_MULTI_PLATFORM_BUILD` (same as `--disable-multi-platform-build`)
@@ -1113,6 +1121,9 @@ Options:
     -c, --config='':
 	File for global configurations (defaults to $HOME/.skaffold/config)
 
+    --debug-cache=false:
+	Record the inputs to each artifact's build cache hash, and report which of them changed when an artifact has to be rebuilt
+
     -d, --default-repo='':
 	Default repository value (overrides global config)
 
@@ -1265,6 +1276,7 @@ Env vars:
 * `SKAFFOLD_CLOUD_RUN_LOCATION` (same as `--cloud-run-location`)
 * `SKAFFOLD_CLOUD_RUN_PROJECT` (same as `--cloud-run-project`)
 * `SKAFFOLD_CONFIG` (same as `--config`)
+* `SKAFFOLD_DEBUG_CACHE` (same as `--debug-cache`)
 * `SKAFFOLD_DEFAULT_REPO` (same as `--default-repo`)
 * `SKAFFOLD_DETECT_MINIKUBE` (same as `--detect-minikube`)
 * `SKAFFOLD_DIGEST_SOURCE` (same as `--digest-source`)
@@ -1814,6 +1826,9 @@ Options:
     -c, --config='':
 	File for global configurations (defaults to $HOME/.skaffold/config)
 
+    --debug-cache=false:
+	Record the inputs to each artifact's build cache hash, and report which of them changed when an artifact has to be rebuilt
+
     -d, --default-repo='':
 	Default repository value (overrides global config)
 
@@ -1952,6 +1967,7 @@ Env vars:
 * `SKAFFOLD_CLOUD_RUN_LOCATION` (same as `--cloud-run-location`)
 * `SKAFFOLD_CLOUD_RUN_PROJECT` (same as `--cloud-run-project`)
 * `SKAFFOLD_CONFIG` (same as `--config`)
+* `SKAFFOLD_DEBUG_CACHE` (same as `--debug-cache`)
 * `SKAFFOLD_DEFAULT_REPO` (same as `--default-repo`)
 * `SKAFFOLD_DETECT_MINIKUBE` (same as `--detect-minikube`)
 * `SKAFFOLD_DIGEST_SOURCE` (same as `--digest-source`)

--- a/docs-v2/content/en/docs/tutorials/artifact-dependencies.md
+++ b/docs-v2/content/en/docs/tutorials/artifact-dependencies.md
@@ -40,8 +40,8 @@ If this is the first time you're running this, then it should build the artifact
 
 ```text
 Checking cache...
- - base: Not found. Building
- - app: Not found. Building
+ - base: Not found. Building (no cached build for the current inputs)
+ - app: Not found. Building (no cached build for the current inputs)
 
 Building [base]...
 <docker build logs here>

--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -145,7 +145,7 @@ def get_regexs():
     # Search for "YEAR" which exists in the boilerplate, but shouldn't in the real thing
     regexs["year"] = re.compile( 'YEAR' )
     # dates can be 2018, company holder names can be anything
-    regexs["date"] = re.compile( '(2019|2020|2021|2022|2023|2024|2025)' )
+    regexs["date"] = re.compile( '(2019|2020|2021|2022|2023|2024|2025|2026)' )
     # strip // +build \n\n build constraints
     regexs["go_build_constraints"] = re.compile(r"^(// \+build.*\n)+\n", re.MULTILINE)
     # strip //go:build \n build constraints (for go1.17 and higher)

--- a/pkg/skaffold/build/cache/cache.go
+++ b/pkg/skaffold/build/cache/cache.go
@@ -47,14 +47,17 @@ type ArtifactCache map[string]ImageDetails
 
 // cache holds any data necessary for accessing the cache
 type cache struct {
-	artifactCache      ArtifactCache
-	hashByName         map[string]string
-	artifactGraph      graph.ArtifactGraph
-	artifactStore      build.ArtifactStore
-	cacheMutex         sync.RWMutex
-	client             docker.LocalDaemon
-	cfg                Config
-	cacheFile          string
+	artifactCache ArtifactCache
+	hashByName    map[string]string
+	artifactGraph graph.ArtifactGraph
+	artifactStore build.ArtifactStore
+	cacheMutex    sync.RWMutex
+	client        docker.LocalDaemon
+	cfg           Config
+	cacheFile     string
+	// inputsDir is where per-artifact hash input snapshots are kept, or "" when the user
+	// did not ask for cache diagnostics.
+	inputsDir          string
 	isLocalImage       func(imageName string) (bool, error)
 	importMissingImage func(imageName string) (bool, error)
 	lister             DependencyLister
@@ -71,6 +74,7 @@ type Config interface {
 	GetCluster() config.Cluster
 	CacheArtifacts() bool
 	CacheFile() string
+	DebugCache() bool
 	Mode() config.RunMode
 }
 
@@ -90,6 +94,13 @@ func NewCache(ctx context.Context, cfg Config, isLocalImage func(imageName strin
 	if err != nil {
 		log.Entry(context.TODO()).Warnf("Error retrieving artifact cache, not using skaffold cache: %v", err)
 		return &noCache{}, nil
+	}
+
+	// Snapshots live beside the cache file they explain, so that two projects with a
+	// same-named artifact do not overwrite each other's snapshots.
+	var inputsDir string
+	if cfg.DebugCache() {
+		inputsDir = cacheFile + "-inputs"
 	}
 
 	hashByName := make(map[string]string)
@@ -126,6 +137,7 @@ func NewCache(ctx context.Context, cfg Config, isLocalImage func(imageName strin
 		client:             client,
 		cfg:                cfg,
 		cacheFile:          cacheFile,
+		inputsDir:          inputsDir,
 		isLocalImage:       isLocalImage,
 		importMissingImage: importMissingImage,
 		lister:             dependencies,

--- a/pkg/skaffold/build/cache/details.go
+++ b/pkg/skaffold/build/cache/details.go
@@ -54,6 +54,10 @@ const (
 	// rebuildImageMissing means the current hash does have a cache entry, but the image it
 	// refers to can no longer be found locally or remotely, typically because it was pruned.
 	rebuildImageMissing
+	// rebuildInputsChanged means the inputs feeding the artifact's hash were recorded on a
+	// previous run and differ from this one. Only ever set when --debug-cache is in use;
+	// the changes themselves are carried alongside it.
+	rebuildInputsChanged
 )
 
 // description returns the explanation appended to "Not found. Building", or "" for
@@ -64,6 +68,8 @@ func (r rebuildReason) description() string {
 		return "no cached build for the current inputs"
 	case rebuildImageMissing:
 		return "cached image is no longer available"
+	case rebuildInputsChanged:
+		return "inputs changed"
 	default:
 		return ""
 	}
@@ -73,6 +79,9 @@ func (r rebuildReason) description() string {
 type needsBuilding struct {
 	hash   string
 	reason rebuildReason
+	// changes lists the inputs that differ from the previous run, one per line, and is only
+	// populated for rebuildInputsChanged.
+	changes []string
 }
 
 func (d needsBuilding) Hash() string {

--- a/pkg/skaffold/build/cache/details.go
+++ b/pkg/skaffold/build/cache/details.go
@@ -39,9 +39,40 @@ func (d failed) Hash() string {
 	return ""
 }
 
+// rebuildReason describes why a cache lookup concluded that an artifact has to be rebuilt.
+// It is derived only from what the lookup already knows, so that the two very different
+// causes -- the artifact's inputs changed, and the previously built image disappeared --
+// can be told apart in the output.
+type rebuildReason int
+
+const (
+	// rebuildUnknown is the zero value, used when no reason was determined.
+	rebuildUnknown rebuildReason = iota
+	// rebuildNoCacheEntry means the artifact's current hash has no entry in the artifact
+	// cache: either one of its inputs changed, or it was never built before.
+	rebuildNoCacheEntry
+	// rebuildImageMissing means the current hash does have a cache entry, but the image it
+	// refers to can no longer be found locally or remotely, typically because it was pruned.
+	rebuildImageMissing
+)
+
+// description returns the explanation appended to "Not found. Building", or "" for
+// rebuildUnknown so that the line is printed unchanged.
+func (r rebuildReason) description() string {
+	switch r {
+	case rebuildNoCacheEntry:
+		return "no cached build for the current inputs"
+	case rebuildImageMissing:
+		return "cached image is no longer available"
+	default:
+		return ""
+	}
+}
+
 // Not found, needs building
 type needsBuilding struct {
-	hash string
+	hash   string
+	reason rebuildReason
 }
 
 func (d needsBuilding) Hash() string {

--- a/pkg/skaffold/build/cache/hash.go
+++ b/pkg/skaffold/build/cache/hash.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"os"
 	"sort"
+	"strings"
 
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/build/buildpacks"
 	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/build/kaniko"
@@ -55,15 +56,19 @@ type artifactHasherImpl struct {
 	lister    DependencyLister
 	mode      config.RunMode
 	syncStore *util.SyncStore[string]
+	// inputs records what each artifact's hash was computed from, and is nil unless the
+	// user asked for cache diagnostics.
+	inputs *inputRecorder
 }
 
 // newArtifactHasher returns a new instance of an artifactHasher. Use newArtifactHasherFunc instead of calling this function directly.
-func newArtifactHasher(artifacts graph.ArtifactGraph, lister DependencyLister, mode config.RunMode) artifactHasher {
+func newArtifactHasher(artifacts graph.ArtifactGraph, lister DependencyLister, mode config.RunMode, inputs *inputRecorder) artifactHasher {
 	return &artifactHasherImpl{
 		artifacts: artifacts,
 		lister:    lister,
 		mode:      mode,
 		syncStore: util.NewSyncStore[string](),
+		inputs:    inputs,
 	}
 }
 
@@ -97,13 +102,20 @@ func (h *artifactHasherImpl) hash(ctx context.Context, out io.Writer, a *latest.
 func (h *artifactHasherImpl) safeHash(ctx context.Context, out io.Writer, a *latest.Artifact, platforms platform.Matcher, tag string) (string, error) {
 	return h.syncStore.Exec(a.ImageName,
 		func() (string, error) {
-			return singleArtifactHash(ctx, out, h.lister, a, h.mode, platforms, tag)
+			return singleArtifactHash(ctx, out, h.lister, a, h.mode, platforms, tag, h.inputs)
 		})
 }
 
 // singleArtifactHash calculates the hash for a single artifact, and ignores its required artifacts.
-func singleArtifactHash(ctx context.Context, out io.Writer, depLister DependencyLister, a *latest.Artifact, mode config.RunMode, m platform.Matcher, tag string) (string, error) {
+func singleArtifactHash(ctx context.Context, out io.Writer, depLister DependencyLister, a *latest.Artifact, mode config.RunMode, m platform.Matcher, tag string, recorder *inputRecorder) (string, error) {
 	var inputs []string
+	// hashInputs mirrors inputs, keyed so that a change can be attributed to a specific
+	// dependency file or to one of the artifact's non-file inputs. Only populated when the
+	// recorder is enabled.
+	var hashInputs map[string]string
+	if recorder != nil {
+		hashInputs = map[string]string{}
+	}
 
 	// Append the artifact's configuration
 	config, err := artifactConfigFunc(a)
@@ -111,6 +123,9 @@ func singleArtifactHash(ctx context.Context, out io.Writer, depLister Dependency
 		return "", fmt.Errorf("getting artifact's configuration for %q: %w", a.ImageName, err)
 	}
 	inputs = append(inputs, config)
+	if hashInputs != nil {
+		hashInputs[metaInputPrefix+"config"] = config
+	}
 
 	// Append the digest of each input file
 	deps, err := depLister(ctx, a, tag)
@@ -130,6 +145,9 @@ func singleArtifactHash(ctx context.Context, out io.Writer, depLister Dependency
 			return "", fmt.Errorf("getting hash for %q: %w", d, err)
 		}
 		inputs = append(inputs, h)
+		if hashInputs != nil {
+			hashInputs[d] = h
+		}
 	}
 
 	// add build args for the artifact if specified
@@ -139,6 +157,9 @@ func singleArtifactHash(ctx context.Context, out io.Writer, depLister Dependency
 	}
 	if args != nil {
 		inputs = append(inputs, args...)
+		if hashInputs != nil {
+			hashInputs[metaInputPrefix+"build args"] = strings.Join(args, ",")
+		}
 	}
 
 	// add build platforms
@@ -148,6 +169,10 @@ func singleArtifactHash(ctx context.Context, out io.Writer, depLister Dependency
 	}
 	sort.Strings(ps)
 	inputs = append(inputs, ps...)
+	if hashInputs != nil {
+		hashInputs[metaInputPrefix+"platforms"] = strings.Join(ps, ",")
+		recorder.record(ctx, a.ImageName, hashInputs)
+	}
 
 	return encode(inputs)
 }

--- a/pkg/skaffold/build/cache/hash.go
+++ b/pkg/skaffold/build/cache/hash.go
@@ -146,7 +146,7 @@ func singleArtifactHash(ctx context.Context, out io.Writer, depLister Dependency
 		}
 		inputs = append(inputs, h)
 		if hashInputs != nil {
-			hashInputs[d] = h
+			hashInputs[inputKey(a.Workspace, d)] = h
 		}
 	}
 

--- a/pkg/skaffold/build/cache/hash_test.go
+++ b/pkg/skaffold/build/cache/hash_test.go
@@ -164,7 +164,7 @@ func TestGetHashForArtifact(t *testing.T) {
 			}
 
 			depLister := stubDependencyLister(test.dependencies)
-			actual, err := newArtifactHasher(nil, depLister, test.mode).hash(context.Background(), io.Discard, test.artifact, test.platforms, testTag)
+			actual, err := newArtifactHasher(nil, depLister, test.mode, nil).hash(context.Background(), io.Discard, test.artifact, test.platforms, testTag)
 
 			t.CheckNoError(err)
 			t.CheckDeepEqual(test.expected, actual)
@@ -248,7 +248,7 @@ func TestGetHashForArtifactWithDependencies(t *testing.T) {
 				return test.fileDeps[a.ImageName], nil
 			}
 
-			actual, err := newArtifactHasher(g, depLister, test.mode).hash(context.Background(), io.Discard, test.artifacts[0], platform.Resolver{}, testTag)
+			actual, err := newArtifactHasher(g, depLister, test.mode, nil).hash(context.Background(), io.Discard, test.artifacts[0], platform.Resolver{}, testTag)
 
 			t.CheckNoError(err)
 			t.CheckDeepEqual(test.expected, actual)
@@ -311,21 +311,21 @@ func TestBuildArgs(t *testing.T) {
 			}
 			t.Override(&fileHasherFunc, mockCacheHasher)
 			t.Override(&artifactConfigFunc, fakeArtifactConfig)
-			actual, err := newArtifactHasher(nil, stubDependencyLister(nil), test.mode).hash(context.Background(), io.Discard, artifact, platform.Resolver{}, testTag)
+			actual, err := newArtifactHasher(nil, stubDependencyLister(nil), test.mode, nil).hash(context.Background(), io.Discard, artifact, platform.Resolver{}, testTag)
 
 			t.CheckNoError(err)
 			t.CheckDeepEqual(test.expected, actual)
 
 			// Change order of buildargs
 			artifact.ArtifactType.DockerArtifact.BuildArgs = map[string]*string{"two": util.Ptr("2"), "one": util.Ptr("1")}
-			actual, err = newArtifactHasher(nil, stubDependencyLister(nil), test.mode).hash(context.Background(), io.Discard, artifact, platform.Resolver{}, testTag)
+			actual, err = newArtifactHasher(nil, stubDependencyLister(nil), test.mode, nil).hash(context.Background(), io.Discard, artifact, platform.Resolver{}, testTag)
 
 			t.CheckNoError(err)
 			t.CheckDeepEqual(test.expected, actual)
 
 			// Change build args, get different hash
 			artifact.ArtifactType.DockerArtifact.BuildArgs = map[string]*string{"one": util.Ptr("1")}
-			actual, err = newArtifactHasher(nil, stubDependencyLister(nil), test.mode).hash(context.Background(), io.Discard, artifact, platform.Resolver{}, testTag)
+			actual, err = newArtifactHasher(nil, stubDependencyLister(nil), test.mode, nil).hash(context.Background(), io.Discard, artifact, platform.Resolver{}, testTag)
 
 			t.CheckNoError(err)
 			if actual == test.expected {
@@ -358,7 +358,7 @@ func TestBuildArgsEnvSubstitution(t *testing.T) {
 		t.Override(&artifactConfigFunc, fakeArtifactConfig)
 
 		depLister := stubDependencyLister([]string{"graph"})
-		hash1, err := newArtifactHasher(nil, depLister, config.RunModes.Build).hash(context.Background(), io.Discard, artifact, platform.Resolver{}, testTag)
+		hash1, err := newArtifactHasher(nil, depLister, config.RunModes.Build, nil).hash(context.Background(), io.Discard, artifact, platform.Resolver{}, testTag)
 
 		t.CheckNoError(err)
 
@@ -368,7 +368,7 @@ func TestBuildArgsEnvSubstitution(t *testing.T) {
 			return []string{"FOO=baz"}
 		}
 
-		hash2, err := newArtifactHasher(nil, depLister, config.RunModes.Build).hash(context.Background(), io.Discard, artifact, platform.Resolver{}, testTag)
+		hash2, err := newArtifactHasher(nil, depLister, config.RunModes.Build, nil).hash(context.Background(), io.Discard, artifact, platform.Resolver{}, testTag)
 
 		t.CheckNoError(err)
 		if hash1 == hash2 {
@@ -435,11 +435,11 @@ func TestBuildArgsImageInfoSubstitution(t *testing.T) {
 			t.Override(&artifactConfigFunc, fakeArtifactConfig)
 
 			depLister := stubDependencyLister([]string{"graph"})
-			hash1, err := newArtifactHasher(nil, depLister, config.RunModes.Build).hash(context.Background(), io.Discard, test.artifactType, platform.Resolver{}, test.originalTag)
+			hash1, err := newArtifactHasher(nil, depLister, config.RunModes.Build, nil).hash(context.Background(), io.Discard, test.artifactType, platform.Resolver{}, test.originalTag)
 
 			t.CheckNoError(err)
 
-			hash2, err := newArtifactHasher(nil, depLister, config.RunModes.Build).hash(context.Background(), io.Discard, test.artifactType, platform.Resolver{}, test.newTag)
+			hash2, err := newArtifactHasher(nil, depLister, config.RunModes.Build, nil).hash(context.Background(), io.Discard, test.artifactType, platform.Resolver{}, test.newTag)
 
 			t.CheckNoError(err)
 			if hash1 == hash2 {
@@ -497,7 +497,7 @@ func TestCacheHasher(t *testing.T) {
 			path := originalFile
 			depLister := stubDependencyLister([]string{tmpDir.Path(originalFile)})
 
-			oldHash, err := newArtifactHasher(nil, depLister, config.RunModes.Build).hash(context.Background(), io.Discard, &latest.Artifact{}, platform.Resolver{}, testTag)
+			oldHash, err := newArtifactHasher(nil, depLister, config.RunModes.Build, nil).hash(context.Background(), io.Discard, &latest.Artifact{}, platform.Resolver{}, testTag)
 			t.CheckNoError(err)
 
 			test.update(originalFile, tmpDir)
@@ -506,7 +506,7 @@ func TestCacheHasher(t *testing.T) {
 			}
 
 			depLister = stubDependencyLister([]string{tmpDir.Path(path)})
-			newHash, err := newArtifactHasher(nil, depLister, config.RunModes.Build).hash(context.Background(), io.Discard, &latest.Artifact{}, platform.Resolver{}, testTag)
+			newHash, err := newArtifactHasher(nil, depLister, config.RunModes.Build, nil).hash(context.Background(), io.Discard, &latest.Artifact{}, platform.Resolver{}, testTag)
 
 			t.CheckNoError(err)
 			t.CheckFalse(test.differentHash && oldHash == newHash)

--- a/pkg/skaffold/build/cache/inputs.go
+++ b/pkg/skaffold/build/cache/inputs.go
@@ -1,0 +1,255 @@
+/*
+Copyright 2026 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/GoogleContainerTools/skaffold/v2/pkg/skaffold/output/log"
+)
+
+// metaInputPrefix marks the hash inputs that are not dependency files: the artifact's
+// configuration, its build args and its platforms. "!" sorts before the characters a path
+// realistically starts with, so these entries group together at the top of a snapshot.
+const metaInputPrefix = "!"
+
+// maxSnapshotLine bounds the line length accepted when reading a snapshot back. Keys are
+// file paths, so the default bufio limit is generous already, but a corrupt or truncated
+// file should not make the reader allocate without bound.
+const maxSnapshotLine = 1024 * 1024
+
+// inputChanges is the difference between an artifact's hash inputs on this run and on the
+// previous recorded run.
+type inputChanges struct {
+	modified []string
+	added    []string
+	removed  []string
+}
+
+// empty reports whether nothing at all changed.
+func (c inputChanges) empty() bool {
+	return len(c.modified) == 0 && len(c.added) == 0 && len(c.removed) == 0
+}
+
+// lines renders the changes one per line, prefixed with "~" for modified, "+" for added and
+// "-" for removed, in that order.
+func (c inputChanges) lines() []string {
+	lines := make([]string, 0, len(c.modified)+len(c.added)+len(c.removed))
+	for _, p := range c.modified {
+		lines = append(lines, "~ "+displayInput(p))
+	}
+	for _, p := range c.added {
+		lines = append(lines, "+ "+displayInput(p))
+	}
+	for _, p := range c.removed {
+		lines = append(lines, "- "+displayInput(p))
+	}
+	return lines
+}
+
+// inputRecorder snapshots the inputs that feed each artifact's cache hash and diffs them
+// against the previous run, so that a cache miss can name what actually changed. It is
+// created per cache lookup pass, and is a no-op when nil, which is the case unless the user
+// asked for it with --debug-cache.
+type inputRecorder struct {
+	dir string
+
+	mu      sync.Mutex
+	changes map[string]inputChanges
+}
+
+// newInputRecorder returns a recorder writing snapshots to dir, or nil if dir is empty.
+func newInputRecorder(dir string) *inputRecorder {
+	if dir == "" {
+		return nil
+	}
+	return &inputRecorder{
+		dir:     dir,
+		changes: map[string]inputChanges{},
+	}
+}
+
+// record diffs an artifact's hash inputs against its previous snapshot and stores the result
+// for changesFor, then writes the new snapshot. Values are hashed, never stored verbatim:
+// build args and artifact configuration routinely hold credentials, and a snapshot only ever
+// needs to answer "is this the same as last time".
+//
+// Failures are logged and otherwise ignored: this is diagnostic bookkeeping, and must never
+// be able to fail a build.
+func (r *inputRecorder) record(ctx context.Context, imageName string, inputs map[string]string) {
+	if r == nil {
+		return
+	}
+
+	digests := make(map[string]string, len(inputs))
+	for key, value := range inputs {
+		if strings.ContainsAny(key, "\t\n") {
+			// The snapshot format is line and tab delimited; such a key cannot round-trip.
+			log.Entry(ctx).Debugf("cache input %q for %q cannot be recorded, skipping", key, imageName)
+			continue
+		}
+		digests[key] = digestOf(value)
+	}
+
+	path := snapshotPath(r.dir, imageName)
+
+	previous, err := readSnapshot(path)
+	switch {
+	case os.IsNotExist(err):
+		// No previous run to compare against; report no changes rather than reporting
+		// every input as newly added.
+	case err != nil:
+		log.Entry(ctx).Warnf("could not read cache input snapshot %s: %v", path, err)
+	default:
+		r.mu.Lock()
+		r.changes[imageName] = diffInputs(previous, digests)
+		r.mu.Unlock()
+	}
+
+	if err := writeSnapshot(path, digests); err != nil {
+		log.Entry(ctx).Warnf("could not write cache input snapshot %s: %v", path, err)
+	}
+}
+
+// changesFor returns what changed for an artifact since the previous run. The second result
+// is false when nothing was recorded, either because recording is off or because there was
+// no previous snapshot to compare against.
+func (r *inputRecorder) changesFor(imageName string) (inputChanges, bool) {
+	if r == nil {
+		return inputChanges{}, false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	changes, ok := r.changes[imageName]
+	return changes, ok
+}
+
+// diffInputs compares two sets of input digests.
+func diffInputs(previous, current map[string]string) inputChanges {
+	var changes inputChanges
+	for key, digest := range current {
+		switch previousDigest, existed := previous[key]; {
+		case !existed:
+			changes.added = append(changes.added, key)
+		case previousDigest != digest:
+			changes.modified = append(changes.modified, key)
+		}
+	}
+	for key := range previous {
+		if _, stillPresent := current[key]; !stillPresent {
+			changes.removed = append(changes.removed, key)
+		}
+	}
+
+	sort.Strings(changes.modified)
+	sort.Strings(changes.added)
+	sort.Strings(changes.removed)
+	return changes
+}
+
+// digestOf hashes an input value so that no build arg or configuration value is written to
+// disk in the clear.
+func digestOf(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])
+}
+
+// displayInput strips the marker from a non-file input so that it reads naturally,
+// e.g. "!config" becomes "config".
+func displayInput(key string) string {
+	return strings.TrimPrefix(key, metaInputPrefix)
+}
+
+// snapshotPath is where an artifact's snapshot lives. Image names can contain characters
+// that are not valid in a filename, so they are replaced rather than escaped; a collision
+// between two such names costs a spurious diff, nothing more.
+func snapshotPath(dir, imageName string) string {
+	safe := strings.Map(func(r rune) rune {
+		switch r {
+		case '/', '\\', ':', '*', '?', '"', '<', '>', '|':
+			return '_'
+		}
+		return r
+	}, imageName)
+	return filepath.Join(dir, safe+".txt")
+}
+
+// readSnapshot parses a snapshot file into a map of input key to digest. Lines that do not
+// parse are skipped: a partially written snapshot should degrade into a wider diff, not an
+// error.
+func readSnapshot(path string) (map[string]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	snapshot := map[string]string{}
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(nil, maxSnapshotLine)
+	for scanner.Scan() {
+		key, digest, ok := strings.Cut(scanner.Text(), "\t")
+		if !ok {
+			continue
+		}
+		snapshot[key] = digest
+	}
+	return snapshot, scanner.Err()
+}
+
+// writeSnapshot writes the snapshot through a temporary file so that a concurrent reader,
+// or a run interrupted mid-write, never sees a half-written snapshot.
+func writeSnapshot(path string, digests map[string]string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+
+	keys := make([]string, 0, len(digests))
+	for key := range digests {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var b strings.Builder
+	for _, key := range keys {
+		fmt.Fprintf(&b, "%s\t%s\n", key, digests[key])
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmp.Name())
+
+	if _, err := tmp.WriteString(b.String()); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmp.Name(), path)
+}

--- a/pkg/skaffold/build/cache/inputs.go
+++ b/pkg/skaffold/build/cache/inputs.go
@@ -177,6 +177,25 @@ func digestOf(value string) string {
 	return hex.EncodeToString(sum[:])
 }
 
+// inputKey is the key a dependency is recorded under: its path relative to the artifact's
+// workspace where that is possible. Dependency paths reach us however the builder resolved
+// them, which for some configurations is absolute. Recording them as given would make the
+// same file, in two checkouts of the same repository, compare as one path added and another
+// removed -- burying the change the user is actually looking for. Relative keys also read
+// better in the output.
+func inputKey(workspace, dep string) string {
+	if workspace == "" {
+		return dep
+	}
+	rel, err := filepath.Rel(workspace, dep)
+	if err != nil {
+		// Mixing an absolute workspace with a relative dependency, or vice versa; there is
+		// nothing sensible to relativise against, so record the path as given.
+		return dep
+	}
+	return filepath.ToSlash(rel)
+}
+
 // displayInput strips the marker from a non-file input so that it reads naturally,
 // e.g. "!config" becomes "config".
 func displayInput(key string) string {

--- a/pkg/skaffold/build/cache/inputs_test.go
+++ b/pkg/skaffold/build/cache/inputs_test.go
@@ -1,0 +1,235 @@
+/*
+Copyright 2026 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/GoogleContainerTools/skaffold/v2/testutil"
+)
+
+// cmpInputChanges lets the comparison reach inputChanges' unexported fields.
+var cmpInputChanges = cmp.AllowUnexported(inputChanges{})
+
+func TestDiffInputs(t *testing.T) {
+	tests := []struct {
+		description string
+		previous    map[string]string
+		current     map[string]string
+		expected    inputChanges
+	}{
+		{
+			description: "nothing changed",
+			previous:    map[string]string{"app.py": "a"},
+			current:     map[string]string{"app.py": "a"},
+			expected:    inputChanges{},
+		},
+		{
+			description: "file modified",
+			previous:    map[string]string{"app.py": "a"},
+			current:     map[string]string{"app.py": "b"},
+			expected:    inputChanges{modified: []string{"app.py"}},
+		},
+		{
+			description: "file added",
+			previous:    map[string]string{"app.py": "a"},
+			current:     map[string]string{"app.py": "a", "new.txt": "b"},
+			expected:    inputChanges{added: []string{"new.txt"}},
+		},
+		{
+			description: "file removed",
+			previous:    map[string]string{"app.py": "a", "old.txt": "b"},
+			current:     map[string]string{"app.py": "a"},
+			expected:    inputChanges{removed: []string{"old.txt"}},
+		},
+		{
+			description: "everything at once, each list sorted",
+			previous:    map[string]string{"b": "1", "a": "2", "gone": "3", "alsogone": "4"},
+			current:     map[string]string{"b": "changed", "a": "changed", "new": "5", "alsonew": "6"},
+			expected: inputChanges{
+				modified: []string{"a", "b"},
+				added:    []string{"alsonew", "new"},
+				removed:  []string{"alsogone", "gone"},
+			},
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.CheckDeepEqual(test.expected, diffInputs(test.previous, test.current), cmpInputChanges)
+		})
+	}
+}
+
+func TestInputChangesLines(t *testing.T) {
+	testutil.Run(t, "modified, then added, then removed", func(t *testutil.T) {
+		changes := inputChanges{
+			modified: []string{"app.py"},
+			added:    []string{"new.txt"},
+			removed:  []string{"old.txt"},
+		}
+		t.CheckDeepEqual([]string{"~ app.py", "+ new.txt", "- old.txt"}, changes.lines())
+	})
+
+	testutil.Run(t, "the marker is stripped from non-file inputs", func(t *testutil.T) {
+		changes := inputChanges{modified: []string{metaInputPrefix + "build args"}}
+		t.CheckDeepEqual([]string{"~ build args"}, changes.lines())
+	})
+}
+
+func TestInputRecorderReportsChangesAfterFirstRun(t *testing.T) {
+	testutil.Run(t, "", func(t *testutil.T) {
+		dir := t.NewTempDir().Path("inputs")
+		ctx := context.Background()
+
+		// First run: there is nothing to compare against, so no changes are reported.
+		first := newInputRecorder(dir)
+		first.record(ctx, "app", map[string]string{"app.py": "a", "keep.txt": "k"})
+		if _, ok := first.changesFor("app"); ok {
+			t.Errorf("expected no changes to be recorded on the first run")
+		}
+
+		// Second run: one input changed, one appeared, one went away.
+		second := newInputRecorder(dir)
+		second.record(ctx, "app", map[string]string{"app.py": "b", "new.txt": "n"})
+		changes, ok := second.changesFor("app")
+		if !ok {
+			t.Fatalf("expected changes to be recorded on the second run")
+		}
+		t.CheckDeepEqual(inputChanges{
+			modified: []string{"app.py"},
+			added:    []string{"new.txt"},
+			removed:  []string{"keep.txt"},
+		}, changes, cmpInputChanges)
+
+		// Third run: back to matching the second, so nothing is reported as changed.
+		third := newInputRecorder(dir)
+		third.record(ctx, "app", map[string]string{"app.py": "b", "new.txt": "n"})
+		changes, ok = third.changesFor("app")
+		if !ok {
+			t.Fatalf("expected a snapshot to be compared on the third run")
+		}
+		if !changes.empty() {
+			t.Errorf("expected no changes, got %v", changes.lines())
+		}
+	})
+}
+
+func TestInputRecorderDoesNotWriteValuesInTheClear(t *testing.T) {
+	testutil.Run(t, "", func(t *testutil.T) {
+		dir := t.NewTempDir().Path("inputs")
+
+		const secret = "SUPER_SECRET_TOKEN_VALUE"
+		recorder := newInputRecorder(dir)
+		recorder.record(context.Background(), "app", map[string]string{
+			metaInputPrefix + "build args": "TOKEN=" + secret,
+		})
+
+		contents, err := os.ReadFile(filepath.Join(dir, "app.txt"))
+		t.CheckNoError(err)
+		if strings.Contains(string(contents), secret) {
+			t.Errorf("snapshot must not contain input values verbatim, got:\n%s", contents)
+		}
+		if !strings.Contains(string(contents), digestOf("TOKEN="+secret)) {
+			t.Errorf("snapshot should record the digest of the value, got:\n%s", contents)
+		}
+	})
+}
+
+func TestInputRecorderSkipsKeysItCannotRoundTrip(t *testing.T) {
+	testutil.Run(t, "", func(t *testutil.T) {
+		dir := t.NewTempDir().Path("inputs")
+		ctx := context.Background()
+
+		newInputRecorder(dir).record(ctx, "app", map[string]string{
+			"fine.txt":          "a",
+			"with\ttab.txt":     "b",
+			"with\nnewline.txt": "c",
+		})
+
+		snapshot, err := readSnapshot(filepath.Join(dir, "app.txt"))
+		t.CheckNoError(err)
+		t.CheckDeepEqual(1, len(snapshot))
+		if _, ok := snapshot["fine.txt"]; !ok {
+			t.Errorf("expected the well-formed key to be recorded, got %v", snapshot)
+		}
+	})
+}
+
+func TestNilInputRecorderIsANoOp(t *testing.T) {
+	testutil.Run(t, "", func(t *testutil.T) {
+		var recorder *inputRecorder
+		t.CheckDeepEqual((*inputRecorder)(nil), newInputRecorder(""))
+
+		// Neither call may panic.
+		recorder.record(context.Background(), "app", map[string]string{"app.py": "a"})
+		_, ok := recorder.changesFor("app")
+		t.CheckDeepEqual(false, ok)
+	})
+}
+
+func TestSnapshotPathReplacesUnsafeCharacters(t *testing.T) {
+	tests := []struct {
+		description string
+		imageName   string
+		expected    string
+	}{
+		{description: "plain name", imageName: "app", expected: "app.txt"},
+		{description: "registry path", imageName: "gcr.io/project/app", expected: "gcr.io_project_app.txt"},
+		{description: "tagged name", imageName: "app:v1", expected: "app_v1.txt"},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.CheckDeepEqual(filepath.Join("dir", test.expected), snapshotPath("dir", test.imageName))
+		})
+	}
+}
+
+func TestWriteSnapshotIsAtomic(t *testing.T) {
+	testutil.Run(t, "", func(t *testutil.T) {
+		dir := t.NewTempDir().Path("inputs")
+		path := filepath.Join(dir, "app.txt")
+
+		t.CheckNoError(writeSnapshot(path, map[string]string{"app.py": "a"}))
+		t.CheckNoError(writeSnapshot(path, map[string]string{"app.py": "b"}))
+
+		// No temporary files may be left behind.
+		entries, err := os.ReadDir(dir)
+		t.CheckNoError(err)
+		t.CheckDeepEqual(1, len(entries))
+		t.CheckDeepEqual("app.txt", entries[0].Name())
+
+		snapshot, err := readSnapshot(path)
+		t.CheckNoError(err)
+		t.CheckDeepEqual(map[string]string{"app.py": "b"}, snapshot)
+	})
+}
+
+func TestReadSnapshotSkipsMalformedLines(t *testing.T) {
+	testutil.Run(t, "", func(t *testutil.T) {
+		tmp := t.NewTempDir().Write("snapshot.txt", "app.py\tabc\ngarbage-with-no-tab\n\nother.txt\tdef\n")
+
+		snapshot, err := readSnapshot(tmp.Path("snapshot.txt"))
+		t.CheckNoError(err)
+		t.CheckDeepEqual(map[string]string{"app.py": "abc", "other.txt": "def"}, snapshot)
+	})
+}

--- a/pkg/skaffold/build/cache/inputs_test.go
+++ b/pkg/skaffold/build/cache/inputs_test.go
@@ -80,6 +80,57 @@ func TestDiffInputs(t *testing.T) {
 	}
 }
 
+func TestInputKey(t *testing.T) {
+	tests := []struct {
+		description string
+		workspace   string
+		dep         string
+		expected    string
+	}{
+		{
+			description: "absolute dependency under an absolute workspace",
+			workspace:   "/home/user/repo/app",
+			dep:         "/home/user/repo/app/src/main.go",
+			expected:    "src/main.go",
+		},
+		{
+			description: "the same file in another checkout gives the same key",
+			workspace:   "/home/user/other-checkout/app",
+			dep:         "/home/user/other-checkout/app/src/main.go",
+			expected:    "src/main.go",
+		},
+		{
+			description: "dependency outside the workspace stays relative to it",
+			workspace:   "/home/user/repo/app",
+			dep:         "/home/user/repo/shared/lib.go",
+			expected:    "../shared/lib.go",
+		},
+		{
+			description: "relative workspace and dependency",
+			workspace:   ".",
+			dep:         "main.go",
+			expected:    "main.go",
+		},
+		{
+			description: "no workspace to relativise against",
+			workspace:   "",
+			dep:         "/home/user/repo/app/main.go",
+			expected:    "/home/user/repo/app/main.go",
+		},
+		{
+			description: "mixed absolute workspace and relative dependency is left alone",
+			workspace:   "/home/user/repo/app",
+			dep:         "main.go",
+			expected:    "main.go",
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.CheckDeepEqual(test.expected, inputKey(test.workspace, test.dep))
+		})
+	}
+}
+
 func TestInputChangesLines(t *testing.T) {
 	testutil.Run(t, "modified, then added, then removed", func(t *testutil.T) {
 		changes := inputChanges{

--- a/pkg/skaffold/build/cache/lookup.go
+++ b/pkg/skaffold/build/cache/lookup.go
@@ -41,14 +41,17 @@ func (c *cache) lookupArtifacts(ctx context.Context, out io.Writer, tags tag.Ima
 
 	ctx, endTrace := instrumentation.StartTrace(ctx, "lookupArtifacts_CacheLookupArtifacts")
 	defer endTrace()
-	h := newArtifactHasherFunc(c.artifactGraph, c.lister, c.cfg.Mode())
+	// Recorded per lookup pass, so a diff always compares this run against the previous
+	// one rather than against an earlier iteration of the same dev loop.
+	inputs := newInputRecorder(c.inputsDir)
+	h := newArtifactHasherFunc(c.artifactGraph, c.lister, c.cfg.Mode(), inputs)
 	var wg sync.WaitGroup
 	for i := range artifacts {
 		wg.Add(1)
 
 		i := i
 		go func() {
-			details[i] = c.lookup(ctx, out, artifacts[i], tags, platforms, h)
+			details[i] = c.lookup(ctx, out, artifacts[i], tags, platforms, h, inputs)
 			wg.Done()
 		}()
 	}
@@ -57,7 +60,7 @@ func (c *cache) lookupArtifacts(ctx context.Context, out io.Writer, tags tag.Ima
 	return details
 }
 
-func (c *cache) lookup(ctx context.Context, out io.Writer, a *latest.Artifact, tags map[string]string, platforms platform.Resolver, h artifactHasher) cacheDetails {
+func (c *cache) lookup(ctx context.Context, out io.Writer, a *latest.Artifact, tags map[string]string, platforms platform.Resolver, h artifactHasher, inputs *inputRecorder) cacheDetails {
 	tag := tags[a.ImageName]
 	ctx, endTrace := instrumentation.StartTrace(ctx, "lookup_CacheLookupOneArtifact", map[string]string{
 		"ImageName": instrumentation.PII(a.ImageName),
@@ -73,6 +76,15 @@ func (c *cache) lookup(ctx context.Context, out io.Writer, a *latest.Artifact, t
 	entry, cacheHit := c.artifactCache[hash]
 	c.cacheMutex.RUnlock()
 
+	// rebuild describes a cache miss for this artifact, preferring the recorded diff of the
+	// hash inputs over the coarser reason inferred from the cache entry alone.
+	rebuild := func(entry ImageDetails) needsBuilding {
+		if changes, ok := inputs.changesFor(a.ImageName); ok && !changes.empty() {
+			return needsBuilding{hash: hash, reason: rebuildInputsChanged, changes: changes.lines()}
+		}
+		return needsBuilding{hash: hash, reason: rebuildReasonFor(entry)}
+	}
+
 	pls := platforms.GetPlatforms(a.ImageName)
 	// TODO (gaghosh): allow `tryImport` when the Docker daemon starts supporting multiarch images
 	// See https://github.com/docker/buildx/issues/1220#issuecomment-1189996403
@@ -83,17 +95,21 @@ func (c *cache) lookup(ctx context.Context, out io.Writer, a *latest.Artifact, t
 		}
 		if entry, err = c.tryImport(ctx, a, tag, hash, pl); err != nil {
 			log.Entry(ctx).Debugf("Could not import artifact from Docker, building instead (%s)", err)
-			return needsBuilding{hash: hash, reason: rebuildReasonFor(entry)}
+			return rebuild(entry)
 		}
 	}
 
 	if isLocal, err := c.isLocalImage(a.ImageName); err != nil {
 		return failed{err}
 	} else if isLocal {
-		return c.lookupLocal(ctx, hash, tag, entry)
+		return c.lookupLocal(ctx, hash, tag, entry, rebuild)
 	}
-	return c.lookupRemote(ctx, hash, tag, pls.Platforms, entry)
+	return c.lookupRemote(ctx, hash, tag, pls.Platforms, entry, rebuild)
 }
+
+// rebuildFunc builds the cache miss result for an artifact, given whichever cache entry the
+// lookup ended up with.
+type rebuildFunc func(ImageDetails) needsBuilding
 
 // rebuildReasonFor derives why an artifact is being rebuilt from the cache entry, if any,
 // that was found for its current hash. A zero entry means this hash was never recorded, so
@@ -106,9 +122,9 @@ func rebuildReasonFor(entry ImageDetails) rebuildReason {
 	return rebuildImageMissing
 }
 
-func (c *cache) lookupLocal(ctx context.Context, hash, tag string, entry ImageDetails) cacheDetails {
+func (c *cache) lookupLocal(ctx context.Context, hash, tag string, entry ImageDetails, rebuild rebuildFunc) cacheDetails {
 	if entry.ID == "" {
-		return needsBuilding{hash: hash, reason: rebuildReasonFor(entry)}
+		return rebuild(entry)
 	}
 
 	// Check the imageID for the tag
@@ -128,10 +144,10 @@ func (c *cache) lookupLocal(ctx context.Context, hash, tag string, entry ImageDe
 		return needsLocalTagging{hash: hash, tag: tag, imageID: entry.ID}
 	}
 
-	return needsBuilding{hash: hash, reason: rebuildReasonFor(entry)}
+	return rebuild(entry)
 }
 
-func (c *cache) lookupRemote(ctx context.Context, hash, tag string, platforms []specs.Platform, entry ImageDetails) cacheDetails {
+func (c *cache) lookupRemote(ctx context.Context, hash, tag string, platforms []specs.Platform, entry ImageDetails, rebuild rebuildFunc) cacheDetails {
 	if remoteDigest, err := docker.RemoteDigest(tag, c.cfg, nil); err == nil {
 		// Image exists remotely with the same tag and digest
 		if remoteDigest == entry.Digest {
@@ -152,7 +168,7 @@ func (c *cache) lookupRemote(ctx context.Context, hash, tag string, platforms []
 		return needsPushing{hash: hash, tag: tag, imageID: entry.ID}
 	}
 
-	return needsBuilding{hash: hash, reason: rebuildReasonFor(entry)}
+	return rebuild(entry)
 }
 
 func (c *cache) tryImport(ctx context.Context, a *latest.Artifact, tag string, hash string, pl v1.Platform) (ImageDetails, error) {

--- a/pkg/skaffold/build/cache/lookup.go
+++ b/pkg/skaffold/build/cache/lookup.go
@@ -83,7 +83,7 @@ func (c *cache) lookup(ctx context.Context, out io.Writer, a *latest.Artifact, t
 		}
 		if entry, err = c.tryImport(ctx, a, tag, hash, pl); err != nil {
 			log.Entry(ctx).Debugf("Could not import artifact from Docker, building instead (%s)", err)
-			return needsBuilding{hash: hash}
+			return needsBuilding{hash: hash, reason: rebuildReasonFor(entry)}
 		}
 	}
 
@@ -95,9 +95,20 @@ func (c *cache) lookup(ctx context.Context, out io.Writer, a *latest.Artifact, t
 	return c.lookupRemote(ctx, hash, tag, pls.Platforms, entry)
 }
 
+// rebuildReasonFor derives why an artifact is being rebuilt from the cache entry, if any,
+// that was found for its current hash. A zero entry means this hash was never recorded, so
+// one of the artifact's inputs must have changed; a populated one means the build was
+// recorded but its image can no longer be found.
+func rebuildReasonFor(entry ImageDetails) rebuildReason {
+	if entry.ID == "" && entry.Digest == "" {
+		return rebuildNoCacheEntry
+	}
+	return rebuildImageMissing
+}
+
 func (c *cache) lookupLocal(ctx context.Context, hash, tag string, entry ImageDetails) cacheDetails {
 	if entry.ID == "" {
-		return needsBuilding{hash: hash}
+		return needsBuilding{hash: hash, reason: rebuildReasonFor(entry)}
 	}
 
 	// Check the imageID for the tag
@@ -117,7 +128,7 @@ func (c *cache) lookupLocal(ctx context.Context, hash, tag string, entry ImageDe
 		return needsLocalTagging{hash: hash, tag: tag, imageID: entry.ID}
 	}
 
-	return needsBuilding{hash: hash}
+	return needsBuilding{hash: hash, reason: rebuildReasonFor(entry)}
 }
 
 func (c *cache) lookupRemote(ctx context.Context, hash, tag string, platforms []specs.Platform, entry ImageDetails) cacheDetails {
@@ -141,7 +152,7 @@ func (c *cache) lookupRemote(ctx context.Context, hash, tag string, platforms []
 		return needsPushing{hash: hash, tag: tag, imageID: entry.ID}
 	}
 
-	return needsBuilding{hash: hash}
+	return needsBuilding{hash: hash, reason: rebuildReasonFor(entry)}
 }
 
 func (c *cache) tryImport(ctx context.Context, a *latest.Artifact, tag string, hash string, pl v1.Platform) (ImageDetails, error) {

--- a/pkg/skaffold/build/cache/lookup_test.go
+++ b/pkg/skaffold/build/cache/lookup_test.go
@@ -186,7 +186,9 @@ func TestLookupLocal(t *testing.T) {
 				cfg:                &mockConfig{mode: config.RunModes.Build},
 			}
 
-			t.Override(&newArtifactHasherFunc, func(_ graph.ArtifactGraph, _ DependencyLister, _ config.RunMode) artifactHasher { return test.hasher })
+			t.Override(&newArtifactHasherFunc, func(_ graph.ArtifactGraph, _ DependencyLister, _ config.RunMode, _ *inputRecorder) artifactHasher {
+				return test.hasher
+			})
 			details := cache.lookupArtifacts(context.Background(), io.Discard, map[string]string{"artifact": "tag"}, platform.Resolver{}, []*latest.Artifact{{
 				ImageName: "artifact",
 			}})
@@ -274,7 +276,9 @@ func TestLookupRemote(t *testing.T) {
 				client:             fakeLocalDaemon(test.api),
 				cfg:                &mockConfig{mode: config.RunModes.Build},
 			}
-			t.Override(&newArtifactHasherFunc, func(_ graph.ArtifactGraph, _ DependencyLister, _ config.RunMode) artifactHasher { return test.hasher })
+			t.Override(&newArtifactHasherFunc, func(_ graph.ArtifactGraph, _ DependencyLister, _ config.RunMode, _ *inputRecorder) artifactHasher {
+				return test.hasher
+			})
 			details := cache.lookupArtifacts(context.Background(), io.Discard, map[string]string{"artifact": "tag"}, platform.Resolver{}, []*latest.Artifact{{
 				ImageName: "artifact",
 			}})

--- a/pkg/skaffold/build/cache/lookup_test.go
+++ b/pkg/skaffold/build/cache/lookup_test.go
@@ -37,6 +37,64 @@ import (
 	"github.com/GoogleContainerTools/skaffold/v2/testutil"
 )
 
+func TestRebuildReasonDescription(t *testing.T) {
+	tests := []struct {
+		description string
+		reason      rebuildReason
+		expected    string
+	}{
+		{
+			description: "unknown reason is not described",
+			reason:      rebuildUnknown,
+			expected:    "",
+		},
+		{
+			description: "no cache entry",
+			reason:      rebuildNoCacheEntry,
+			expected:    "no cached build for the current inputs",
+		},
+		{
+			description: "image missing",
+			reason:      rebuildImageMissing,
+			expected:    "cached image is no longer available",
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.CheckDeepEqual(test.expected, test.reason.description())
+		})
+	}
+}
+
+func TestRebuildReasonFor(t *testing.T) {
+	tests := []struct {
+		description string
+		entry       ImageDetails
+		expected    rebuildReason
+	}{
+		{
+			description: "no entry recorded for this hash",
+			entry:       ImageDetails{},
+			expected:    rebuildNoCacheEntry,
+		},
+		{
+			description: "entry recorded with an image ID",
+			entry:       ImageDetails{ID: "imageID"},
+			expected:    rebuildImageMissing,
+		},
+		{
+			description: "entry recorded with only a digest",
+			entry:       ImageDetails{Digest: "digest"},
+			expected:    rebuildImageMissing,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.CheckDeepEqual(test.expected, rebuildReasonFor(test.entry))
+		})
+	}
+}
+
 func TestLookupLocal(t *testing.T) {
 	tests := []struct {
 		description string
@@ -50,7 +108,7 @@ func TestLookupLocal(t *testing.T) {
 			hasher:      mockHasher{"thehash"},
 			api:         &testutil.FakeAPIClient{},
 			cache:       map[string]ImageDetails{},
-			expected:    needsBuilding{hash: "thehash"},
+			expected:    needsBuilding{hash: "thehash", reason: rebuildNoCacheEntry},
 		},
 		{
 			description: "hash failure",
@@ -63,7 +121,7 @@ func TestLookupLocal(t *testing.T) {
 			cache: map[string]ImageDetails{
 				"hash": {Digest: "ignored"},
 			},
-			expected: needsBuilding{hash: "hash"},
+			expected: needsBuilding{hash: "hash", reason: rebuildImageMissing},
 		},
 		{
 			description: "hit but not found",
@@ -72,7 +130,7 @@ func TestLookupLocal(t *testing.T) {
 				"hash": {ID: "imageID"},
 			},
 			api:      &testutil.FakeAPIClient{},
-			expected: needsBuilding{hash: "hash"},
+			expected: needsBuilding{hash: "hash", reason: rebuildImageMissing},
 		},
 		{
 			description: "hit but not found with error",
@@ -115,7 +173,7 @@ func TestLookupLocal(t *testing.T) {
 				"hash": {ID: "imageID"},
 			},
 			api:      (&testutil.FakeAPIClient{}).Add("tag", "otherImageID"),
-			expected: needsBuilding{hash: "hash"},
+			expected: needsBuilding{hash: "hash", reason: rebuildImageMissing},
 		},
 	}
 	for _, test := range tests {
@@ -154,7 +212,7 @@ func TestLookupRemote(t *testing.T) {
 			hasher:      mockHasher{"hash"},
 			api:         &testutil.FakeAPIClient{ErrImagePull: true},
 			cache:       map[string]ImageDetails{},
-			expected:    needsBuilding{hash: "hash"},
+			expected:    needsBuilding{hash: "hash", reason: rebuildNoCacheEntry},
 		},
 		{
 			description: "hash failure",
@@ -193,7 +251,7 @@ func TestLookupRemote(t *testing.T) {
 				"hash": {ID: "imageID"},
 			},
 			api:      &testutil.FakeAPIClient{},
-			expected: needsBuilding{hash: "hash"},
+			expected: needsBuilding{hash: "hash", reason: rebuildImageMissing},
 		},
 	}
 	for _, test := range tests {

--- a/pkg/skaffold/build/cache/retrieve.go
+++ b/pkg/skaffold/build/cache/retrieve.go
@@ -81,6 +81,9 @@ func (c *cache) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, ar
 			} else {
 				output.Yellow.Fprintln(out, "Not found. Building")
 			}
+			for _, change := range result.changes {
+				output.Default.Fprintf(out, "     %s\n", change)
+			}
 			c.hashByName[artifact.ImageName] = result.Hash()
 			needToBuild = append(needToBuild, artifact)
 			continue

--- a/pkg/skaffold/build/cache/retrieve.go
+++ b/pkg/skaffold/build/cache/retrieve.go
@@ -76,7 +76,11 @@ func (c *cache) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, ar
 
 		case needsBuilding:
 			eventV2.CacheCheckMiss(artifact.ImageName, platforms.GetPlatforms(artifact.ImageName).String())
-			output.Yellow.Fprintln(out, "Not found. Building")
+			if reason := result.reason.description(); reason != "" {
+				output.Yellow.Fprintf(out, "Not found. Building (%s)\n", reason)
+			} else {
+				output.Yellow.Fprintln(out, "Not found. Building")
+			}
 			c.hashByName[artifact.ImageName] = result.Hash()
 			needToBuild = append(needToBuild, artifact)
 			continue

--- a/pkg/skaffold/build/cache/retrieve_test.go
+++ b/pkg/skaffold/build/cache/retrieve_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package cache
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/moby/moby/api/types/registry"
@@ -193,6 +195,66 @@ func TestCacheBuildLocal(t *testing.T) {
 		t.CheckDeepEqual(2, len(bRes))
 		t.CheckDeepEqual("artifact1", bRes[0].ImageName)
 		t.CheckDeepEqual("artifact2", bRes[1].ImageName)
+	})
+}
+
+func TestCacheBuildLocalReportsRebuildReason(t *testing.T) {
+	testutil.Run(t, "", func(t *testutil.T) {
+		tmpDir := t.NewTempDir().
+			Write("dep1", "content1").
+			Chdir()
+
+		tags := map[string]string{"artifact1": "artifact1:tag1"}
+		artifacts := []*latest.Artifact{
+			{ImageName: "artifact1", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{}}},
+		}
+		deps := depLister(map[string][]string{"artifact1": {"dep1"}})
+
+		// Mock Docker
+		t.Override(&docker.DefaultAuthHelper, stubAuth{})
+		dockerDaemon := fakeLocalDaemon(&testutil.FakeAPIClient{})
+		t.Override(&docker.NewAPIClient, func(context.Context, docker.Config) (docker.LocalDaemon, error) {
+			return dockerDaemon, nil
+		})
+		t.Override(&docker.EvalBuildArgsWithEnv, func(_ config.RunMode, _ string, _ string, args map[string]*string, _ map[string]*string, _ map[string]string) (map[string]*string, error) {
+			return args, nil
+		})
+
+		cfg := &mockConfig{
+			pipeline:  latest.Pipeline{Build: latest.BuildConfig{BuildType: latest.BuildType{LocalBuild: &latest.LocalBuild{TryImportMissing: false}}}},
+			cacheFile: tmpDir.Path("cache"),
+		}
+		store := make(mockArtifactStore)
+		artifactCache, err := NewCache(context.Background(), cfg, func(imageName string) (bool, error) { return true, nil }, deps, graph.ToArtifactGraph(artifacts), store)
+		t.CheckNoError(err)
+
+		// First build: nothing has ever been built, so there is no cache entry for this hash.
+		var out bytes.Buffer
+		builder := &mockBuilder{dockerDaemon: dockerDaemon, push: false, store: store, cache: artifactCache}
+		_, err = artifactCache.Build(context.Background(), &out, tags, artifacts, platform.Resolver{}, builder.Build)
+		t.CheckNoError(err)
+		if got := out.String(); !strings.Contains(got, "Not found. Building (no cached build for the current inputs)") {
+			t.Errorf("expected the rebuild reason to be reported, got:\n%s", got)
+		}
+
+		// Second build: the artifact is cached, so no reason is reported at all.
+		out.Reset()
+		builder = &mockBuilder{dockerDaemon: dockerDaemon, push: false, store: store, cache: artifactCache}
+		_, err = artifactCache.Build(context.Background(), &out, tags, artifacts, platform.Resolver{}, builder.Build)
+		t.CheckNoError(err)
+		if got := out.String(); strings.Contains(got, "Not found. Building") {
+			t.Errorf("expected a cache hit, got:\n%s", got)
+		}
+
+		// Third build: a dependency changed, so the new hash has no cache entry either.
+		out.Reset()
+		tmpDir.Write("dep1", "new content")
+		builder = &mockBuilder{dockerDaemon: dockerDaemon, push: false, store: store, cache: artifactCache}
+		_, err = artifactCache.Build(context.Background(), &out, tags, artifacts, platform.Resolver{}, builder.Build)
+		t.CheckNoError(err)
+		if got := out.String(); !strings.Contains(got, "Not found. Building (no cached build for the current inputs)") {
+			t.Errorf("expected the rebuild reason to be reported, got:\n%s", got)
+		}
 	})
 }
 

--- a/pkg/skaffold/build/cache/retrieve_test.go
+++ b/pkg/skaffold/build/cache/retrieve_test.go
@@ -258,6 +258,74 @@ func TestCacheBuildLocalReportsRebuildReason(t *testing.T) {
 	})
 }
 
+func TestCacheBuildLocalReportsChangedInputs(t *testing.T) {
+	testutil.Run(t, "", func(t *testutil.T) {
+		tmpDir := t.NewTempDir().
+			Write("dep1", "content1").
+			Write("dep2", "content2").
+			Chdir()
+
+		tags := map[string]string{"artifact1": "artifact1:tag1"}
+		artifacts := []*latest.Artifact{
+			{ImageName: "artifact1", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{}}},
+		}
+		deps := depLister(map[string][]string{"artifact1": {"dep1", "dep2"}})
+
+		// Mock Docker
+		t.Override(&docker.DefaultAuthHelper, stubAuth{})
+		dockerDaemon := fakeLocalDaemon(&testutil.FakeAPIClient{})
+		t.Override(&docker.NewAPIClient, func(context.Context, docker.Config) (docker.LocalDaemon, error) {
+			return dockerDaemon, nil
+		})
+		t.Override(&docker.EvalBuildArgsWithEnv, func(_ config.RunMode, _ string, _ string, args map[string]*string, _ map[string]*string, _ map[string]string) (map[string]*string, error) {
+			return args, nil
+		})
+
+		cfg := &mockConfig{
+			pipeline:   latest.Pipeline{Build: latest.BuildConfig{BuildType: latest.BuildType{LocalBuild: &latest.LocalBuild{TryImportMissing: false}}}},
+			cacheFile:  tmpDir.Path("cache"),
+			debugCache: true,
+		}
+		store := make(mockArtifactStore)
+		artifactCache, err := NewCache(context.Background(), cfg, func(imageName string) (bool, error) { return true, nil }, deps, graph.ToArtifactGraph(artifacts), store)
+		t.CheckNoError(err)
+
+		build := func(out *bytes.Buffer) {
+			t.Helper()
+			builder := &mockBuilder{dockerDaemon: dockerDaemon, push: false, store: store, cache: artifactCache}
+			_, err := artifactCache.Build(context.Background(), out, tags, artifacts, platform.Resolver{}, builder.Build)
+			t.CheckNoError(err)
+		}
+
+		// First build: nothing was recorded before, so there is nothing to diff against and
+		// the coarser reason is reported instead.
+		var out bytes.Buffer
+		build(&out)
+		if got := out.String(); !strings.Contains(got, "no cached build for the current inputs") {
+			t.Errorf("expected the fallback reason on the first run, got:\n%s", got)
+		}
+
+		// Second build: cached, and the snapshot is refreshed.
+		out.Reset()
+		build(&out)
+
+		// Third build: one dependency changed, and it is named.
+		out.Reset()
+		tmpDir.Write("dep1", "new content")
+		build(&out)
+		got := out.String()
+		if !strings.Contains(got, "Not found. Building (inputs changed)") {
+			t.Errorf("expected the changed-inputs reason, got:\n%s", got)
+		}
+		if !strings.Contains(got, "~ dep1") {
+			t.Errorf("expected the changed dependency to be named, got:\n%s", got)
+		}
+		if strings.Contains(got, "dep2") {
+			t.Errorf("expected the unchanged dependency to be left out, got:\n%s", got)
+		}
+	})
+}
+
 func TestCacheBuildRemote(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
 		tmpDir := t.NewTempDir().
@@ -408,11 +476,13 @@ func TestCacheFindMissing(t *testing.T) {
 type mockConfig struct {
 	runcontext.RunContext // Embedded to provide the default values.
 	cacheFile             string
+	debugCache            bool
 	mode                  config.RunMode
 	pipeline              latest.Pipeline
 }
 
 func (c *mockConfig) CacheArtifacts() bool                            { return true }
 func (c *mockConfig) CacheFile() string                               { return c.cacheFile }
+func (c *mockConfig) DebugCache() bool                                { return c.debugCache }
 func (c *mockConfig) Mode() config.RunMode                            { return c.mode }
 func (c *mockConfig) PipelineForImage(string) (latest.Pipeline, bool) { return c.pipeline, true }

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -39,6 +39,7 @@ type SkaffoldOptions struct {
 	AutoSync                    bool
 	AssumeYes                   bool
 	CacheArtifacts              bool
+	DebugCache                  bool
 	ContainerDebugging          bool
 	Cleanup                     bool
 	DetectMinikube              bool

--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -315,6 +315,7 @@ func (rc *RunContext) AutoSync() bool                                { return rc
 func (rc *RunContext) ContainerDebugging() bool                      { return rc.Opts.ContainerDebugging }
 func (rc *RunContext) CacheArtifacts() bool                          { return rc.Opts.CacheArtifacts }
 func (rc *RunContext) CacheFile() string                             { return rc.Opts.CacheFile }
+func (rc *RunContext) DebugCache() bool                              { return rc.Opts.DebugCache }
 func (rc *RunContext) ConfigurationFile() string                     { return rc.Opts.ConfigurationFile }
 func (rc *RunContext) CustomLabels() []string                        { return rc.Opts.CustomLabels }
 func (rc *RunContext) CustomTag() string                             { return rc.Opts.CustomTag }


### PR DESCRIPTION
# PR 2 — branch `cache-input-diff` (stacked on PR 1)

Title: feat: add --debug-cache to report which inputs caused a rebuild

Fixes #10174

Stacked on #10175. Review only the second commit — isolated diff:
https://github.com/peter-sanford/skaffold-debug/compare/cache-miss-reason...cache-input-diff
I'll rebase onto main once #10175 merges, and this diff becomes the whole PR.

## What

PR 1 says the inputs changed. This says which ones. With `--debug-cache`,
skaffold records the inputs that feed each artifact's hash — dependency files,
artifact config, build args, platforms — and diffs them against the previous
run:

```
Checking cache...
 - app: Not found. Building (inputs changed)
     ~ src/handler.go
     + src/middleware.go
     - src/old_handler.go
```

`~` changed, `+` added, `-` removed.

## Notes for review

- **Off unless asked for.** Nothing is read or written without `--debug-cache`;
  the hashing path is untouched for everyone else. The flag binds to
  `SKAFFOLD_DEBUG_CACHE` through the usual mechanism.
- **Values are never written to disk**, only their digests. Build args and
  artifact config routinely carry credentials.
- **Snapshots live beside the cache file** (`<cache-file>-inputs/`), so two
  projects that share an artifact name do not overwrite each other's snapshots,
  and `--cache-file` moves them.
- **Writes are atomic** (temp file + rename), so an interrupted run cannot
  leave a half-written snapshot.
- **No package-level state.** The recorder is created per lookup pass and
  passed explicitly to the hasher, so nothing outlives the pass that made it.
- Recording failures are logged and ignored: diagnostics must never fail a
  build.
- The first commit is a one-line prerequisite that lets the boilerplate checker
  accept a 2026 copyright header — currently any file added this year fails
  `hack/boilerplate.sh`. Happy to split it out if you would rather take it
  separately.

## Testing

- Unit coverage for the diff, the snapshot round trip, atomic writes, digest-only
  storage, key sanitisation and the nil (disabled) recorder, plus an end-to-end
  test through `Build` asserting the changed dependency is named and unchanged
  ones are not.
- Full unit suite (`-race -short`) passes; `hack/checks.sh` scripts and the docs
  site build pass.
- Verified manually against `examples/getting-started` with a real docker build:
  first run reports the fallback reason, an unchanged run hits the cache, a
  changed `main.go` reports `~ main.go`, and deleting the built image reports
  `cached image is no longer available`.
